### PR TITLE
PARQUET-83 : Hive Query failed if the data type is array<string>

### DIFF
--- a/parquet-avro/src/main/java/parquet/avro/AvroIndexedRecordConverter.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroIndexedRecordConverter.java
@@ -402,18 +402,10 @@ class AvroIndexedRecordConverter<T extends IndexedRecord> extends GroupConverter
     private GenericArray<T> array;
 
     public AvroArrayConverter(ParentValueContainer parent, Type parquetSchema,
-        Schema avroSchema) {
+                        Schema avroSchema) {
       this.parent = parent;
       this.avroSchema = avroSchema;
-      Type elementType = parquetSchema.asGroupType().getType(0);
-      Schema elementSchema = avroSchema.getElementType();
-      converter = newConverter(elementSchema, elementType, new ParentValueContainer() {
-        @Override
-        @SuppressWarnings("unchecked")
-        void add(Object value) {
-          array.add((T) value);
-        }
-      });
+      this.converter = new ArrayValueConverter(parquetSchema, avroSchema);
     }
 
     @Override
@@ -423,14 +415,88 @@ class AvroIndexedRecordConverter<T extends IndexedRecord> extends GroupConverter
 
     @Override
     public void start() {
-      array = new GenericData.Array<T>(0, avroSchema);
+      this.array = new GenericData.Array<T>(0,avroSchema);
     }
 
     @Override
     public void end() {
       parent.add(array);
     }
-  }
+
+    final class ArrayValueConverter extends GroupConverter {
+
+      private T value;
+      private final Converter valueConverter;
+
+      public ArrayValueConverter(Type parquetSchema, Schema avroSchema) {
+
+        Type valueType = parquetSchema.asGroupType().getType(0).asGroupType().getType(0);
+        Schema valueSchema = avroSchema.getElementType();
+        valueConverter = newConverter(valueSchema, valueType, new ParentValueContainer() {
+          @Override
+          @SuppressWarnings("unchecked")
+          void add(Object value) {
+            ArrayValueConverter.this.value = (T) value;
+          }
+        });
+      }
+
+      @Override
+      public Converter getConverter(int fieldIndex) {
+        return valueConverter;
+      }
+
+      @Override
+      public void start() {
+        value = null;
+      }
+
+      @Override
+      public void end() {
+        array.add(value);
+      }
+    }
+   }
+
+
+
+//  static final class AvroArrayConverter<T> extends GroupConverter {
+//
+//    private final ParentValueContainer parent;
+//    private final Schema avroSchema;
+//    private final Converter converter;
+//    private GenericArray<T> array;
+//
+//    public AvroArrayConverter(ParentValueContainer parent, Type parquetSchema,
+//        Schema avroSchema) {
+//      this.parent = parent;
+//      this.avroSchema = avroSchema;
+//      Type elementType = parquetSchema.asGroupType().getType(0).asGroupType().getType(0);
+//      Schema elementSchema = avroSchema.getElementType();
+//      converter = newConverter(elementSchema, elementType, new ParentValueContainer() {
+//        @Override
+//        @SuppressWarnings("unchecked")
+//        void add(Object value) {
+//          array.add((T) value);
+//        }
+//      });
+//    }
+//
+//    @Override
+//    public Converter getConverter(int fieldIndex) {
+//      return converter;
+//    }
+//
+//    @Override
+//    public void start() {
+//      array = new GenericData.Array<T>(0, avroSchema);
+//    }
+//
+//    @Override
+//    public void end() {
+//      parent.add(array);
+//    }
+//  }
 
   static final class AvroUnionConverter<T> extends GroupConverter {
 
@@ -484,7 +550,7 @@ class AvroIndexedRecordConverter<T extends IndexedRecord> extends GroupConverter
     private Map<String, V> map;
 
     public MapConverter(ParentValueContainer parent, Type parquetSchema,
-        Schema avroSchema) {
+                        Schema avroSchema) {
       this.parent = parent;
       this.keyValueConverter = new MapKeyValueConverter(parquetSchema, avroSchema);
     }
@@ -552,5 +618,4 @@ class AvroIndexedRecordConverter<T extends IndexedRecord> extends GroupConverter
       }
     }
   }
-
 }

--- a/parquet-avro/src/main/java/parquet/avro/AvroIndexedRecordConverter.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroIndexedRecordConverter.java
@@ -402,7 +402,7 @@ class AvroIndexedRecordConverter<T extends IndexedRecord> extends GroupConverter
     private GenericArray<T> array;
 
     public AvroArrayConverter(ParentValueContainer parent, Type parquetSchema,
-                        Schema avroSchema) {
+        Schema avroSchema) {
       this.parent = parent;
       this.avroSchema = avroSchema;
       this.converter = new ArrayValueConverter(parquetSchema, avroSchema);
@@ -458,46 +458,6 @@ class AvroIndexedRecordConverter<T extends IndexedRecord> extends GroupConverter
     }
    }
 
-
-
-//  static final class AvroArrayConverter<T> extends GroupConverter {
-//
-//    private final ParentValueContainer parent;
-//    private final Schema avroSchema;
-//    private final Converter converter;
-//    private GenericArray<T> array;
-//
-//    public AvroArrayConverter(ParentValueContainer parent, Type parquetSchema,
-//        Schema avroSchema) {
-//      this.parent = parent;
-//      this.avroSchema = avroSchema;
-//      Type elementType = parquetSchema.asGroupType().getType(0).asGroupType().getType(0);
-//      Schema elementSchema = avroSchema.getElementType();
-//      converter = newConverter(elementSchema, elementType, new ParentValueContainer() {
-//        @Override
-//        @SuppressWarnings("unchecked")
-//        void add(Object value) {
-//          array.add((T) value);
-//        }
-//      });
-//    }
-//
-//    @Override
-//    public Converter getConverter(int fieldIndex) {
-//      return converter;
-//    }
-//
-//    @Override
-//    public void start() {
-//      array = new GenericData.Array<T>(0, avroSchema);
-//    }
-//
-//    @Override
-//    public void end() {
-//      parent.add(array);
-//    }
-//  }
-
   static final class AvroUnionConverter<T> extends GroupConverter {
 
     private final ParentValueContainer parent;
@@ -550,7 +510,7 @@ class AvroIndexedRecordConverter<T extends IndexedRecord> extends GroupConverter
     private Map<String, V> map;
 
     public MapConverter(ParentValueContainer parent, Type parquetSchema,
-                        Schema avroSchema) {
+        Schema avroSchema) {
       this.parent = parent;
       this.keyValueConverter = new MapKeyValueConverter(parquetSchema, avroSchema);
     }
@@ -618,4 +578,5 @@ class AvroIndexedRecordConverter<T extends IndexedRecord> extends GroupConverter
       }
     }
   }
+
 }

--- a/parquet-avro/src/main/java/parquet/avro/AvroSchemaConverter.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroSchemaConverter.java
@@ -20,12 +20,7 @@ import java.util.*;
 import org.apache.avro.Schema;
 
 import org.codehaus.jackson.node.NullNode;
-import parquet.schema.ConversionPatterns;
-import parquet.schema.GroupType;
-import parquet.schema.MessageType;
-import parquet.schema.OriginalType;
-import parquet.schema.PrimitiveType;
-import parquet.schema.Type;
+import parquet.schema.*;
 import parquet.schema.PrimitiveType.PrimitiveTypeName;
 
 import static parquet.schema.OriginalType.*;
@@ -108,8 +103,9 @@ public class AvroSchemaConverter {
     } else if (type.equals(Schema.Type.ENUM)) {
       return primitive(fieldName, BINARY, repetition, ENUM);
     } else if (type.equals(Schema.Type.ARRAY)) {
-      return new GroupType(repetition,fieldName,OriginalType.LIST,
-              new GroupType(Type.Repetition.REPEATED, "bag", convertField("array_element", schema.getElementType(), Type.Repetition.OPTIONAL)));
+      return ConversionPatterns.listType(repetition, fieldName,
+              Types.repeatedGroup().addField(convertField("array_element", schema.getElementType(),
+                      Type.Repetition.OPTIONAL)).named("bag"));
     } else if (type.equals(Schema.Type.MAP)) {
       Type valType = convertField("value", schema.getValueType());
       // avro map key type is always string

--- a/parquet-avro/src/main/java/parquet/avro/AvroSchemaConverter.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroSchemaConverter.java
@@ -108,7 +108,7 @@ public class AvroSchemaConverter {
     } else if (type.equals(Schema.Type.ENUM)) {
       return primitive(fieldName, BINARY, repetition, ENUM);
     } else if (type.equals(Schema.Type.ARRAY)) {
-      return new GroupType(Type.Repetition.OPTIONAL,fieldName,OriginalType.LIST,
+      return new GroupType(repetition,fieldName,OriginalType.LIST,
               new GroupType(Type.Repetition.REPEATED, "bag", convertField("array_element", schema.getElementType(), Type.Repetition.OPTIONAL)));
     } else if (type.equals(Schema.Type.MAP)) {
       Type valType = convertField("value", schema.getValueType());

--- a/parquet-avro/src/main/java/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroWriteSupport.java
@@ -120,11 +120,15 @@ public class AvroWriteSupport extends WriteSupport<IndexedRecord> {
                               Iterable<T> array) {
     recordConsumer.startGroup(); // group wrapper (original type LIST)
     if (array.iterator().hasNext()) {
-      recordConsumer.startField("array", 0);
+      recordConsumer.startField("bag", 0);
+      recordConsumer.startGroup();
+      recordConsumer.startField("array_element", 0);
       for (T elt : array) {
         writeValue(schema.getType(0), avroSchema.getElementType(), elt);
       }
-      recordConsumer.endField("array", 0);
+      recordConsumer.endField("array_element", 0);
+      recordConsumer.endGroup();
+      recordConsumer.endField("bag", 0);
     }
     recordConsumer.endGroup();
   }

--- a/parquet-avro/src/main/java/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroWriteSupport.java
@@ -120,15 +120,15 @@ public class AvroWriteSupport extends WriteSupport<IndexedRecord> {
                               Iterable<T> array) {
     recordConsumer.startGroup(); // group wrapper (original type LIST)
     if (array.iterator().hasNext()) {
-      recordConsumer.startField("bag", 0);
+      recordConsumer.startField(schema.getType(0).getName(), 0);
       recordConsumer.startGroup();
       recordConsumer.startField("array_element", 0);
       for (T elt : array) {
-        writeValue(schema.getType(0), avroSchema.getElementType(), elt);
+        writeValue(schema.getType(0).asGroupType().getType(0), avroSchema.getElementType(), elt);
       }
       recordConsumer.endField("array_element", 0);
       recordConsumer.endGroup();
-      recordConsumer.endField("bag", 0);
+      recordConsumer.endField(schema.getType(0).getName(), 0);
     }
     recordConsumer.endGroup();
   }

--- a/parquet-avro/src/test/java/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/parquet/avro/TestAvroSchemaConverter.java
@@ -41,16 +41,22 @@ public class TestAvroSchemaConverter {
       "    required int32 mynestedint;\n" +
       "  }\n" +
       "  required binary myenum (ENUM);\n" +
-      "  required group myarray (LIST) {\n" +
-      "    repeated int32 array;\n" +
+      "  optional group myarray (LIST) {\n" +
+      "    repeated group bag {\n" +
+      "       optional int32 array_element;\n" +
+      "   }\n" +
       "  }\n" +
       "  optional group myoptionalarray (LIST) {\n" +
-      "    repeated int32 array;\n" +
+      "    repeated group bag {\n" +
+      "       optional int32 array_element;\n" +
+      "   }\n" +
       "  }\n" +
-      "  required group myrecordarray (LIST) {\n" +
-      "    repeated group array {\n" +
-      "      required int32 a;\n" +
-      "      required int32 b;\n" +
+      "  optional group myrecordarray (LIST) {\n" +
+      "    repeated group bag {\n" +
+      "     optional group array_element {\n" +
+      "       required int32 a;\n" +
+      "       required int32 b;\n" +
+      "     }\n" +
       "    }\n" +
       "  }\n" +
       "  required group mymap (MAP) {\n" +
@@ -116,14 +122,20 @@ public class TestAvroSchemaConverter {
             "    required int32 mynestedint;\n" +
             "  }\n" +
             "  required binary myenum (ENUM);\n" +
-            "  required group myarray (LIST) {\n" +
-            "    repeated int32 array;\n" +
+            "  optional group myarray (LIST) {\n" +
+            "    repeated group bag {\n" +
+            "       optional int32 array_element;\n" +
+            "   }\n" +
             "  }\n" +
-            "  required group myemptyarray (LIST) {\n" +
-            "    repeated int32 array;\n" +
+            "  optional group myemptyarray (LIST) {\n" +
+            "    repeated group bag {\n" +
+            "       optional int32 array_element;\n" +
+            "   }\n" +
             "  }\n" +
             "  optional group myoptionalarray (LIST) {\n" +
-            "    repeated int32 array;\n" +
+            "    repeated group bag {\n" +
+            "       optional int32 array_element;\n" +
+            "   }\n" +
             "  }\n" +
             "  required group mymap (MAP) {\n" +
             "    repeated group map (MAP_KEY_VALUE) {\n" +
@@ -214,10 +226,12 @@ public class TestAvroSchemaConverter {
     System.err.println("Avro schema: " + schema.toString(true));
 
     testAvroToParquetConversion(schema, "message HasArray {\n" +
-        "  required group myarray (LIST) {\n" +
-        "    repeated group array {\n" +
-        "      optional binary s1 (UTF8);\n" +
-        "      optional binary s2 (UTF8);\n" +
+        "  optional group myarray (LIST) {\n" +
+        "    repeated group bag {\n" +
+        "       optional group array_element {\n" +
+        "         optional binary s1 (UTF8);\n" +
+        "         optional binary s2 (UTF8);\n" +
+        "      }\n" +
         "    }\n" +
         "  }\n" +
         "}\n");

--- a/parquet-avro/src/test/java/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/parquet/avro/TestAvroSchemaConverter.java
@@ -41,7 +41,7 @@ public class TestAvroSchemaConverter {
       "    required int32 mynestedint;\n" +
       "  }\n" +
       "  required binary myenum (ENUM);\n" +
-      "  optional group myarray (LIST) {\n" +
+      "  required group myarray (LIST) {\n" +
       "    repeated group bag {\n" +
       "       optional int32 array_element;\n" +
       "   }\n" +
@@ -51,7 +51,7 @@ public class TestAvroSchemaConverter {
       "       optional int32 array_element;\n" +
       "   }\n" +
       "  }\n" +
-      "  optional group myrecordarray (LIST) {\n" +
+      "  required group myrecordarray (LIST) {\n" +
       "    repeated group bag {\n" +
       "     optional group array_element {\n" +
       "       required int32 a;\n" +
@@ -122,12 +122,12 @@ public class TestAvroSchemaConverter {
             "    required int32 mynestedint;\n" +
             "  }\n" +
             "  required binary myenum (ENUM);\n" +
-            "  optional group myarray (LIST) {\n" +
+            "  required group myarray (LIST) {\n" +
             "    repeated group bag {\n" +
             "       optional int32 array_element;\n" +
             "   }\n" +
             "  }\n" +
-            "  optional group myemptyarray (LIST) {\n" +
+            "  required group myemptyarray (LIST) {\n" +
             "    repeated group bag {\n" +
             "       optional int32 array_element;\n" +
             "   }\n" +
@@ -226,7 +226,7 @@ public class TestAvroSchemaConverter {
     System.err.println("Avro schema: " + schema.toString(true));
 
     testAvroToParquetConversion(schema, "message HasArray {\n" +
-        "  optional group myarray (LIST) {\n" +
+        "  required group myarray (LIST) {\n" +
         "    repeated group bag {\n" +
         "       optional group array_element {\n" +
         "         optional binary s1 (UTF8);\n" +

--- a/parquet-avro/src/test/java/parquet/avro/TestReadWrite.java
+++ b/parquet-avro/src/test/java/parquet/avro/TestReadWrite.java
@@ -269,27 +269,37 @@ public class TestReadWrite {
 
         recordConsumer.startField("myarray", index);
         recordConsumer.startGroup();
-        recordConsumer.startField("array", 0);
+        recordConsumer.startField("bag", 0);
+        recordConsumer.startGroup();
+        recordConsumer.startField("array_element", 0);
         for (int val : (int[]) record.get("myarray")) {
           recordConsumer.addInteger(val);
         }
-        recordConsumer.endField("array", 0);
+        recordConsumer.endField("array_element", 0);
+        recordConsumer.endGroup();
+        recordConsumer.endField("bag",0);
         recordConsumer.endGroup();
         recordConsumer.endField("myarray", index++);
 
         recordConsumer.startField("myoptionalarray", index);
         recordConsumer.startGroup();
-        recordConsumer.startField("array", 0);
+        recordConsumer.startField("bag", 0);
+        recordConsumer.startGroup();
+        recordConsumer.startField("array_element", 0);
         for (int val : (int[]) record.get("myoptionalarray")) {
           recordConsumer.addInteger(val);
         }
-        recordConsumer.endField("array", 0);
+        recordConsumer.endField("array_element", 0);
+        recordConsumer.endGroup();
+        recordConsumer.endField("bag",0);
         recordConsumer.endGroup();
         recordConsumer.endField("myoptionalarray", index++);
 
         recordConsumer.startField("myrecordarray", index);
         recordConsumer.startGroup();
-        recordConsumer.startField("array", 0);
+        recordConsumer.startField("bag", 0);
+        recordConsumer.startGroup();
+        recordConsumer.startField("array_element", 0);
         recordConsumer.startGroup();
         recordConsumer.startField("a", 0);
         for (int val : (int[]) record.get("myrecordarraya")) {
@@ -302,10 +312,11 @@ public class TestReadWrite {
         }
         recordConsumer.endField("b", 1);
         recordConsumer.endGroup();
-        recordConsumer.endField("array", 0);
+        recordConsumer.endField("array_element", 0);
+        recordConsumer.endGroup();
+        recordConsumer.endField("bag",0);
         recordConsumer.endGroup();
         recordConsumer.endField("myrecordarray", index++);
-
         recordConsumer.startField("mymap", index);
         recordConsumer.startGroup();
         recordConsumer.startField("map", 0);
@@ -361,7 +372,7 @@ public class TestReadWrite {
 
     List<Integer> integerArray = Arrays.asList(1, 2, 3);
 
-    Schema recordArraySchema = Schema.createRecord("array", null, null, false);
+    Schema recordArraySchema = Schema.createRecord("array_element", null, null, false);
     recordArraySchema.setFields(Arrays.asList(
         new Schema.Field("a", Schema.create(Schema.Type.INT), null, null),
         new Schema.Field("b", Schema.create(Schema.Type.INT), null, null)

--- a/parquet-avro/src/test/resources/allFromParquet.avsc
+++ b/parquet-avro/src/test/resources/allFromParquet.avsc
@@ -56,7 +56,7 @@
       "type" : "array",
       "items" : {
         "type" : "record",
-        "name" : "array",
+        "name" : "array_element",
         "namespace" : "",
         "fields" : [ {
            "name" : "a",


### PR DESCRIPTION
Changed the  Parquet-Avro array definition to the Hive understandable.
Now with this fix Avro schema definition is going to be converted to the following format as below.
```
{ "name" : "action", "type" : [ { "type" : "array", "items" : "string" }, "null" ] }
```
Schema definition after this fix:
```
optional group action {
    repeated group bag {
        optional binary array_element
    }
}
```