### PR TITLE
PARQUET-14: Support lifted coercions of file schemas into compatible read schemas.

### DIFF
--- a/parquet-column/src/main/java/parquet/column/ColumnReadStore.java
+++ b/parquet-column/src/main/java/parquet/column/ColumnReadStore.java
@@ -23,9 +23,15 @@ package parquet.column;
 public interface ColumnReadStore {
 
   /**
-   * @param path the column to read
+   * @param physicalDescriptor the column to read
+   * @param logicalDescriptor the column to read
    * @return the column reader for that descriptor
    */
-  abstract public ColumnReader getColumnReader(ColumnDescriptor path);
+  public ColumnReader getColumnReader(ColumnDescriptor physicalDescriptor, ColumnDescriptor logicalDescriptor);
 
+  /**
+   * @param columnDescriptor the column to read
+   * @return the column reader for that descriptor
+   */
+  public ColumnReader getColumnReader(ColumnDescriptor columnDescriptor);
 }

--- a/parquet-column/src/main/java/parquet/column/ColumnWriter.java
+++ b/parquet-column/src/main/java/parquet/column/ColumnWriter.java
@@ -15,7 +15,6 @@
  */
 package parquet.column;
 
-import parquet.column.statistics.Statistics;
 import parquet.io.api.Binary;
 
 /**

--- a/parquet-column/src/main/java/parquet/column/impl/ColumnReadStoreImpl.java
+++ b/parquet-column/src/main/java/parquet/column/impl/ColumnReadStoreImpl.java
@@ -54,8 +54,13 @@ public class ColumnReadStoreImpl implements ColumnReadStore {
   }
 
   @Override
-  public ColumnReader getColumnReader(ColumnDescriptor path) {
-    return newMemColumnReader(path, pageReadStore.getPageReader(path));
+  public ColumnReader getColumnReader(ColumnDescriptor columnDescriptor) {
+    return newMemColumnReader(columnDescriptor, pageReadStore.getPageReader(columnDescriptor));
+  }
+
+  @Override
+  public ColumnReader getColumnReader(ColumnDescriptor physicalDescriptor, ColumnDescriptor logicalDescriptor) {
+    return newMemColumnReader(logicalDescriptor, pageReadStore.getPageReader(physicalDescriptor));
   }
 
   private ColumnReaderImpl newMemColumnReader(ColumnDescriptor path, PageReader pageReader) {

--- a/parquet-column/src/main/java/parquet/io2/ColumnIO2.java
+++ b/parquet-column/src/main/java/parquet/io2/ColumnIO2.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2014 GoDaddy, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io2;
+
+import parquet.io.InvalidRecordException;
+import parquet.schema.Type;
+
+import java.util.List;
+
+abstract class ColumnIO2<T extends Type> {
+  private final T type;
+  private final String name;
+  private final LeafInfo leafInfo;
+  private ColumnIO2<?> parent;
+
+  public ColumnIO2(
+      final T type,
+      final String name,
+      final LeafInfo leafInfo) {
+    this.type = type;
+    this.name = name;
+    this.leafInfo = leafInfo;
+  }
+
+  public final T getType() {
+    return type;
+  }
+
+  public final String getName() {
+    return name;
+  }
+
+  public final LeafInfo getLeafInfo() {
+    return leafInfo;
+  }
+
+  public abstract List<PrimitiveColumnIO2> getLeafColumnIO();
+
+  void setParent(final ColumnIO2<?> parent) {
+    this.parent = parent;
+  }
+
+  ColumnIO2<?> getParent() {
+    return parent;
+  }
+
+  abstract PrimitiveColumnIO2 getLast();
+  abstract PrimitiveColumnIO2 getFirst();
+
+  boolean isFirst() {
+    return getFirst() == this;
+  }
+
+  boolean isLast() {
+    return getLast() == this;
+  }
+
+  ColumnIO2<?> getParent(int r) {
+    if (leafInfo.getLogicalPath().getRepetitionLevel() == r && getType().isRepetition(Type.Repetition.REPEATED)) {
+      return this;
+    } else if (parent != null && parent.leafInfo.getLogicalPath().getDefinitionLevel() >= r) {
+      return getParent().getParent(r);
+    } else {
+      throw new InvalidRecordException("no parent("+r+") for "+this);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName()+" "+type.getName()
+        +" "+leafInfo.getLogicalPath();
+  }
+}

--- a/parquet-column/src/main/java/parquet/io2/ColumnIO2Factory.java
+++ b/parquet-column/src/main/java/parquet/io2/ColumnIO2Factory.java
@@ -1,0 +1,336 @@
+/**
+ * Copyright 2014 GoDaddy, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io2;
+
+import parquet.schema.GroupType;
+import parquet.schema.MessageType;
+import parquet.schema.PrimitiveType;
+import parquet.schema.Type;
+import parquet.schema.TypeVisitor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Factory that supports type coercions in two directions:
+ *
+ * a) Lifting
+ * b) Extracted
+ *
+ * Lifting conversions allow a requested schema to have additional
+ * nodes compared to the file schema assuming that the leaf nodes
+ * maintain invariants around repetition and definition counts.
+ * This mode is primarily meant to allow Pig and Hive to load
+ * files that were written using parquet-protobuf or some other
+ * writer that does not have a first class notion of nullable values
+ * but it needs to be read into a schema that does. These conversions
+ * are safe at runtime as they do not lose or discard any information.
+ *
+ * Extracted conversions go the other direction. Such conversions
+ * are not always safe at runtime and are disabled by default.
+ */
+public class ColumnIO2Factory {
+  Option<GroupColumnIO2<GroupType>> groupType(
+      final GroupType fileGroupType,
+      final GroupType requestedGroupType,
+      final LeafInfo leafInfo) {
+
+    // find suitable matching nodes in the disk schema for
+    // for each child node in the requested schema
+    final ArrayList<ColumnIO2<?>> children = new ArrayList<ColumnIO2<?>>(requestedGroupType.getFieldCount());
+    final List<Type> requestedFields = requestedGroupType.getFields();
+    for (int i = 0; i < requestedGroupType.getFieldCount(); ++i) {
+      final int ii = i;
+      final Type requestedField = requestedFields.get(ii);
+
+      // attempt various matching strategies until the first match is returned using a breadth first
+      // search. this doesn't guarantee that the best match is found, just a suitable match.
+      Option
+          .<ColumnIO2<?>>empty()
+          .or(new Function<Void, Option<ColumnIO2<?>>>() {
+            @Override
+            public Option<ColumnIO2<?>> call(Void unit) {
+              // a field name matches, check to see if the schemas are compatible
+              if (!fileGroupType.containsField(requestedField.getName())) {
+                return Option.empty();
+              }
+
+              final int fileFieldIndex = fileGroupType.getFieldIndex(requestedField.getName());
+              final Type fileField = fileGroupType.getType(fileFieldIndex);
+
+              final ColumnPath logicalPath = new ColumnPath(requestedField, ii);
+              final ColumnPath physicalPath = new ColumnPath(fileField, fileFieldIndex);
+              final LeafInfo columnLeaf = leafInfo.combine(new LeafInfo(physicalPath, logicalPath));
+
+              return create(fileField, requestedField, columnLeaf);
+            }
+          })
+          .or(new Function<Void, Option<ColumnIO2<?>>>() {
+            @Override
+            public Option<ColumnIO2<?>> call(Void unit) {
+              // lifted match test
+              // since there is not an exact or subtype match we will check for compatible types that require lifting
+              if (requestedField.isPrimitive()) {
+                // carry on the search, look for extraction matches next
+                return Option.empty();
+              }
+
+              final GroupType parent = requestedField.asGroupType();
+              if (parent.getFieldCount() != 1) {
+                // lifting candidates are groups with a single field
+                return Option.empty();
+              }
+
+              final Type requestedField = parent.getFields().get(0);
+              final GroupType liftedType = new GroupType(parent.getRepetition(), parent.getName(), requestedField);
+              final int repCorrections = repetitionCorrection(parent, fileGroupType);
+              final ColumnPath logicalPath = new ColumnPath(parent, ii, repCorrections, 0);
+              // leave the physical path empty
+              final LeafInfo columnLeaf = leafInfo.combine(new LeafInfo(ColumnPath.empty, logicalPath));
+
+              return groupType(
+                  fileGroupType,
+                  liftedType,
+                  columnLeaf)
+                  .map(new Function<GroupColumnIO2<GroupType>, ColumnIO2<?>>() {
+                    @Override
+                    public ColumnIO2<?> call(final GroupColumnIO2<GroupType> value) {
+                      return value;
+                    }
+                  });
+            }
+          })
+          .or(new Function<Void, Option<ColumnIO2<?>>>() {
+            @Override
+            public Option<ColumnIO2<?>> call(Void unit) {
+              // TODO: extracted match
+              return Option.empty();
+            }
+          })
+          .or(new Function<Void, Option<ColumnIO2<?>>>() {
+            @Override
+            public Option<ColumnIO2<?>> call(Void unit) {
+              if (requestedField.isPrimitive()) {
+                return Option.empty();
+              }
+
+              final GroupType renamed = requestedField.asGroupType();
+              final int repCorrections = repetitionCorrection(renamed, fileGroupType);
+              final ColumnPath logicalPath = new ColumnPath(renamed, ii, repCorrections, 0);
+              // leave the physical path empty
+              final LeafInfo columnLeaf = leafInfo.combine(new LeafInfo(ColumnPath.empty, logicalPath));
+
+              return groupType(
+                  fileGroupType,
+                  renamed,
+                  columnLeaf)
+                  .map(new Function<GroupColumnIO2<GroupType>, ColumnIO2<?>>() {
+                    @Override
+                    public ColumnIO2<?> call(final GroupColumnIO2<GroupType> value) {
+                      return value;
+                    }
+                  });
+            }
+          })
+          .map(new Function<ColumnIO2<?>, Void>() {
+            @Override
+            public Void call(final ColumnIO2<?> child) {
+              children.add(child);
+              return null;
+            }
+          });
+    }
+
+    if (children.isEmpty()) {
+      // continue searching other paths
+      return Option.empty();
+    }
+
+    final ArrayList<Type> matchedTypes = new ArrayList<Type>(children.size());
+    for (final ColumnIO2<?> child : children) {
+      matchedTypes.add(child.getType());
+    }
+
+    final GroupType actualType = new GroupType(
+        requestedGroupType.getRepetition(),
+        requestedGroupType.getName(),
+        matchedTypes);
+
+    return Option.pure(
+        new GroupColumnIO2<GroupType>(
+            actualType,
+            actualType.getName(),
+            leafInfo,
+            Collections.unmodifiableList(children)));
+  }
+
+  Option<PrimitiveColumnIO2> primitiveType(
+      final PrimitiveType fileSchema,
+      final PrimitiveType requestedSchema,
+      final LeafInfo leafInfo) {
+    if (!fileSchema.getName().equals(requestedSchema.getName())) {
+      return Option.empty();
+    }
+
+    if (!fileSchema.getPrimitiveTypeName().equals(requestedSchema.getPrimitiveTypeName())) {
+      // this would be a convenient place to check for legal widening conversions
+      return Option.empty();
+    }
+
+    if (leafInfo.getPhysicalPath().getRepetitionLevel() != leafInfo.getLogicalPath().getRepetitionLevel()) {
+      // TODO: figure out how to deal with required vs optional vs repeated?
+      return Option.empty();
+    }
+
+    if (leafInfo.getPhysicalPath().getDefinitionLevel() != leafInfo.getLogicalPath().getDefinitionLevel()) {
+      // TODO: figure out how to deal with required vs optional vs repeated?
+      return Option.empty();
+    }
+
+    return Option.pure(
+        new PrimitiveColumnIO2(
+            fileSchema,
+            fileSchema.getName(),
+            leafInfo));
+  }
+
+  public Option<MessageColumnIO2> messageType(
+      final MessageType fileSchema,
+      final MessageType requestedSchema) {
+    return create(fileSchema, requestedSchema, LeafInfo.empty)
+        .map(new Function<ColumnIO2<?>, MessageColumnIO2>() {
+          @Override
+          public MessageColumnIO2 call(ColumnIO2<?> value) {
+            // yuck
+            value.setParent(null);
+            return (MessageColumnIO2) value;
+          }
+        });
+  }
+
+  private static int repetitionCorrection(final Type fileType, final Type requestedType) {
+    if (requestedType.getRepetition() == fileType.getRepetition() &&
+        fileType.getRepetition() == Type.Repetition.REPEATED) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  Option<ColumnIO2<?>> create(
+      final Type fileSchema,
+      final Type requestedSchema,
+      final LeafInfo leafInfo) {
+    return requestedSchema.accept(new TypeVisitor<Option<ColumnIO2<?>>>() {
+      @Override
+      public Option<ColumnIO2<?>> visit(final GroupType requestedGroupType) {
+        return fileSchema.accept(new TypeVisitor<Option<ColumnIO2<?>>>() {
+          @Override
+          public Option<ColumnIO2<?>> visit(final GroupType fileGroupType) {
+            return groupType(fileGroupType, requestedGroupType, leafInfo)
+                .map(new Function<GroupColumnIO2<GroupType>, ColumnIO2<?>>() {
+                  @Override
+                  public ColumnIO2<?> call(GroupColumnIO2<GroupType> value) {
+                    return value;
+                  }
+                });
+          }
+
+          @Override
+          public Option<ColumnIO2<?>> visit(final MessageType fileMessageType) {
+            // TODO: check to see if it needs to be wrapped in a MessageColumnIO2?
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          public Option<ColumnIO2<?>> visit(final PrimitiveType filePrimitiveType) {
+            // see if there is a compatible group representation
+            return visit(new GroupType(
+                filePrimitiveType.getRepetition(),
+                filePrimitiveType.getName(),
+                new PrimitiveType(
+                    Type.Repetition.REQUIRED,
+                    filePrimitiveType.getPrimitiveTypeName(),
+                    filePrimitiveType.getTypeLength(),
+                    filePrimitiveType.getName(),
+                    filePrimitiveType.getOriginalType())));
+          }
+        });
+      }
+
+      @Override
+      public Option<ColumnIO2<?>> visit(final MessageType requestedMessageType) {
+        return fileSchema.accept(new TypeVisitor<Option<ColumnIO2<?>>>() {
+          @Override
+          public Option<ColumnIO2<?>> visit(final GroupType fileGroupType) {
+            return visit(new MessageType(
+                fileGroupType.getName(),
+                fileGroupType.getFields()));
+          }
+
+          @Override
+          public Option<ColumnIO2<?>> visit(final MessageType fileMessageType) {
+            return groupType(fileMessageType, requestedMessageType, leafInfo)
+                .map(new Function<GroupColumnIO2<GroupType>, ColumnIO2<?>>() {
+                  @Override
+                  public ColumnIO2<?> call(final GroupColumnIO2<GroupType> groupColumnIO) {
+                    return new MessageColumnIO2(
+                        requestedMessageType,
+                        groupColumnIO.getName(),
+                        leafInfo,
+                        groupColumnIO.getChildren());
+                  }
+                });
+          }
+
+          @Override
+          public Option<ColumnIO2<?>> visit(final PrimitiveType filePrimitiveType) {
+            return Option.empty();
+          }
+        });
+      }
+
+      @Override
+      public Option<ColumnIO2<?>> visit(final PrimitiveType requestedPrimitiveType) {
+        return fileSchema.accept(new TypeVisitor<Option<ColumnIO2<?>>>() {
+          @Override
+          public Option<ColumnIO2<?>> visit(final GroupType fileGroupType) {
+            // requesting a primitive but file schema is a group
+            return Option.empty();
+          }
+
+          @Override
+          public Option<ColumnIO2<?>> visit(final MessageType fileMessageType) {
+            // requesting a primitive but file schema is a message
+            return Option.empty();
+          }
+
+          @Override
+          public Option<ColumnIO2<?>> visit(final PrimitiveType filePrimitiveType) {
+            return primitiveType(filePrimitiveType, requestedPrimitiveType, leafInfo)
+                .map(new Function<PrimitiveColumnIO2, ColumnIO2<?>>() {
+                  @Override
+                  public ColumnIO2<?> call(PrimitiveColumnIO2 value) {
+                    return value;
+                  }
+                });
+          }
+        });
+      }
+    });
+  }
+}

--- a/parquet-column/src/main/java/parquet/io2/ColumnPath.java
+++ b/parquet-column/src/main/java/parquet/io2/ColumnPath.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2014 GoDaddy, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io2;
+
+import parquet.column.ColumnDescriptor;
+import parquet.schema.Type;
+
+import java.util.Arrays;
+
+final class ColumnPath {
+  private final Type type;
+  private final String[] namedPath;
+  private final int[] indexPath;
+  private final int index;
+  private final int repetitionLevel;
+  private final int definitionLevel;
+
+  public final static ColumnPath empty = new ColumnPath(null, new String[0], new int[0], 0, 0, 0);
+
+  ColumnPath(
+      final Type type,
+      final int index) {
+    this(
+        type,
+        index,
+        type.isRepetition(Type.Repetition.REPEATED) ? 1 : 0,
+        type.isRepetition(Type.Repetition.REQUIRED) ? 0 : 1);
+  }
+
+  ColumnPath(
+      final Type type,
+      final int index,
+      final int repetitionLevel,
+      final int definitionLevel) {
+    this(
+        type,
+        new String[]{type.getName()},
+        new int[]{index},
+        index,
+        repetitionLevel,
+        definitionLevel);
+  }
+
+  private ColumnPath(
+      final Type type,
+      final String[] namedPath,
+      final int[] indexPath,
+      final int index,
+      final int repetitionLevel,
+      final int definitionLevel) {
+    this.type = type;
+    this.namedPath = namedPath;
+    this.indexPath = indexPath;
+    this.index = index;
+    this.repetitionLevel = repetitionLevel;
+    this.definitionLevel = definitionLevel;
+  }
+
+  public ColumnDescriptor getColumnDescriptor() {
+    return new ColumnDescriptor(
+        namedPath,
+        type.asPrimitiveType().getPrimitiveTypeName(),
+        type.asPrimitiveType().getTypeLength(),
+        repetitionLevel,
+        definitionLevel);
+  }
+
+  public String[] getPath() {
+    return namedPath;
+  }
+
+  public int[] getIndexes() {
+    return indexPath;
+  }
+
+  public ColumnPath combine(final ColumnPath other) {
+    String[] newNamedPath = Arrays.copyOf(this.namedPath, this.namedPath.length + other.namedPath.length);
+    System.arraycopy(other.namedPath, 0, newNamedPath, this.namedPath.length, other.namedPath.length);
+
+    int[] newIndexPath = Arrays.copyOf(this.indexPath, this.indexPath.length + other.indexPath.length);
+    System.arraycopy(other.indexPath, 0, newIndexPath, this.indexPath.length, other.indexPath.length);
+
+    return new ColumnPath(
+        other.type,
+        newNamedPath,
+        newIndexPath,
+        other.index,
+        this.repetitionLevel + other.repetitionLevel,
+        this.definitionLevel + other.definitionLevel);
+  }
+
+  public int getRepetitionLevel() {
+    return repetitionLevel;
+  }
+
+  public int getDefinitionLevel() {
+    return definitionLevel;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ColumnPath that = (ColumnPath) o;
+
+    if (definitionLevel != that.definitionLevel) return false;
+    if (index != that.index) return false;
+    if (repetitionLevel != that.repetitionLevel) return false;
+    if (!Arrays.equals(indexPath, that.indexPath)) return false;
+    if (!Arrays.equals(namedPath, that.namedPath)) return false;
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(namedPath);
+    result = 31 * result + Arrays.hashCode(indexPath);
+    result = 31 * result + index;
+    result = 31 * result + repetitionLevel;
+    result = 31 * result + definitionLevel;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "r:"+getRepetitionLevel()
+        +" d:"+getDefinitionLevel()
+        +" "+ Arrays.toString(namedPath);
+  }
+}

--- a/parquet-column/src/main/java/parquet/io2/EmptyRecordReader.java
+++ b/parquet-column/src/main/java/parquet/io2/EmptyRecordReader.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io2;
+
+import parquet.io.RecordReader;
+import parquet.io.api.GroupConverter;
+import parquet.io.api.RecordMaterializer;
+
+/**
+ * used to read empty schema
+ *
+ * @author Mickael Lacour <m.lacour@criteo.com>
+ *
+ * @param <T> the type of the materialized record
+ */
+public class EmptyRecordReader<T> extends RecordReader<T> {
+
+  private final GroupConverter recordConsumer;
+  private final RecordMaterializer<T> recordMaterializer;
+
+  public EmptyRecordReader(RecordMaterializer<T> recordMaterializer) {
+    this.recordMaterializer = recordMaterializer;
+    this.recordConsumer = recordMaterializer.getRootConverter(); // TODO: validator(wrap(recordMaterializer), validating, root.getType());
+  }
+
+  /**
+   * @see parquet.io.RecordReader#read()
+   */
+  @Override
+  public T read() {
+    recordConsumer.start();
+    recordConsumer.end();
+    return recordMaterializer.getCurrentRecord();
+  }
+}

--- a/parquet-column/src/main/java/parquet/io2/FilteredRecordReader.java
+++ b/parquet-column/src/main/java/parquet/io2/FilteredRecordReader.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io2;
+
+import parquet.column.ColumnReader;
+import parquet.column.impl.ColumnReadStoreImpl;
+import parquet.filter.RecordFilter;
+import parquet.filter.UnboundRecordFilter;
+import parquet.io.api.RecordMaterializer;
+
+/**
+ * Extends the
+ * @author Jacob Metcalf
+ *
+ */
+public class FilteredRecordReader<T> extends RecordReaderImplementation<T> {
+
+  private final RecordFilter recordFilter;
+  private final long recordCount;
+  private long recordsRead = 0;
+
+  /**
+   * @param root          the root of the schema
+   * @param validating
+   * @param columnStore
+   * @param unboundFilter Filter records, pass in NULL_FILTER to leave unfiltered.
+   */
+  public FilteredRecordReader(MessageColumnIO2 root, RecordMaterializer<T> recordMaterializer, boolean validating,
+                              ColumnReadStoreImpl columnStore, UnboundRecordFilter unboundFilter, long recordCount) {
+    super(root, recordMaterializer, validating, columnStore);
+    this.recordCount = recordCount;
+    if ( unboundFilter != null ) {
+      recordFilter = unboundFilter.bind(getColumnReaders());
+    } else {
+      recordFilter = null;
+    }
+  }
+
+  /**
+   * Override read() method to provide skip.
+   */
+  @Override
+  public T read() {
+    skipToMatch();
+    if (recordsRead == recordCount) {
+      return null;
+    }
+    ++ recordsRead;
+    return super.read();
+  }
+
+
+  /**
+   * Skips forwards until the filter finds the first match. Returns false
+   * if none found.
+   */
+  private void skipToMatch() {
+    while (recordsRead < recordCount && !recordFilter.isMatch()) {
+      State currentState = getState(0);
+      do {
+        ColumnReader columnReader = currentState.column;
+
+        // currentLevel = depth + 1 at this point
+        // set the current value
+        if (columnReader.getCurrentDefinitionLevel() >= currentState.maxDefinitionLevel) {
+          columnReader.skip();
+        }
+        columnReader.consume();
+
+        // Based on repetition level work out next state to go to
+        int nextR = currentState.maxRepetitionLevel == 0 ? 0 : columnReader.getCurrentRepetitionLevel();
+        currentState = currentState.getNextState(nextR);
+      } while (currentState != null);
+      ++ recordsRead;
+    }
+  }
+}

--- a/parquet-column/src/main/java/parquet/io2/Function.java
+++ b/parquet-column/src/main/java/parquet/io2/Function.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2012 Twitter, Inc.
+ * Copyright 2014 GoDaddy, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,30 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parquet.schema;
+package parquet.io2;
 
-/**
- * Implement this interface to visit a schema
- *
- * type.accept(new TypeVisitor() { ... });
- *
- * @author Julien Le Dem
- *
- */
-public interface TypeVisitor<T> {
-
-  /**
-   * @param groupType the group type to visit
-   */
-  T visit(GroupType groupType);
-
-  /**
-   * @param messageType the message type to visit
-   */
-  T visit(MessageType messageType);
-
-  /**
-   * @param primitiveType the primitive type to visit
-   */
-  T visit(PrimitiveType primitiveType);
+public interface Function<T, R> {
+  R call(final T value);
 }

--- a/parquet-column/src/main/java/parquet/io2/GroupColumnIO2.java
+++ b/parquet-column/src/main/java/parquet/io2/GroupColumnIO2.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2014 GoDaddy, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io2;
+
+import parquet.schema.GroupType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GroupColumnIO2<T extends GroupType> extends ColumnIO2<T> {
+  private final List<ColumnIO2<?>> children;
+
+  public GroupColumnIO2(
+      final T type,
+      final String name,
+      final LeafInfo leafInfo,
+      final List<ColumnIO2<?>> children) {
+    super(type, name, leafInfo);
+    this.children = children;
+  }
+
+  @Override
+  void setParent(final ColumnIO2<?> parent) {
+    super.setParent(parent);
+    for (final ColumnIO2<?> child : children) {
+      child.setParent(this);
+    }
+  }
+
+  @Override
+  PrimitiveColumnIO2 getLast() {
+    return children.get(children.size() - 1).getLast();
+  }
+
+  @Override
+  PrimitiveColumnIO2 getFirst() {
+    return children.get(0).getFirst();
+  }
+
+  public List<ColumnIO2<?>> getChildren() {
+    return children;
+  }
+
+  @Override
+  public final List<PrimitiveColumnIO2> getLeafColumnIO() {
+    final ArrayList<PrimitiveColumnIO2> arr = new ArrayList<PrimitiveColumnIO2>();
+    for (final ColumnIO2<?> child : children) {
+      arr.addAll(child.getLeafColumnIO());
+    }
+    return arr;
+  }
+}

--- a/parquet-column/src/main/java/parquet/io2/LeafInfo.java
+++ b/parquet-column/src/main/java/parquet/io2/LeafInfo.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2014 GoDaddy, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io2;
+
+final class LeafInfo {
+  private final ColumnPath physicalPath;
+  private final ColumnPath logicalPath;
+
+  static final LeafInfo empty = new LeafInfo(ColumnPath.empty, ColumnPath.empty);
+
+  LeafInfo(
+      final ColumnPath physicalPath,
+      final ColumnPath logicalPath) {
+    this.physicalPath = physicalPath;
+    this.logicalPath = logicalPath;
+  }
+
+  LeafInfo combine(final LeafInfo other) {
+    return new LeafInfo(
+        this.physicalPath.combine(other.physicalPath),
+        this.logicalPath.combine(other.logicalPath));
+  }
+
+  public ColumnPath getPhysicalPath() {
+    return physicalPath;
+  }
+
+  public ColumnPath getLogicalPath() {
+    return logicalPath;
+  }
+
+  @Override
+  public String toString() {
+    return "LeafInfo{" +
+        "physicalPath=" + physicalPath +
+        ", logicalPath=" + logicalPath +
+        '}';
+  }
+}

--- a/parquet-column/src/main/java/parquet/io2/MessageColumnIO2.java
+++ b/parquet-column/src/main/java/parquet/io2/MessageColumnIO2.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2012 Twitter, Inc.
+ * Copyright 2014 GoDaddy, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io2;
+
+import parquet.column.ColumnDescriptor;
+import parquet.column.impl.ColumnReadStoreImpl;
+import parquet.column.page.PageReadStore;
+import parquet.filter.UnboundRecordFilter;
+import parquet.io.*;
+import parquet.io.api.RecordMaterializer;
+import parquet.schema.MessageType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MessageColumnIO2 extends GroupColumnIO2<MessageType> {
+  public MessageColumnIO2(
+      final MessageType type,
+      final String name,
+      final LeafInfo leafInfo,
+      final List<ColumnIO2<?>> children) {
+    super(type, name, leafInfo, children);
+  }
+
+  public <T> RecordReader<T> getRecordReader(PageReadStore columns, RecordMaterializer<T> recordMaterializer) {
+    final List<PrimitiveColumnIO2> leaves = getLeafColumnIO();
+    if (leaves.size() > 0) {
+      return new parquet.io2.RecordReaderImplementation<T>(
+          this,
+          recordMaterializer,
+          false,
+          new ColumnReadStoreImpl(columns, recordMaterializer.getRootConverter(), getType())
+      );
+    } else {
+      return new EmptyRecordReader<T>(recordMaterializer);
+    }
+  }
+
+  public <T> RecordReader<T> getRecordReader(PageReadStore columns, RecordMaterializer<T> recordMaterializer,
+                                             UnboundRecordFilter unboundFilter) {
+
+    return (unboundFilter == null)
+        ? getRecordReader(columns, recordMaterializer)
+        : new FilteredRecordReader<T>(
+        this,
+        recordMaterializer,
+        false,
+        new ColumnReadStoreImpl(columns, recordMaterializer.getRootConverter(), getType()),
+        unboundFilter,
+        columns.getRowCount()
+    );
+  }
+
+  public List<ColumnDescriptor> getPhysicalColumnDescriptors() {
+    final List<PrimitiveColumnIO2> leafs = getLeafColumnIO();
+    final ArrayList<ColumnDescriptor> res = new ArrayList<ColumnDescriptor>(leafs.size());
+    for (PrimitiveColumnIO2 leaf : leafs) {
+      res.add(leaf.getLeafInfo().getPhysicalPath().getColumnDescriptor());
+    }
+    return res;
+  }
+}

--- a/parquet-column/src/main/java/parquet/io2/Option.java
+++ b/parquet-column/src/main/java/parquet/io2/Option.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2014 GoDaddy, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io2;
+
+public abstract class Option<T> {
+  Option() {
+  }
+
+  private static class Some<T> extends Option<T> {
+    private final T value;
+
+    public Some(final T value) {
+      this.value = value;
+    }
+
+    @Override
+    public <R> Option<R> map(final Function<T, R> f) {
+      return new Some<R>(f.call(this.value));
+    }
+
+    @Override
+    public <R> Option<R> flatMap(final Function<T, Option<R>> f) {
+      return f.call(this.value);
+    }
+
+    @Override
+    public Option<T> or(final Function<Void, Option<T>> alternative) {
+      return this;
+    }
+
+    @Override
+    public <R> Option<R> ap(final Option<Function<T, R>> f) {
+      return f.map(new Function<Function<T, R>, R>() {
+        @Override
+        public R call(final Function<T, R> g) {
+          return g.call(value);
+        }
+      });
+    }
+
+    @Override
+    public T get() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return "Some{" +
+          "value=" + value +
+          '}';
+    }
+  }
+
+  private final static class None<T> extends Option<T> {
+    public None() {
+    }
+
+    @Override
+    public <R> Option<R> map(final Function<T, R> f) {
+      return new None<R>();
+    }
+
+    @Override
+    public <R> Option<R> flatMap(final Function<T, Option<R>> f) {
+      return new None<R>();
+    }
+
+    @Override
+    public Option<T> or(final Function<Void, Option<T>> alternative) {
+      return alternative.call(null);
+    }
+
+    @Override
+    public <R> Option<R> ap(final Option<Function<T, R>> f) {
+      return new None<R>();
+    }
+
+    @Override
+    public T get() {
+      throw new RuntimeException();
+    }
+
+    @Override
+    public String toString() {
+      return "None";
+    }
+  }
+
+  public abstract <R> Option<R> map(final Function<T, R> f);
+  public abstract <R> Option<R> flatMap(final Function<T, Option<R>> f);
+  public abstract Option<T> or(final Function<Void, Option<T>> alternative);
+  public abstract <R> Option<R> ap(final Option<Function<T, R>> f);
+  public abstract T get();
+
+  public static <T> Option<T> pure(final T value) {
+    return new Some<T>(value);
+  }
+
+  public static <T> Option<T> empty() {
+    return new None<T>();
+  }
+}

--- a/parquet-column/src/main/java/parquet/io2/PrimitiveColumnIO2.java
+++ b/parquet-column/src/main/java/parquet/io2/PrimitiveColumnIO2.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2014 GoDaddy, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io2;
+
+import parquet.schema.PrimitiveType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class PrimitiveColumnIO2 extends ColumnIO2<PrimitiveType> {
+  public PrimitiveColumnIO2(
+      final PrimitiveType fileSchema,
+      final String name,
+      final LeafInfo leafInfo) {
+    super(fileSchema, name, leafInfo);
+  }
+
+  @Override
+  public List<PrimitiveColumnIO2> getLeafColumnIO() {
+    final ArrayList<PrimitiveColumnIO2> arr = new ArrayList<PrimitiveColumnIO2>(1);
+    arr.add(this);
+    return arr;
+  }
+
+  @Override
+  PrimitiveColumnIO2 getLast() {
+    return this;
+  }
+
+  @Override
+  PrimitiveColumnIO2 getFirst() {
+    return this;
+  }
+
+  public boolean isFirst(int r) {
+    return getFirst(r) == this;
+  }
+
+  private PrimitiveColumnIO2 getFirst(int r) {
+    ColumnIO2 parent = getParent(r);
+    return parent.getFirst();
+  }
+
+  public boolean isLast(int r) {
+    return getLast(r) == this;
+  }
+
+  private PrimitiveColumnIO2 getLast(int r) {
+    ColumnIO2 parent = getParent(r);
+    return parent.getLast();
+  }
+
+  public ColumnIO2<?>[] getColumnPath() {
+    final ArrayList<ColumnIO2<?>> path = new ArrayList<ColumnIO2<?>>();
+    ColumnIO2<?> ref = this;
+    do {
+      path.add(ref);
+      ref = ref.getParent();
+    } while (ref != null);
+
+    Collections.reverse(path);
+    return path.toArray(new ColumnIO2[path.size()]);
+  }
+}

--- a/parquet-column/src/main/java/parquet/io2/RecordReaderImplementation.java
+++ b/parquet-column/src/main/java/parquet/io2/RecordReaderImplementation.java
@@ -1,0 +1,465 @@
+/**
+ * Copyright 2012 Twitter, Inc.
+ * Copyright 2014 GoDaddy, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import parquet.Log;
+import parquet.column.ColumnReader;
+import parquet.column.impl.ColumnReadStoreImpl;
+import parquet.io.ParquetEncodingException;
+import parquet.io.RecordConsumerLoggingWrapper;
+import parquet.io.RecordReader;
+import parquet.io.ValidatingRecordConsumer;
+import parquet.io.api.Converter;
+import parquet.io.api.GroupConverter;
+import parquet.io.api.PrimitiveConverter;
+import parquet.io.api.RecordConsumer;
+import parquet.io.api.RecordMaterializer;
+import parquet.schema.MessageType;
+import parquet.schema.PrimitiveType.PrimitiveTypeName;
+
+
+/**
+ * used to read reassembled records
+ * @author Julien Le Dem
+ *
+ * @param <T> the type of the materialized record
+ */
+class RecordReaderImplementation<T> extends RecordReader<T> {
+  private static final Log LOG = Log.getLog(RecordReaderImplementation.class);
+
+  public static class Case {
+
+    private int id;
+    private final int startLevel;
+    private final int depth;
+    private final int nextLevel;
+    private final boolean goingUp;
+    private final boolean goingDown;
+    private final int nextState;
+    private final boolean defined;
+
+    public Case(int startLevel, int depth, int nextLevel, int nextState, boolean defined) {
+      this.startLevel = startLevel;
+      this.depth = depth;
+      this.nextLevel = nextLevel;
+      this.nextState = nextState;
+      this.defined = defined;
+      // means going up the tree (towards the leaves) of the record
+      // true if we need to open up groups in this case
+      goingUp = startLevel <= depth;
+      // means going down the tree (towards the root) of the record
+      // true if we need to close groups in this case
+      goingDown = depth + 1 > nextLevel;
+    }
+
+    public void setID(int id) {
+      this.id = id;
+    }
+
+    @Override
+    // this implementation is buggy but the simpler one bellow has duplicates.
+    // it still works but generates more code than necessary
+    // a middle ground is necessary
+//    public int hashCode() {
+//      int hashCode = 0;
+//      if (goingUp) {
+//        hashCode += 1 * (1 + startLevel) + 2 * (1 + depth);
+//      }
+//      if (goingDown) {
+//        hashCode += 3 * (1 + depth) + 5 * (1 + nextLevel);
+//      }
+//      return hashCode;
+//    }
+
+    public int hashCode() {
+      int hashCode = 17;
+      hashCode += 31 * startLevel;
+      hashCode += 31 * depth;
+      hashCode += 31 * nextLevel;
+      hashCode += 31 * nextState;
+      hashCode += 31 * (defined ? 0 : 1);
+      return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj instanceof Case) {
+        return equals((Case)obj);
+      }
+      return false;
+    }
+
+    // see comment for hashCode above
+//    public boolean equals(Case other) {
+//      if (goingUp && !other.goingUp || !goingUp && other.goingUp) {
+//        return false;
+//      }
+//      if (goingUp && other.goingUp && (startLevel != other.startLevel || depth != other.depth)) {
+//        return false;
+//      }
+//      if (goingDown && !other.goingDown || !goingDown && other.goingDown) {
+//        return false;
+//      }
+//      if (goingDown && other.goingDown && (depth != other.depth || nextLevel != other.nextLevel)) {
+//        return false;
+//      }
+//      return true;
+//    }
+
+    public boolean equals(Case other) {
+      return startLevel == other.startLevel
+          && depth == other.depth
+          && nextLevel == other.nextLevel
+          && nextState == other.nextState
+          && ((defined && other.defined) || (!defined && !other.defined));
+    }
+
+    public int getID() {
+      return id;
+    }
+
+    public int getStartLevel() {
+      return startLevel;
+    }
+
+    public int getDepth() {
+      return depth;
+    }
+    public int getNextLevel() {
+      return nextLevel;
+    }
+
+    public int getNextState() {
+      return nextState;
+    }
+
+    public boolean isGoingUp() {
+      return goingUp;
+    }
+
+    public boolean isGoingDown() {
+      return goingDown;
+    }
+
+    public boolean isDefined() {
+      return defined;
+    }
+
+    @Override
+    public String toString() {
+      return "Case " + startLevel + " -> " + depth + " -> " + nextLevel + "; goto sate_"+getNextState();
+    }
+
+  }
+
+  public static class State {
+
+    public final int id;
+    public final PrimitiveColumnIO2 primitiveColumnIO;
+    public final int maxDefinitionLevel;
+    public final int maxRepetitionLevel;
+    public final PrimitiveTypeName primitive;
+    public final ColumnReader column;
+    public final String[] fieldPath; // indexed by currentLevel
+    public final int[] indexFieldPath; // indexed by currentLevel
+    public final GroupConverter[] groupConverterPath;
+    public final PrimitiveConverter primitiveConverter;
+    public final String primitiveField;
+    public final int primitiveFieldIndex;
+    public final int[] nextLevel; //indexed by next r
+
+    private int[] definitionLevelToDepth; // indexed by current d
+    private State[] nextState; // indexed by next r
+    private Case[][][] caseLookup;
+    private List<Case> definedCases;
+    private List<Case> undefinedCases;
+
+    private State(int id, PrimitiveColumnIO2 primitiveColumnIO, ColumnReader column, int[] nextLevel, GroupConverter[] groupConverterPath, PrimitiveConverter primitiveConverter) {
+      final ColumnPath logicalPath = primitiveColumnIO.getLeafInfo().getLogicalPath();
+      final ColumnPath physicalPath = primitiveColumnIO.getLeafInfo().getPhysicalPath();
+      this.id = id;
+      this.primitiveColumnIO = primitiveColumnIO;
+      this.maxDefinitionLevel = physicalPath.getDefinitionLevel();
+      this.maxRepetitionLevel = physicalPath.getRepetitionLevel();
+      this.column = column;
+      this.nextLevel = nextLevel;
+      this.groupConverterPath = groupConverterPath;
+      this.primitiveConverter = primitiveConverter;
+      this.primitive = primitiveColumnIO.getType().asPrimitiveType().getPrimitiveTypeName();
+      this.fieldPath = logicalPath.getPath();
+      this.primitiveField = fieldPath[fieldPath.length - 1];
+      this.indexFieldPath = logicalPath.getIndexes();
+      this.primitiveFieldIndex = indexFieldPath[indexFieldPath.length - 1];
+    }
+
+    public int getDepth(int definitionLevel) {
+      return definitionLevelToDepth[definitionLevel];
+    }
+
+    public List<Case> getDefinedCases() {
+      return definedCases;
+    }
+
+    public List<Case> getUndefinedCases() {
+      return undefinedCases;
+    }
+
+    public Case getCase(int currentLevel, int d, int nextR) {
+      return caseLookup[currentLevel][d][nextR];
+    }
+
+    public State getNextState(int nextR) {
+      return nextState[nextR];
+    }
+  }
+
+  private final GroupConverter recordRootConverter;
+  private final RecordMaterializer<T> recordMaterializer;
+
+  private State[] states;
+  private final ColumnReader[] columnReaders;
+
+  /**
+   * @param root the root of the schema
+   * @param recordMaterializer responsible of materializing the records
+   * @param validating whether we should validate against the schema
+   * @param columnStore where to read the column data from
+   */
+  public RecordReaderImplementation(MessageColumnIO2 root, RecordMaterializer<T> recordMaterializer, boolean validating, ColumnReadStoreImpl columnStore) {
+    this.recordMaterializer = recordMaterializer;
+    this.recordRootConverter = recordMaterializer.getRootConverter(); // TODO: validator(wrap(recordMaterializer), validating, root.getType());
+    PrimitiveColumnIO2[] leaves = root.getLeafColumnIO().toArray(new PrimitiveColumnIO2[root.getLeafColumnIO().size()]);
+    columnReaders = new ColumnReader[leaves.length];
+    int[][] nextColumnIdxForRepLevel = new int[leaves.length][];
+    int[][] levelToClose = new int[leaves.length][];
+    GroupConverter[][] groupConverterPaths = new GroupConverter[leaves.length][];
+    PrimitiveConverter[] leafConverters = new PrimitiveConverter[leaves.length];
+    int[] firstIndexForLevel  = new int[256]; // "256 levels of nesting ought to be enough for anybody"
+    // build the automaton
+    for (int i = 0; i < leaves.length; i++) {
+      PrimitiveColumnIO2 leafColumnIO = leaves[i];
+      //generate converters along the path from root to leaf
+      final int[] indexFieldPath = leafColumnIO.getLeafInfo().getLogicalPath().getIndexes();
+      groupConverterPaths[i] = new GroupConverter[indexFieldPath.length - 1];
+      GroupConverter current = this.recordRootConverter;
+      for (int j = 0; j < indexFieldPath.length - 1; j++) {
+        current = current.getConverter(indexFieldPath[j]).asGroupConverter();
+        groupConverterPaths[i][j] = current;
+      }
+      leafConverters[i] = current.getConverter(indexFieldPath[indexFieldPath.length - 1]).asPrimitiveConverter();
+      columnReaders[i] = columnStore.getColumnReader(leafColumnIO.getLeafInfo().getPhysicalPath().getColumnDescriptor(), leafColumnIO.getLeafInfo().getLogicalPath().getColumnDescriptor());
+      int maxRepetitionLevel = leafColumnIO.getLeafInfo().getLogicalPath().getRepetitionLevel();
+      nextColumnIdxForRepLevel[i] = new int[maxRepetitionLevel+1];
+
+      levelToClose[i] = new int[maxRepetitionLevel+1]; //next level
+      for (int nextRepLevel = 0; nextRepLevel <= maxRepetitionLevel; ++nextRepLevel) {
+        // remember which is the first for this level
+        if (leafColumnIO.isFirst(nextRepLevel)) {
+          firstIndexForLevel[nextRepLevel] = i;
+        }
+        int nextColIdx;
+        //TODO: when we use nextColumnIdxForRepLevel, should we provide current rep level or the rep level for next item
+        // figure out automaton transition
+        if (nextRepLevel == 0) { // 0 always means jump to the next (the last one being a special case)
+          nextColIdx = i + 1;
+        } else if (leafColumnIO.isLast(nextRepLevel)) { // when we are at the last of the next repetition level we jump back to the first
+          nextColIdx = firstIndexForLevel[nextRepLevel];
+        } else { // otherwise we just go back to the next.
+          nextColIdx = i + 1;
+        }
+        // figure out which level down the tree we need to go back
+        if (nextColIdx == leaves.length) { // reached the end of the record => close all levels
+          levelToClose[i][nextRepLevel] = 0;
+        } else if (leafColumnIO.isLast(nextRepLevel)) { // reached the end of this level => close the repetition level
+          ColumnIO2<?> parent = leafColumnIO.getParent(nextRepLevel);
+          levelToClose[i][nextRepLevel] = parent.getLeafInfo().getLogicalPath().getPath().length - 1;
+        } else { // otherwise close until the next common parent
+          levelToClose[i][nextRepLevel] = getCommonParentLevel(
+              leafColumnIO.getLeafInfo().getLogicalPath().getPath(),
+              leaves[nextColIdx].getLeafInfo().getLogicalPath().getPath());
+        }
+        // sanity check: that would be a bug
+        if (levelToClose[i][nextRepLevel] > leaves[i].getLeafInfo().getLogicalPath().getPath().length-1) {
+          throw new ParquetEncodingException(Arrays.toString(leaves[i].getLeafInfo().getLogicalPath().getPath())+" -("+nextRepLevel+")-> "+levelToClose[i][nextRepLevel]);
+        }
+        nextColumnIdxForRepLevel[i][nextRepLevel] = nextColIdx;
+      }
+    }
+    states = new State[leaves.length];
+    for (int i = 0; i < leaves.length; i++) {
+      states[i] = new State(i, leaves[i], columnReaders[i], levelToClose[i], groupConverterPaths[i], leafConverters[i]);
+
+      int[] definitionLevelToDepth = new int[states[i].primitiveColumnIO.getLeafInfo().getLogicalPath().getDefinitionLevel() + 1];
+      // for each possible definition level, determine the depth at which to create groups
+      final ColumnIO2[] path = states[i].primitiveColumnIO.getColumnPath();
+      int depth = 0;
+      for (int d = 0; d < definitionLevelToDepth.length; ++d) {
+        while (depth < (states[i].fieldPath.length - 1)
+          && d >= path[depth + 1].getLeafInfo().getLogicalPath().getDefinitionLevel()
+          ) {
+          ++ depth;
+        }
+        definitionLevelToDepth[d] = depth - 1;
+      }
+      states[i].definitionLevelToDepth = definitionLevelToDepth;
+    }
+    for (int i = 0; i < leaves.length; i++) {
+      State state = states[i];
+      int[] nextStateIds = nextColumnIdxForRepLevel[i];
+      state.nextState = new State[nextStateIds.length];
+      for (int j = 0; j < nextStateIds.length; j++) {
+        state.nextState[j] = nextStateIds[j] == states.length ? null : states[nextStateIds[j]];
+      }
+    }
+    for (int i = 0; i < states.length; i++) {
+      State state = states[i];
+      final Map<Case, Case> definedCases = new HashMap<Case, Case>();
+      final Map<Case, Case> undefinedCases = new HashMap<Case, Case>();
+      Case[][][] caseLookup = new Case[state.fieldPath.length][][];
+      for (int currentLevel = 0; currentLevel < state.fieldPath.length; ++ currentLevel) {
+        caseLookup[currentLevel] = new Case[state.maxDefinitionLevel+1][];
+        for (int d = 0; d <= state.maxDefinitionLevel; ++ d) {
+          caseLookup[currentLevel][d] = new Case[state.maxRepetitionLevel+1];
+          for (int nextR = 0; nextR <= state.maxRepetitionLevel; ++ nextR) {
+            int caseStartLevel = currentLevel;
+            int caseDepth = Math.max(state.getDepth(d), caseStartLevel - 1);
+            int caseNextLevel = Math.min(state.nextLevel[nextR], caseDepth + 1);
+            Case currentCase = new Case(caseStartLevel, caseDepth, caseNextLevel, getNextReader(state.id, nextR), d == state.maxDefinitionLevel);
+            Map<Case, Case> cases = currentCase.isDefined() ? definedCases : undefinedCases;
+            if (!cases.containsKey(currentCase)) {
+              currentCase.setID(cases.size());
+              cases.put(currentCase, currentCase);
+            } else {
+              currentCase = cases.get(currentCase);
+            }
+            caseLookup[currentLevel][d][nextR] = currentCase;
+          }
+        }
+      }
+      state.caseLookup = caseLookup;
+      state.definedCases = new ArrayList<Case>(definedCases.values());
+      state.undefinedCases = new ArrayList<Case>(undefinedCases.values());
+      Comparator<Case> caseComparator = new Comparator<Case>() {
+        @Override
+        public int compare(Case o1, Case o2) {
+          return o1.id - o2.id;
+        }
+      };
+      Collections.sort(state.definedCases, caseComparator);
+      Collections.sort(state.undefinedCases, caseComparator);
+    }
+  }
+
+  //TODO: have those wrappers for a converter
+  private RecordConsumer validator(RecordConsumer recordConsumer, boolean validating, MessageType schema) {
+    return validating ? new ValidatingRecordConsumer(recordConsumer, schema) : recordConsumer;
+  }
+
+  private RecordConsumer wrap(RecordConsumer recordConsumer) {
+    if (Log.DEBUG) {
+      return new RecordConsumerLoggingWrapper(recordConsumer);
+    }
+    return recordConsumer;
+  }
+
+  /**
+   * @see parquet.io.RecordReader#read()
+   */
+  @Override
+  public T read() {
+    int currentLevel = 0;
+    recordRootConverter.start();
+    State currentState = states[0];
+    do {
+      ColumnReader columnReader = currentState.column;
+      int d = columnReader.getCurrentDefinitionLevel();
+      // creating needed nested groups until the current field (opening tags)
+      int depth = currentState.definitionLevelToDepth[d];
+      for (; currentLevel <= depth; ++currentLevel) {
+        currentState.groupConverterPath[currentLevel].start();
+      }
+      // currentLevel = depth + 1 at this point
+      // set the current value
+      if (d >= currentState.maxDefinitionLevel) {
+        // not null
+        columnReader.writeCurrentValueToConverter();
+      }
+      columnReader.consume();
+
+      int nextR = currentState.maxRepetitionLevel == 0 ? 0 : columnReader.getCurrentRepetitionLevel();
+      // level to go to close current groups
+      int next = currentState.nextLevel[nextR];
+      for (; currentLevel > next; currentLevel--) {
+        currentState.groupConverterPath[currentLevel - 1].end();
+      }
+
+      currentState = currentState.nextState[nextR];
+    } while (currentState != null);
+    recordRootConverter.end();
+    return recordMaterializer.getCurrentRecord();
+  }
+
+  private static void log(String string) {
+    LOG.debug(string);
+  }
+
+  int getNextReader(int current, int nextRepetitionLevel) {
+    State nextState = states[current].nextState[nextRepetitionLevel];
+    return nextState == null ? states.length : nextState.id;
+  }
+
+  int getNextLevel(int current, int nextRepetitionLevel) {
+    return states[current].nextLevel[nextRepetitionLevel];
+  }
+
+  private int getCommonParentLevel(String[] previous, String[] next) {
+    int i = 0;
+    while (i < Math.min(previous.length, next.length) && previous[i].equals(next[i])) {
+      ++i;
+    }
+    return i;
+  }
+
+  protected int getStateCount() {
+    return states.length;
+  }
+
+  protected State getState(int i) {
+    return states[i];
+  }
+
+  protected RecordMaterializer<T> getMaterializer() {
+    return recordMaterializer;
+  }
+
+  protected Converter getRecordConsumer() {
+    return recordRootConverter;
+  }
+
+  protected Iterable<ColumnReader> getColumnReaders() {
+    // Converting the array to an iterable ensures that the array cannot be altered
+    return Arrays.asList(columnReaders);
+  }
+}

--- a/parquet-column/src/main/java/parquet/schema/GroupType.java
+++ b/parquet-column/src/main/java/parquet/schema/GroupType.java
@@ -179,8 +179,8 @@ public class GroupType extends Type {
    * {@inheritDoc}
    */
   @Override
-  public void accept(TypeVisitor visitor) {
-    visitor.visit(this);
+  public <T> T accept(TypeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
   /**

--- a/parquet-column/src/main/java/parquet/schema/MessageType.java
+++ b/parquet-column/src/main/java/parquet/schema/MessageType.java
@@ -53,8 +53,8 @@ public final class MessageType extends GroupType {
    * {@inheritDoc}
    */
   @Override
-  public void accept(TypeVisitor visitor) {
-    visitor.visit(this);
+  public <T> T accept(TypeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
   /**

--- a/parquet-column/src/main/java/parquet/schema/PrimitiveType.java
+++ b/parquet-column/src/main/java/parquet/schema/PrimitiveType.java
@@ -370,8 +370,8 @@ public final class PrimitiveType extends Type {
    * {@inheritDoc}
    */
   @Override
-  public void accept(TypeVisitor visitor) {
-    visitor.visit(this);
+  public <T> T accept(TypeVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 
   /**

--- a/parquet-column/src/main/java/parquet/schema/Type.java
+++ b/parquet-column/src/main/java/parquet/schema/Type.java
@@ -161,7 +161,7 @@ abstract public class Type {
    * Visits this type with the given visitor
    * @param visitor the visitor to visit this type
    */
-  abstract public void accept(TypeVisitor visitor);
+  abstract public <T> T accept(TypeVisitor<T> visitor);
 
   @Override
   public int hashCode() {

--- a/parquet-hadoop/src/main/java/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/parquet/format/converter/ParquetMetadataConverter.java
@@ -95,9 +95,9 @@ public class ParquetMetadataConverter {
   }
 
   private void addToList(final List<SchemaElement> result, parquet.schema.Type field) {
-    field.accept(new TypeVisitor() {
+    field.accept(new TypeVisitor<Void>() {
       @Override
-      public void visit(PrimitiveType primitiveType) {
+      public Void visit(PrimitiveType primitiveType) {
         SchemaElement element = new SchemaElement(primitiveType.getName());
         element.setRepetition_type(toParquetRepetition(primitiveType.getRepetition()));
         element.setType(getType(primitiveType.getPrimitiveTypeName()));
@@ -112,22 +112,25 @@ public class ParquetMetadataConverter {
           element.setType_length(primitiveType.getTypeLength());
         }
         result.add(element);
+        return null;
       }
 
       @Override
-      public void visit(MessageType messageType) {
+      public Void visit(MessageType messageType) {
         SchemaElement element = new SchemaElement(messageType.getName());
         visitChildren(result, messageType.asGroupType(), element);
+        return null;
       }
 
       @Override
-      public void visit(GroupType groupType) {
+      public Void visit(GroupType groupType) {
         SchemaElement element = new SchemaElement(groupType.getName());
         element.setRepetition_type(toParquetRepetition(groupType.getRepetition()));
         if (groupType.getOriginalType() != null) {
           element.setConverted_type(getConvertedType(groupType.getOriginalType()));
         }
         visitChildren(result, groupType, element);
+        return null;
       }
 
       private void visitChildren(final List<SchemaElement> result,

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ColumnChunkPageReadStore.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ColumnChunkPageReadStore.java
@@ -16,6 +16,7 @@
 package parquet.hadoop;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;

--- a/parquet-hadoop/src/main/java/parquet/hadoop/metadata/ColumnPath.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/metadata/ColumnPath.java
@@ -17,6 +17,7 @@ package parquet.hadoop.metadata;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Locale;
 
 public final class ColumnPath implements Iterable<String> {
 

--- a/parquet-pig/src/main/java/parquet/pig/ParquetLoader.java
+++ b/parquet-pig/src/main/java/parquet/pig/ParquetLoader.java
@@ -165,7 +165,7 @@ public class ParquetLoader extends LoadFunc implements LoadMetadata, LoadPushDow
   public Tuple getNext() throws IOException {
     try {
       if (reader.nextKeyValue()) {
-        return (Tuple)reader.getCurrentValue();
+        return reader.getCurrentValue();
       } else {
         return null;
       }

--- a/parquet-pig/src/main/java/parquet/pig/TupleReadSupport.java
+++ b/parquet-pig/src/main/java/parquet/pig/TupleReadSupport.java
@@ -136,10 +136,7 @@ public class TupleReadSupport extends ReadSupport<Tuple> {
       return new ReadContext(initContext.getFileSchema());
     } else {
       // project the file schema according to the requested Pig schema
-      MessageType parquetRequestedSchema =
-          pigSchemaConverter.filter(
-          initContext.getFileSchema(),
-          requestedPigSchema);
+      MessageType parquetRequestedSchema = pigSchemaConverter.convert(requestedPigSchema);
       return new ReadContext(parquetRequestedSchema);
     }
   }

--- a/parquet-pig/src/test/java/parquet/pig/TestPigSchemaConverter.java
+++ b/parquet-pig/src/test/java/parquet/pig/TestPigSchemaConverter.java
@@ -74,9 +74,6 @@ public class TestPigSchemaConverter {
     MessageType schema = pigSchemaConverter.convert(pigSchema);
     MessageType expectedMT = MessageTypeParser.parseMessageType(schemaString);
     assertEquals("converting "+pigSchemaString+" to "+schemaString, expectedMT, schema);
-
-    MessageType filtered = pigSchemaConverter.filter(schema, pigSchema);
-    assertEquals("converting "+pigSchemaString+" to "+schemaString+" and filtering", schema.toString(), filtered.toString());
   }
 
   @Test


### PR DESCRIPTION
**NOTE: This is not fully compatible with the old parquet-column/io layer, has some code duplication, is missing tests, etc, etc. I am submitting this request now to start a discussion on the new concepts it contains and to discuss how (or if) to introduce breaking API changes.**

---

Pig and Hive assume certain values are nullable but should support
reading from Parquet files that do not have a representation of null
values. This patch introduces the notion type lifting. Lifted values
exist at runtime merely to provide a translation between the disk schema
and requested schema.

For example, a Parquet file with the following schema can not be read
from Pig or Hive:

```
message file_schema {
  optional binary key (UTF8);
  repeated group records {
    optional binary name (UTF8);
    optional binary type;
  }
}
```

The requested schema that e.g. Pig requires wraps the `records` group
in an optional group in order to provide an explicit representation
of a null value.

```
message requested_schema {
  optional binary key (UTF8);
  optional group records (LIST) {
    repeated group records {
      optional binary name (UTF8);
      optional binary type;
    }
  }
}
```

The file and requested schemas are not equal but are compatible for
reads with a simple transformation. When a nullable field present
in the requested schema but not on the file schema a GroupType wrapper
is inserted. This lifts non-nullable values into a nullable value.
