### PR TITLE
Parquet 78 byte buffer write 20140904

### DIFF
--- a/parquet-column/src/main/java/parquet/column/ColumnWriter.java
+++ b/parquet-column/src/main/java/parquet/column/ColumnWriter.java
@@ -87,6 +87,12 @@ public interface ColumnWriter {
    */
   void flush();
 
+ /**
+  * Close the underlying store. This should be called when there are no
+  * more data to be written.
+  */
+  void close();
+
   /**
    * used to decide when to write a page or row group
    * @return the number of bytes of memory used to buffer the current data

--- a/parquet-column/src/main/java/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/parquet/column/ParquetProperties.java
@@ -1,6 +1,8 @@
 package parquet.column;
 
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesUtils;
+import parquet.bytes.HeapByteBufferAllocator;
 import parquet.column.values.ValuesWriter;
 import parquet.column.values.boundedint.DevNullValuesWriter;
 import parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
@@ -47,19 +49,25 @@ public class ParquetProperties {
   private final int dictionaryPageSizeThreshold;
   private final WriterVersion writerVersion;
   private final boolean enableDictionary;
+  private ByteBufferAllocator allocator;
 
   public ParquetProperties(int dictPageSize, WriterVersion writerVersion, boolean enableDict) {
+    this(dictPageSize, writerVersion, enableDict, new HeapByteBufferAllocator());
+  }
+
+  public ParquetProperties(int dictPageSize, WriterVersion writerVersion, boolean enableDict, ByteBufferAllocator allocator) {
     this.dictionaryPageSizeThreshold = dictPageSize;
     this.writerVersion = writerVersion;
     this.enableDictionary = enableDict;
+    this.allocator=allocator;
   }
   
-  public static ValuesWriter getColumnDescriptorValuesWriter(int maxLevel,  int initialSizePerCol) {
+  public static ValuesWriter getColumnDescriptorValuesWriter(int maxLevel,  int initialSizePerCol, ByteBufferAllocator allocator) {
     if (maxLevel == 0) {
       return new DevNullValuesWriter();
     } else {
       return new RunLengthBitPackingHybridValuesWriter(
-          BytesUtils.getWidthFromMaxInt(maxLevel), initialSizePerCol);
+          BytesUtils.getWidthFromMaxInt(maxLevel), initialSizePerCol, allocator!=null?allocator:new HeapByteBufferAllocator());
     }
   }
 
@@ -67,65 +75,65 @@ public class ParquetProperties {
     switch (path.getType()) {
     case BOOLEAN:
       if(writerVersion == WriterVersion.PARQUET_1_0) {
-        return new BooleanPlainValuesWriter();
+        return new BooleanPlainValuesWriter(this.allocator);
       } else if (writerVersion == WriterVersion.PARQUET_2_0) {
-        return new RunLengthBitPackingHybridValuesWriter(1, initialSizePerCol);
+        return new RunLengthBitPackingHybridValuesWriter(1, initialSizePerCol, this.allocator);
       }
       break;
     case BINARY:
       if(enableDictionary) {
-        return new PlainBinaryDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol);
+        return new PlainBinaryDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol, this.allocator);
       } else {
         if (writerVersion == WriterVersion.PARQUET_1_0) {
-          return new PlainValuesWriter(initialSizePerCol);
+          return new PlainValuesWriter(initialSizePerCol, this.allocator);
         } else if (writerVersion == WriterVersion.PARQUET_2_0) {
-          return new DeltaByteArrayWriter(initialSizePerCol);
+          return new DeltaByteArrayWriter(initialSizePerCol, this.allocator);
         } 
       }
       break;
     case INT32:
       if(enableDictionary) {
-        return new PlainIntegerDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol);
+        return new PlainIntegerDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol, this.allocator);
       } else {
         if(writerVersion == WriterVersion.PARQUET_1_0) {
-          return new PlainValuesWriter(initialSizePerCol);
+          return new PlainValuesWriter(initialSizePerCol, this.allocator);
         } else if(writerVersion == WriterVersion.PARQUET_2_0) {
-          return new DeltaBinaryPackingValuesWriter(initialSizePerCol);
+          return new DeltaBinaryPackingValuesWriter(initialSizePerCol, this.allocator);
         }
       }
       break;
     case INT64:
       if(enableDictionary) {
-        return new PlainLongDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol);
+        return new PlainLongDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol, this.allocator);
       } else {
-        return new PlainValuesWriter(initialSizePerCol);
+        return new PlainValuesWriter(initialSizePerCol, this.allocator);
       }
     case INT96:
       if (enableDictionary) {
-        return new PlainFixedLenArrayDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol, 12);
+        return new PlainFixedLenArrayDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol, 12, this.allocator);
       } else {
-        return new FixedLenByteArrayPlainValuesWriter(12, initialSizePerCol);
+        return new FixedLenByteArrayPlainValuesWriter(12, initialSizePerCol, this.allocator);
       }
     case DOUBLE:
       if(enableDictionary) {
-        return new PlainDoubleDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol);
+        return new PlainDoubleDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol, this.allocator);
       } else {
-        return new PlainValuesWriter(initialSizePerCol);
+        return new PlainValuesWriter(initialSizePerCol, this.allocator);
       }
     case FLOAT:
       if(enableDictionary) {
-        return new PlainFloatDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol);
+        return new PlainFloatDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol, this.allocator);
       } else {
-        return new PlainValuesWriter(initialSizePerCol);
+        return new PlainValuesWriter(initialSizePerCol, this.allocator);
       }
     case FIXED_LEN_BYTE_ARRAY:
       if (enableDictionary && (writerVersion == WriterVersion.PARQUET_2_0)) {
-        return new PlainFixedLenArrayDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol, path.getTypeLength());
+        return new PlainFixedLenArrayDictionaryValuesWriter(dictionaryPageSizeThreshold, initialSizePerCol, path.getTypeLength(), this.allocator);
       } else {
-        return new FixedLenByteArrayPlainValuesWriter(path.getTypeLength(), initialSizePerCol);
+        return new FixedLenByteArrayPlainValuesWriter(path.getTypeLength(), initialSizePerCol, this.allocator);
       }
     default:
-      return new PlainValuesWriter(initialSizePerCol);
+      return new PlainValuesWriter(initialSizePerCol, this.allocator);
     }
     return null;
   }

--- a/parquet-column/src/main/java/parquet/column/impl/ColumnReaderImpl.java
+++ b/parquet-column/src/main/java/parquet/column/impl/ColumnReaderImpl.java
@@ -20,6 +20,7 @@ import static parquet.Log.DEBUG;
 import static parquet.Preconditions.checkNotNull;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.Log;
 import parquet.column.ColumnDescriptor;
@@ -518,16 +519,16 @@ class ColumnReaderImpl implements ColumnReader {
     this.pageValueCount = page.getValueCount();
     this.endOfPageValueCount = readValues + pageValueCount;
     try {
-      byte[] bytes = page.getBytes().toByteArray();
-      if (DEBUG) LOG.debug("page size " + bytes.length + " bytes and " + pageValueCount + " records");
+      ByteBuffer byteBuf = page.getBytes().toByteBuffer();
+      if (DEBUG) LOG.debug("page size " + page.getBytes().size() + " bytes and " + pageValueCount + " records");
       if (DEBUG) LOG.debug("reading repetition levels at 0");
-      repetitionLevelColumn.initFromPage(pageValueCount, bytes, 0);
+      repetitionLevelColumn.initFromPage(pageValueCount, byteBuf, 0);
       int next = repetitionLevelColumn.getNextOffset();
       if (DEBUG) LOG.debug("reading definition levels at " + next);
-      definitionLevelColumn.initFromPage(pageValueCount, bytes, next);
+      definitionLevelColumn.initFromPage(pageValueCount, byteBuf, next);
       next = definitionLevelColumn.getNextOffset();
       if (DEBUG) LOG.debug("reading data at " + next);
-      dataColumn.initFromPage(pageValueCount, bytes, next);
+      dataColumn.initFromPage(pageValueCount, byteBuf, next);
     } catch (IOException e) {
       throw new ParquetDecodingException("could not read page " + page + " in col " + path, e);
     }

--- a/parquet-column/src/main/java/parquet/column/impl/ColumnWriteStoreImpl.java
+++ b/parquet-column/src/main/java/parquet/column/impl/ColumnWriteStoreImpl.java
@@ -114,6 +114,14 @@ public class ColumnWriteStoreImpl implements ColumnWriteStore {
     }
   }
 
+  @Override
+  public void close() {
+    Collection<ColumnWriterImpl> values = columns.values();
+    for (ColumnWriterImpl memColumn : values) {
+      memColumn.close();
+    }
+  }
+
   public String memUsageString() {
     StringBuilder b = new StringBuilder("Store {\n");
     Collection<ColumnWriterImpl> values = columns.values();

--- a/parquet-column/src/main/java/parquet/column/impl/ColumnWriterImpl.java
+++ b/parquet-column/src/main/java/parquet/column/impl/ColumnWriterImpl.java
@@ -68,9 +68,16 @@ final class ColumnWriterImpl implements ColumnWriter {
     this.valueCountForNextSizeCheck = INITIAL_COUNT_FOR_SIZE_CHECK;
     resetStatistics();
 
-    ParquetProperties parquetProps = new ParquetProperties(dictionaryPageSizeThreshold, writerVersion, enableDictionary);
-    this.repetitionLevelColumn = ParquetProperties.getColumnDescriptorValuesWriter(path.getMaxRepetitionLevel(), initialSizePerCol);
-    this.definitionLevelColumn = ParquetProperties.getColumnDescriptorValuesWriter(path.getMaxDefinitionLevel(), initialSizePerCol);
+    ParquetProperties parquetProps = new ParquetProperties(dictionaryPageSizeThreshold,
+      writerVersion,
+      enableDictionary,
+      pageWriter.getAllocator());
+    this.repetitionLevelColumn = ParquetProperties.getColumnDescriptorValuesWriter(path.getMaxRepetitionLevel(),
+      initialSizePerCol,
+      pageWriter.getAllocator());
+    this.definitionLevelColumn = ParquetProperties.getColumnDescriptorValuesWriter(path.getMaxDefinitionLevel(),
+      initialSizePerCol,
+      pageWriter.getAllocator());
     this.dataColumn = parquetProps.getValuesWriter(path, initialSizePerCol);
   }
 
@@ -245,6 +252,15 @@ final class ColumnWriterImpl implements ColumnWriter {
       }
       dataColumn.resetDictionary();
     }
+  }
+
+  @Override
+  public void close() {
+    flush();
+    // Close the Values writers.
+    repetitionLevelColumn.close();
+    definitionLevelColumn.close();
+    dataColumn.close();
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/column/page/PageWriter.java
+++ b/parquet-column/src/main/java/parquet/column/page/PageWriter.java
@@ -17,6 +17,7 @@ package parquet.column.page;
 
 import java.io.IOException;
 
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
 import parquet.column.Encoding;
 import parquet.column.statistics.Statistics;
@@ -70,5 +71,23 @@ public interface PageWriter {
   void writeDictionaryPage(DictionaryPage dictionaryPage) throws IOException;
 
   public abstract String memUsageString(String prefix);
+
+  /**
+   * Gets the associated ByteBuffer allocator. The allocator is passed in all the way down to
+   * the Column ValuesWriter(s).
+   * @return
+   */
+  ByteBufferAllocator getAllocator();
+
+  /**
+   * Reset the page writer. Reset/reallocate any resources.
+   */
+  public void reset();
+
+
+  /**
+   * Close the page writer. Free any resources.
+   */
+  public void close();
 
 }

--- a/parquet-column/src/main/java/parquet/column/statistics/BinaryStatistics.java
+++ b/parquet-column/src/main/java/parquet/column/statistics/BinaryStatistics.java
@@ -67,8 +67,8 @@ public class BinaryStatistics extends Statistics<Binary> {
   }
 
   public void updateStats(Binary min_value, Binary max_value) {
-    if (min.compareTo(min_value) > 0) { min = min_value; }
-    if (max.compareTo(max_value) < 0) { max = max_value; }
+    if (min.compareTo(min_value) > 0) { min = Binary.fromByteArray(min_value.getBytes()); }
+    if (max.compareTo(max_value) < 0) { max = Binary.fromByteArray(max_value.getBytes()); }
   }
 
   public void initializeStats(Binary min_value, Binary max_value) {

--- a/parquet-column/src/main/java/parquet/column/values/ValuesReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/ValuesReader.java
@@ -19,11 +19,12 @@ import java.io.IOException;
 
 import parquet.io.ParquetDecodingException;
 import parquet.io.api.Binary;
+import java.nio.ByteBuffer;
 
 /**
  * Base class to implement an encoding for a given column type.
  *
- * A ValuesReader is provided with a page (byte-array) and is responsible
+ * A ValuesReader is provided with a page (byte-buffer) and is responsible
  * for deserializing the primitive values stored in that page.
  *
  * Given that pages are homogeneous (store only a single type), typical subclasses
@@ -54,6 +55,11 @@ public abstract class ValuesReader {
    * @param offset where to start reading from in the page
    *
    * @throws IOException
+   */
+  public abstract void initFromPage(int valueCount, ByteBuffer page, int offset) throws IOException;
+  
+  /*
+   * Compatitble Interface.
    */
   public abstract void initFromPage(int valueCount, byte[] page, int offset) throws IOException;
   

--- a/parquet-column/src/main/java/parquet/column/values/ValuesWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/ValuesWriter.java
@@ -53,6 +53,12 @@ public abstract class ValuesWriter {
   public abstract void reset();
 
   /**
+   * Called to close the values writer. Any output stream is closed and can no longer be used.
+   * All resources are released.
+   */
+  public abstract void close();
+
+  /**
    * @return the dictionary page or null if not dictionary based
    */
   public DictionaryPage createDictionaryPage() {

--- a/parquet-column/src/main/java/parquet/column/values/bitpacking/BitPackingValuesReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/bitpacking/BitPackingValuesReader.java
@@ -18,11 +18,12 @@ package parquet.column.values.bitpacking;
 import static parquet.bytes.BytesUtils.getWidthFromMaxInt;
 import static parquet.column.values.bitpacking.BitPacking.createBitPackingReader;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.Log;
 import parquet.bytes.BytesUtils;
+import parquet.bytes.ByteBufferInputStream;
 import parquet.column.values.ValuesReader;
 import parquet.column.values.bitpacking.BitPacking.BitPackingReader;
 import parquet.io.ParquetDecodingException;
@@ -36,7 +37,7 @@ import parquet.io.ParquetDecodingException;
 public class BitPackingValuesReader extends ValuesReader {
   private static final Log LOG = Log.getLog(BitPackingValuesReader.class);
 
-  private ByteArrayInputStream in;
+  private ByteBufferInputStream in;
   private BitPackingReader bitPackingReader;
   private final int bitsPerValue;
   private int nextOffset;
@@ -66,13 +67,18 @@ public class BitPackingValuesReader extends ValuesReader {
    * @see parquet.column.values.ValuesReader#initFromPage(long, byte[], int)
    */
   @Override
-  public void initFromPage(int valueCount, byte[] in, int offset) throws IOException {
+  public void initFromPage(int valueCount, ByteBuffer in, int offset) throws IOException {
     int effectiveBitLength = valueCount * bitsPerValue;
     int length = BytesUtils.paddedByteCountFromBits(effectiveBitLength);
     if (Log.DEBUG) LOG.debug("reading " + length + " bytes for " + valueCount + " values of size " + bitsPerValue + " bits." );
-    this.in = new ByteArrayInputStream(in, offset, length);
+    this.in = new ByteBufferInputStream(in.duplicate(), offset, length);
     this.bitPackingReader = createBitPackingReader(bitsPerValue, this.in, valueCount);
     this.nextOffset = offset + length;
+  }
+  
+  @Override
+  public void initFromPage(int valueCount, byte[] page, int offset) throws IOException{
+    this.initFromPage(valueCount, ByteBuffer.wrap(page), offset);
   }
   
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/bitpacking/BitPackingValuesWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/bitpacking/BitPackingValuesWriter.java
@@ -21,6 +21,7 @@ import static parquet.column.values.bitpacking.BitPacking.getBitPackingWriter;
 
 import java.io.IOException;
 
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
 import parquet.bytes.CapacityByteArrayOutputStream;
 import parquet.column.Encoding;
@@ -39,13 +40,15 @@ public class BitPackingValuesWriter extends ValuesWriter {
   private CapacityByteArrayOutputStream out;
   private BitPackingWriter bitPackingWriter;
   private int bitsPerValue;
+  private ByteBufferAllocator allocator;
 
   /**
    * @param bound the maximum value stored by this column
    */
-  public BitPackingValuesWriter(int bound, int initialCapacity) {
+  public BitPackingValuesWriter(int bound, int initialCapacity, ByteBufferAllocator allocator) {
     this.bitsPerValue = getWidthFromMaxInt(bound);
-    this.out = new CapacityByteArrayOutputStream(initialCapacity);
+    this.allocator=allocator;
+    this.out = new CapacityByteArrayOutputStream(initialCapacity, this.allocator);
     init();
   }
 
@@ -97,6 +100,11 @@ public class BitPackingValuesWriter extends ValuesWriter {
   public void reset() {
     out.reset();
     init();
+  }
+
+  @Override
+  public void close() {
+    out.close();
   }
 
   /**

--- a/parquet-column/src/main/java/parquet/column/values/bitpacking/ByteBitPackingValuesWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/bitpacking/ByteBitPackingValuesWriter.java
@@ -19,6 +19,7 @@ import static parquet.column.Encoding.BIT_PACKED;
 
 import java.io.IOException;
 
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
 import parquet.bytes.BytesUtils;
 import parquet.column.Encoding;
@@ -31,7 +32,7 @@ public class ByteBitPackingValuesWriter extends ValuesWriter {
   private final int bitWidth;
   private ByteBasedBitPackingEncoder encoder;
 
-  public ByteBitPackingValuesWriter(int bound, Packer packer) {
+  public ByteBitPackingValuesWriter(int bound, Packer packer, ByteBufferAllocator a) {
     this.packer = packer;
     this.bitWidth = BytesUtils.getWidthFromMaxInt(bound);
     this.encoder = new ByteBasedBitPackingEncoder(bitWidth, packer);
@@ -63,6 +64,11 @@ public class ByteBitPackingValuesWriter extends ValuesWriter {
   @Override
   public void reset() {
     encoder = new ByteBasedBitPackingEncoder(bitWidth, packer);
+  }
+
+  @Override
+  public void close() {
+    /* nothing to do */
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/boundedint/BitReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/boundedint/BitReader.java
@@ -16,13 +16,14 @@
 package parquet.column.values.boundedint;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.io.ParquetDecodingException;
 
 class BitReader {
   private int currentByte = 0;
   private int currentPosition = 8;
-  private byte[] buf;
+  private ByteBuffer buf;
   private int currentBufferPosition = 0;
   private static final int[] byteGetValueMask = new int[8];
   private static final int[] readMask = new int[32];
@@ -47,7 +48,7 @@ class BitReader {
    * The array is not copied, so must not be mutated during the course of
    * reading.
    */
-  public void prepare(byte[] buf, int offset, int length) {
+  public void prepare(ByteBuffer buf, int offset, int length) {
     this.buf = buf;
     this.endBufferPosistion = offset + length;
     currentByte = 0;
@@ -84,7 +85,7 @@ class BitReader {
 
   private int getNextByte() {
     if (currentBufferPosition < endBufferPosistion) {
-      return buf[currentBufferPosition++] & 0xFF;
+      return buf.get(currentBufferPosition++) & 0xFF;
     }
     return 0;
   }

--- a/parquet-column/src/main/java/parquet/column/values/boundedint/BitWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/boundedint/BitWriter.java
@@ -16,6 +16,7 @@
 package parquet.column.values.boundedint;
 
 import parquet.Log;
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
 import parquet.bytes.CapacityByteArrayOutputStream;
 
@@ -29,6 +30,7 @@ class BitWriter {
   private static final int[] byteToTrueMask = new int[8];
   private static final int[] byteToFalseMask = new int[8];
   private boolean finished = false;
+  private ByteBufferAllocator allocator;
   static {
     int currentMask = 1;
     for (int i = 0; i < byteToTrueMask.length; i++) {
@@ -38,8 +40,9 @@ class BitWriter {
     }
   }
 
-  public BitWriter(int initialCapacity) {
-    this.baos = new CapacityByteArrayOutputStream(initialCapacity);
+  public BitWriter(int initialCapacity, ByteBufferAllocator allocator) {
+    this.allocator=allocator;
+    this.baos = new CapacityByteArrayOutputStream(initialCapacity, allocator);
   }
 
   public void writeBit(boolean bit) {
@@ -152,5 +155,12 @@ class BitWriter {
 
   public String memUsageString(String prefix) {
     return baos.memUsageString(prefix);
+  }
+
+  public void close() {
+    currentByte = 0;
+    currentBytePosition = 0;
+    finished = false;
+    baos.close();
   }
 }

--- a/parquet-column/src/main/java/parquet/column/values/boundedint/BoundedIntValuesReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/boundedint/BoundedIntValuesReader.java
@@ -18,6 +18,7 @@ package parquet.column.values.boundedint;
 import static parquet.Log.DEBUG;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.Log;
 import parquet.bytes.BytesUtils;
@@ -67,8 +68,8 @@ class BoundedIntValuesReader extends ValuesReader {
   // bytes would have to be serialized). This is the flip-side
   // to BoundedIntColumnWriter.writeData(BytesOutput)
   @Override
-  public void initFromPage(int valueCount, byte[] in, int offset) throws IOException {
-    if (DEBUG) LOG.debug("reading size at "+ offset + ": " + in[offset] + " " + in[offset + 1] + " " + in[offset + 2] + " " + in[offset + 3] + " ");
+  public void initFromPage(int valueCount, ByteBuffer in, int offset) throws IOException {
+    if (DEBUG) LOG.debug("reading size at "+ offset + ": " + in.get(offset) + " " + in.get(offset + 1) + " " + in.get(offset + 2) + " " + in.get(offset + 3) + " ");
     int totalBytes = BytesUtils.readIntLittleEndian(in, offset);
     if (DEBUG) LOG.debug("will read "+ totalBytes + " bytes");
     currentValueCt = 0;
@@ -76,6 +77,11 @@ class BoundedIntValuesReader extends ValuesReader {
     bitReader.prepare(in, offset + 4, totalBytes);
     if (DEBUG) LOG.debug("will read next from " + (offset + totalBytes + 4));
     this.nextOffset = offset + totalBytes + 4;
+  }
+  
+  @Override
+  public void initFromPage(int valueCount, byte[] page, int offset) throws IOException{
+    this.initFromPage(valueCount, ByteBuffer.wrap(page), offset);
   }
   
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/boundedint/BoundedIntValuesWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/boundedint/BoundedIntValuesWriter.java
@@ -18,6 +18,7 @@ package parquet.column.values.boundedint;
 import static parquet.bytes.BytesInput.concat;
 import static parquet.column.Encoding.RLE;
 import parquet.Log;
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
 import parquet.column.Encoding;
 import parquet.column.values.ValuesWriter;
@@ -46,6 +47,7 @@ class BoundedIntValuesWriter extends ValuesWriter {
   private int bitsPerValue;
   private BitWriter bitWriter;
   private boolean isFirst = true;
+  private ByteBufferAllocator allocator;
 
   private static final int[] byteToTrueMask = new int[8];
   static {
@@ -56,11 +58,12 @@ class BoundedIntValuesWriter extends ValuesWriter {
     }
   }
 
-  public BoundedIntValuesWriter(int bound, int initialCapacity) {
+  public BoundedIntValuesWriter(int bound, int initialCapacity, ByteBufferAllocator allocator) {
     if (bound == 0) {
       throw new ParquetEncodingException("Value bound cannot be 0. Use DevNullColumnWriter instead.");
     }
-    this.bitWriter = new BitWriter(initialCapacity);
+    this.allocator=allocator;
+    this.bitWriter = new BitWriter(initialCapacity, allocator);
     bitsPerValue = (int)Math.ceil(Math.log(bound + 1)/Math.log(2));
     shouldRepeatThreshold = (bitsPerValue + 9)/(1 + bitsPerValue);
     if (Log.DEBUG) LOG.debug("init column with bit width of " + bitsPerValue + " and repeat threshold of " + shouldRepeatThreshold);
@@ -95,6 +98,16 @@ class BoundedIntValuesWriter extends ValuesWriter {
     thereIsABufferedValue = false;
     isFirst = true;
     bitWriter.reset();
+  }
+
+  @Override
+  public void close() {
+    currentValue = -1;
+    currentValueCt = -1;
+    currentValueIsRepeated = false;
+    thereIsABufferedValue = false;
+    isFirst = true;
+    bitWriter.close();
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/boundedint/DevNullValuesWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/boundedint/DevNullValuesWriter.java
@@ -37,6 +37,11 @@ public class DevNullValuesWriter extends ValuesWriter {
   }
 
   @Override
+  public void close() {
+
+  }
+
+  @Override
   public void writeInteger(int v) {
   }
 

--- a/parquet-column/src/main/java/parquet/column/values/boundedint/ZeroIntegerValuesReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/boundedint/ZeroIntegerValuesReader.java
@@ -16,6 +16,7 @@
 package parquet.column.values.boundedint;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.column.values.ValuesReader;
 
@@ -33,8 +34,13 @@ public class ZeroIntegerValuesReader extends ValuesReader {
   }
 
   @Override
-  public void initFromPage(int valueCount, byte[] in, int offset) throws IOException {
+  public void initFromPage(int valueCount, ByteBuffer in, int offset) throws IOException {
     this.nextOffset = offset;
+  }
+  
+  @Override
+  public void initFromPage(int valueCount, byte[] page, int offset) throws IOException{
+    this.initFromPage(valueCount, ByteBuffer.wrap(page), offset);
   }
   
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/delta/DeltaBinaryPackingValuesReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/delta/DeltaBinaryPackingValuesReader.java
@@ -21,9 +21,11 @@ import parquet.column.values.ValuesReader;
 import parquet.column.values.bitpacking.BytePacker;
 import parquet.column.values.bitpacking.Packer;
 import parquet.io.ParquetDecodingException;
+import parquet.bytes.ByteBufferInputStream;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 /**
  * Read values written by {@link DeltaBinaryPackingValuesWriter}
@@ -37,7 +39,7 @@ public class DeltaBinaryPackingValuesReader extends ValuesReader {
    */
   private int valuesRead;
   private int minDeltaInCurrentBlock;
-  private byte[] page;
+  private ByteBuffer page;
   /**
    * stores the decoded values including the first value which is written to the header
    */
@@ -47,7 +49,7 @@ public class DeltaBinaryPackingValuesReader extends ValuesReader {
    * when data is not aligned to mini block, which means padding 0s are in the buffer
    */
   private int valuesBuffered;
-  private ByteArrayInputStream in;
+  private ByteBufferInputStream in;
   private int nextOffset;
   private DeltaBinaryPackingConfig config;
   private int[] bitWidths;
@@ -61,8 +63,8 @@ public class DeltaBinaryPackingValuesReader extends ValuesReader {
    * @throws IOException
    */
   @Override
-  public void initFromPage(int valueCount, byte[] page, int offset) throws IOException {
-    in = new ByteArrayInputStream(page, offset, page.length - offset);
+  public void initFromPage(int valueCount, ByteBuffer page, int offset) throws IOException {
+    in = new ByteBufferInputStream(page.duplicate(), offset, page.limit() - offset);
     this.config = DeltaBinaryPackingConfig.readConfig(in);
     this.page = page;
     this.totalValueCount = BytesUtils.readUnsignedVarInt(in);
@@ -75,7 +77,12 @@ public class DeltaBinaryPackingValuesReader extends ValuesReader {
     while (valuesBuffered < totalValueCount) { //values Buffered could be more than totalValueCount, since we flush on a mini block basis
       loadNewBlockToBuffer();
     }
-    this.nextOffset = page.length - in.available();
+    this.nextOffset = page.limit() - in.available();
+  }
+  
+  @Override
+  public void initFromPage(int valueCount, byte[] page, int offset) throws IOException{
+    this.initFromPage(valueCount, ByteBuffer.wrap(page), offset);
   }
   
   @Override
@@ -148,7 +155,7 @@ public class DeltaBinaryPackingValuesReader extends ValuesReader {
 
   private void unpack8Values(BytePacker packer) {
     //calculate the pos because the packer api uses array not stream
-    int pos = page.length - in.available();
+    int pos = page.limit() - in.available();
     packer.unpack8Values(page, pos, valuesBuffer, valuesBuffered);
     this.valuesBuffered += 8;
     //sync the pos in stream

--- a/parquet-column/src/main/java/parquet/column/values/delta/DeltaBinaryPackingValuesWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/delta/DeltaBinaryPackingValuesWriter.java
@@ -15,6 +15,7 @@
  */
 package parquet.column.values.delta;
 
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
 import parquet.bytes.BytesUtils;
 import parquet.bytes.CapacityByteArrayOutputStream;
@@ -100,6 +101,8 @@ public class DeltaBinaryPackingValuesWriter extends ValuesWriter {
    */
   private int previousValue = 0;
 
+  private ByteBufferAllocator allocator;
+
   /**
    * min delta is written to the beginning of each block.
    * it's zig-zag encoded. The deltas stored in each block is actually the difference to min delta,
@@ -108,16 +111,17 @@ public class DeltaBinaryPackingValuesWriter extends ValuesWriter {
    */
   private int minDeltaInCurrentBlock = Integer.MAX_VALUE;
   
-  public DeltaBinaryPackingValuesWriter(int slabSize) {
-    this(DEFAULT_NUM_BLOCK_VALUES, DEFAULT_NUM_MINIBLOCKS, slabSize);
+  public DeltaBinaryPackingValuesWriter(int slabSize, ByteBufferAllocator allocator) {
+    this(DEFAULT_NUM_BLOCK_VALUES, DEFAULT_NUM_MINIBLOCKS, slabSize, allocator);
   }
 
-  public DeltaBinaryPackingValuesWriter(int blockSizeInValues, int miniBlockNum, int slabSize) {
+  public DeltaBinaryPackingValuesWriter(int blockSizeInValues, int miniBlockNum, int slabSize, ByteBufferAllocator allocator) {
     this.config = new DeltaBinaryPackingConfig(blockSizeInValues, miniBlockNum);
     bitWidths = new int[config.miniBlockNumInABlock];
     deltaBlockBuffer = new int[blockSizeInValues];
     miniBlockByteBuffer = new byte[config.miniBlockSizeInValues * MAX_BITWIDTH];
-    baos = new CapacityByteArrayOutputStream(slabSize);
+    this.allocator=allocator;
+    baos = new CapacityByteArrayOutputStream(slabSize, this.allocator);
   }
 
   @Override
@@ -250,6 +254,14 @@ public class DeltaBinaryPackingValuesWriter extends ValuesWriter {
   public void reset() {
     this.totalValueCount = 0;
     this.baos.reset();
+    this.deltaValuesToFlush = 0;
+    this.minDeltaInCurrentBlock = Integer.MAX_VALUE;
+  }
+
+  @Override
+  public void close() {
+    this.totalValueCount = 0;
+    this.baos.close();
     this.deltaValuesToFlush = 0;
     this.minDeltaInCurrentBlock = Integer.MAX_VALUE;
   }

--- a/parquet-column/src/main/java/parquet/column/values/deltalengthbytearray/DeltaLengthByteArrayValuesReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/deltalengthbytearray/DeltaLengthByteArrayValuesReader.java
@@ -18,6 +18,7 @@ package parquet.column.values.deltalengthbytearray;
 import static parquet.Log.DEBUG;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.Log;
 import parquet.column.values.ValuesReader;
@@ -34,7 +35,7 @@ public class DeltaLengthByteArrayValuesReader extends ValuesReader {
 
   private static final Log LOG = Log.getLog(DeltaLengthByteArrayValuesReader.class);
   private ValuesReader lengthReader;
-  private byte[] in;
+  private ByteBuffer in;
   private int offset;
 
   public DeltaLengthByteArrayValuesReader() {
@@ -42,9 +43,9 @@ public class DeltaLengthByteArrayValuesReader extends ValuesReader {
   }
 
   @Override
-  public void initFromPage(int valueCount, byte[] in, int offset)
+  public void initFromPage(int valueCount, ByteBuffer in, int offset)
       throws IOException {
-    if (DEBUG) LOG.debug("init from page at offset "+ offset + " for length " + (in.length - offset));
+    if (DEBUG) LOG.debug("init from page at offset "+ offset + " for length " + (in.limit() - offset));
     lengthReader.initFromPage(valueCount, in, offset);
     offset = lengthReader.getNextOffset();
     this.in = in;
@@ -52,11 +53,16 @@ public class DeltaLengthByteArrayValuesReader extends ValuesReader {
   }
 
   @Override
+  public void initFromPage(int valueCount, byte[] page, int offset) throws IOException{
+    this.initFromPage(valueCount, ByteBuffer.wrap(page), offset);
+  }
+  
+  @Override
   public Binary readBytes() {
     int length = lengthReader.readInteger();
     int start = offset;
     offset = start + length;
-    return Binary.fromByteArray(in, start, length);
+    return Binary.fromByteBuffer(in, start, length);
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/deltalengthbytearray/DeltaLengthByteArrayValuesWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/deltalengthbytearray/DeltaLengthByteArrayValuesWriter.java
@@ -18,6 +18,7 @@ package parquet.column.values.deltalengthbytearray;
 import java.io.IOException;
 
 import parquet.Log;
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
 import parquet.bytes.CapacityByteArrayOutputStream;
 import parquet.bytes.LittleEndianDataOutputStream;
@@ -44,14 +45,16 @@ public class DeltaLengthByteArrayValuesWriter extends ValuesWriter {
   private ValuesWriter lengthWriter;
   private CapacityByteArrayOutputStream arrayOut;
   private LittleEndianDataOutputStream out;
+  private ByteBufferAllocator allocator;
 
-  public DeltaLengthByteArrayValuesWriter(int initialSize) {
-    arrayOut = new CapacityByteArrayOutputStream(initialSize);
+  public DeltaLengthByteArrayValuesWriter(int initialSize, ByteBufferAllocator allocator) {
+    arrayOut = new CapacityByteArrayOutputStream(initialSize, allocator);
     out = new LittleEndianDataOutputStream(arrayOut);
+    this.allocator=allocator;
     lengthWriter = new DeltaBinaryPackingValuesWriter(
         DeltaBinaryPackingValuesWriter.DEFAULT_NUM_BLOCK_VALUES,
         DeltaBinaryPackingValuesWriter.DEFAULT_NUM_MINIBLOCKS,
-        initialSize);
+        initialSize, this.allocator);
   }
 
   @Override
@@ -89,6 +92,12 @@ public class DeltaLengthByteArrayValuesWriter extends ValuesWriter {
   public void reset() {
     lengthWriter.reset();
     arrayOut.reset();
+  }
+
+  @Override
+  public void close() {
+    lengthWriter.close();
+    arrayOut.close();
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/deltastrings/DeltaByteArrayReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/deltastrings/DeltaByteArrayReader.java
@@ -16,6 +16,7 @@
 package parquet.column.values.deltastrings;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.column.values.ValuesReader;
 import parquet.column.values.delta.DeltaBinaryPackingValuesReader;
@@ -41,11 +42,16 @@ public class DeltaByteArrayReader extends ValuesReader {
   }
 
   @Override
-  public void initFromPage(int valueCount, byte[] page, int offset)
+  public void initFromPage(int valueCount, ByteBuffer page, int offset)
       throws IOException {
     prefixLengthReader.initFromPage(valueCount, page, offset);
     int next = prefixLengthReader.getNextOffset();
     suffixReader.initFromPage(valueCount, page, next);	
+  }
+  
+  @Override
+  public void initFromPage(int valueCount, byte[] page, int offset) throws IOException{
+    this.initFromPage(valueCount, ByteBuffer.wrap(page), offset);
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/dictionary/PlainValuesDictionary.java
+++ b/parquet-column/src/main/java/parquet/column/values/dictionary/PlainValuesDictionary.java
@@ -19,6 +19,7 @@ import static parquet.bytes.BytesUtils.readIntLittleEndian;
 import static parquet.column.Encoding.PLAIN_DICTIONARY;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.Preconditions;
 import parquet.column.Dictionary;
@@ -81,17 +82,18 @@ public abstract class PlainValuesDictionary extends Dictionary {
      */
     public PlainBinaryDictionary(DictionaryPage dictionaryPage, Integer length) throws IOException {
       super(dictionaryPage);
-      final byte[] dictionaryBytes = dictionaryPage.getBytes().toByteArray();
+      final ByteBuffer dictionaryBytes = dictionaryPage.getBytes().toByteBuffer();
       binaryDictionaryContent = new Binary[dictionaryPage.getDictionarySize()];
-      int offset = 0;
+      int offset = dictionaryBytes.position();
       if (length == null) {
         // dictionary values are stored in order: size (4 bytes LE) followed by {size} bytes
+        
         for (int i = 0; i < binaryDictionaryContent.length; i++) {
           int len = readIntLittleEndian(dictionaryBytes, offset);
           // read the length
           offset += 4;
           // wrap the content in a binary
-          binaryDictionaryContent[i] = Binary.fromByteArray(dictionaryBytes, offset, len);
+          binaryDictionaryContent[i] = Binary.fromByteBuffer(dictionaryBytes, offset, len);
           // increment to the next value
           offset += len;
         }
@@ -101,14 +103,14 @@ public abstract class PlainValuesDictionary extends Dictionary {
             "Invalid byte array length: " + length);
         for (int i = 0; i < binaryDictionaryContent.length; i++) {
           // wrap the content in a Binary
-          binaryDictionaryContent[i] = Binary.fromByteArray(
+          binaryDictionaryContent[i] = Binary.fromByteBuffer(
               dictionaryBytes, offset, length);
           // increment to the next value
           offset += length;
         }
       }
     }
-
+    
     @Override
     public Binary decodeToBinary(int id) {
       return binaryDictionaryContent[id];
@@ -143,10 +145,10 @@ public abstract class PlainValuesDictionary extends Dictionary {
      */
     public PlainLongDictionary(DictionaryPage dictionaryPage) throws IOException {
       super(dictionaryPage);
-      final byte[] dictionaryBytes = dictionaryPage.getBytes().toByteArray();
+      final ByteBuffer dictionaryByteBuf = dictionaryPage.getBytes().toByteBuffer();
       longDictionaryContent = new long[dictionaryPage.getDictionarySize()];
       LongPlainValuesReader longReader = new LongPlainValuesReader();
-      longReader.initFromPage(dictionaryPage.getDictionarySize(), dictionaryBytes, 0);
+      longReader.initFromPage(dictionaryPage.getDictionarySize(), dictionaryByteBuf, dictionaryByteBuf.position());
       for (int i = 0; i < longDictionaryContent.length; i++) {
         longDictionaryContent[i] = longReader.readLong();
       }
@@ -186,10 +188,10 @@ public abstract class PlainValuesDictionary extends Dictionary {
      */
     public PlainDoubleDictionary(DictionaryPage dictionaryPage) throws IOException {
       super(dictionaryPage);
-      final byte[] dictionaryBytes = dictionaryPage.getBytes().toByteArray();
+      final ByteBuffer dictionaryByteBuf = dictionaryPage.getBytes().toByteBuffer();
       doubleDictionaryContent = new double[dictionaryPage.getDictionarySize()];
       DoublePlainValuesReader doubleReader = new DoublePlainValuesReader();
-      doubleReader.initFromPage(dictionaryPage.getDictionarySize(), dictionaryBytes, 0);
+      doubleReader.initFromPage(dictionaryPage.getDictionarySize(), dictionaryByteBuf, dictionaryByteBuf.position());
       for (int i = 0; i < doubleDictionaryContent.length; i++) {
         doubleDictionaryContent[i] = doubleReader.readDouble();
       }
@@ -229,10 +231,10 @@ public abstract class PlainValuesDictionary extends Dictionary {
      */
     public PlainIntegerDictionary(DictionaryPage dictionaryPage) throws IOException {
       super(dictionaryPage);
-      final byte[] dictionaryBytes = dictionaryPage.getBytes().toByteArray();
+      final ByteBuffer dictionaryByteBuf = dictionaryPage.getBytes().toByteBuffer();
       intDictionaryContent = new int[dictionaryPage.getDictionarySize()];
       IntegerPlainValuesReader intReader = new IntegerPlainValuesReader();
-      intReader.initFromPage(dictionaryPage.getDictionarySize(), dictionaryBytes, 0);
+      intReader.initFromPage(dictionaryPage.getDictionarySize(), dictionaryByteBuf, dictionaryByteBuf.position());
       for (int i = 0; i < intDictionaryContent.length; i++) {
         intDictionaryContent[i] = intReader.readInteger();
       }
@@ -272,10 +274,10 @@ public abstract class PlainValuesDictionary extends Dictionary {
      */
     public PlainFloatDictionary(DictionaryPage dictionaryPage) throws IOException {
       super(dictionaryPage);
-      final byte[] dictionaryBytes = dictionaryPage.getBytes().toByteArray();
+      final ByteBuffer dictionaryByteBuf = dictionaryPage.getBytes().toByteBuffer();
       floatDictionaryContent = new float[dictionaryPage.getDictionarySize()];
       FloatPlainValuesReader floatReader = new FloatPlainValuesReader();
-      floatReader.initFromPage(dictionaryPage.getDictionarySize(), dictionaryBytes, 0);
+      floatReader.initFromPage(dictionaryPage.getDictionarySize(), dictionaryByteBuf, dictionaryByteBuf.position());
       for (int i = 0; i < floatDictionaryContent.length; i++) {
         floatDictionaryContent[i] = floatReader.readFloat();
       }

--- a/parquet-column/src/main/java/parquet/column/values/plain/BinaryPlainValuesReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/plain/BinaryPlainValuesReader.java
@@ -18,6 +18,7 @@ package parquet.column.values.plain;
 import static parquet.Log.DEBUG;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.Log;
 import parquet.bytes.BytesUtils;
@@ -27,7 +28,7 @@ import parquet.io.api.Binary;
 
 public class BinaryPlainValuesReader extends ValuesReader {
   private static final Log LOG = Log.getLog(BinaryPlainValuesReader.class);
-  private byte[] in;
+  private ByteBuffer in;
   private int offset;
 
   @Override
@@ -36,7 +37,7 @@ public class BinaryPlainValuesReader extends ValuesReader {
       int length = BytesUtils.readIntLittleEndian(in, offset);
       int start = offset + 4;
       offset = start + length;
-      return Binary.fromByteArray(in, start, length);
+      return Binary.fromByteBuffer(in, start, length);
     } catch (IOException e) {
       throw new ParquetDecodingException("could not read bytes at offset " + offset, e);
     } catch (RuntimeException e) {
@@ -57,11 +58,15 @@ public class BinaryPlainValuesReader extends ValuesReader {
   }
 
   @Override
-  public void initFromPage(int valueCount, byte[] in, int offset)
+  public void initFromPage(int valueCount, ByteBuffer in, int offset)
       throws IOException {
-    if (DEBUG) LOG.debug("init from page at offset "+ offset + " for length " + (in.length - offset));
+    if (DEBUG) LOG.debug("init from page at offset "+ offset + " for length " + (in.limit() - offset));
     this.in = in;
     this.offset = offset;
   }
 
+  @Override
+  public void initFromPage(int valueCount, byte[] page, int offset) throws IOException{
+    this.initFromPage(valueCount, ByteBuffer.wrap(page), offset);
+  }
 }

--- a/parquet-column/src/main/java/parquet/column/values/plain/BooleanPlainValuesReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/plain/BooleanPlainValuesReader.java
@@ -19,6 +19,7 @@ import static parquet.Log.DEBUG;
 import static parquet.column.values.bitpacking.Packer.LITTLE_ENDIAN;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.Log;
 import parquet.column.values.ValuesReader;
@@ -59,9 +60,14 @@ public class BooleanPlainValuesReader extends ValuesReader {
    * @see parquet.column.values.ValuesReader#initFromPage(byte[], int)
    */
   @Override
-  public void initFromPage(int valueCount, byte[] in, int offset) throws IOException {
-    if (DEBUG) LOG.debug("init from page at offset "+ offset + " for length " + (in.length - offset));
+  public void initFromPage(int valueCount, ByteBuffer in, int offset) throws IOException {
+    if (DEBUG) LOG.debug("init from page at offset "+ offset + " for length " + (in.limit() - offset));
     this.in.initFromPage(valueCount, in, offset);
+  }
+  
+  @Override
+  public void initFromPage(int valueCount, byte[] page, int offset) throws IOException{
+    this.initFromPage(valueCount, ByteBuffer.wrap(page), offset);
   }
   
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/plain/BooleanPlainValuesWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/plain/BooleanPlainValuesWriter.java
@@ -17,6 +17,8 @@ package parquet.column.values.plain;
 
 import static parquet.column.Encoding.PLAIN;
 import static parquet.column.values.bitpacking.Packer.LITTLE_ENDIAN;
+
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
 import parquet.column.Encoding;
 import parquet.column.values.ValuesWriter;
@@ -32,9 +34,11 @@ import parquet.column.values.bitpacking.ByteBitPackingValuesWriter;
 public class BooleanPlainValuesWriter extends ValuesWriter {
 
   private ByteBitPackingValuesWriter bitPackingWriter;
+  private ByteBufferAllocator allocator;
 
-  public BooleanPlainValuesWriter() {
-    bitPackingWriter = new ByteBitPackingValuesWriter(1, LITTLE_ENDIAN);
+  public BooleanPlainValuesWriter(ByteBufferAllocator allocator) {
+    this.allocator=allocator;
+    bitPackingWriter = new ByteBitPackingValuesWriter(1, LITTLE_ENDIAN, this.allocator);
   }
 
   @Override
@@ -55,6 +59,11 @@ public class BooleanPlainValuesWriter extends ValuesWriter {
   @Override
   public void reset() {
     bitPackingWriter.reset();
+  }
+
+  @Override
+  public void close() {
+    bitPackingWriter.close();
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/plain/FixedLenByteArrayPlainValuesReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/plain/FixedLenByteArrayPlainValuesReader.java
@@ -16,6 +16,7 @@
 package parquet.column.values.plain;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import parquet.Log;
 import parquet.column.values.ValuesReader;
 import parquet.io.ParquetDecodingException;
@@ -30,7 +31,7 @@ import static parquet.Log.DEBUG;
  */
 public class FixedLenByteArrayPlainValuesReader extends ValuesReader {
   private static final Log LOG = Log.getLog(FixedLenByteArrayPlainValuesReader.class);
-  private byte[] in;
+  private ByteBuffer in;
   private int offset;
   private int length;
 
@@ -43,7 +44,7 @@ public class FixedLenByteArrayPlainValuesReader extends ValuesReader {
     try {
       int start = offset;
       offset = start + length;
-      return Binary.fromByteArray(in, start, length);
+      return Binary.fromByteBuffer(in, start, length);
     } catch (RuntimeException e) {
       throw new ParquetDecodingException("could not read bytes at offset " + offset, e);
     }
@@ -55,10 +56,15 @@ public class FixedLenByteArrayPlainValuesReader extends ValuesReader {
   }
 
   @Override
-  public void initFromPage(int valueCount, byte[] in, int offset)
+  public void initFromPage(int valueCount, ByteBuffer in, int offset)
       throws IOException {
-    if (DEBUG) LOG.debug("init from page at offset "+ offset + " for length " + (in.length - offset));
+    if (DEBUG) LOG.debug("init from page at offset "+ offset + " for length " + (in.limit() - offset));
     this.in = in;
     this.offset = offset;
+  }
+  
+  @Override
+  public void initFromPage(int valueCount, byte[] page, int offset) throws IOException{
+    this.initFromPage(valueCount, ByteBuffer.wrap(page), offset);
   }
 }

--- a/parquet-column/src/main/java/parquet/column/values/plain/FixedLenByteArrayPlainValuesWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/plain/FixedLenByteArrayPlainValuesWriter.java
@@ -18,6 +18,7 @@ package parquet.column.values.plain;
 import java.io.IOException;
 
 import parquet.Log;
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
 import parquet.bytes.CapacityByteArrayOutputStream;
 import parquet.bytes.LittleEndianDataOutputStream;
@@ -37,10 +38,12 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
   private CapacityByteArrayOutputStream arrayOut;
   private LittleEndianDataOutputStream out;
   private int length;
+  private ByteBufferAllocator allocator;
   
-  public FixedLenByteArrayPlainValuesWriter(int length, int initialSize) {
+  public FixedLenByteArrayPlainValuesWriter(int length, int initialSize, ByteBufferAllocator allocator) {
     this.length = length;
-    this.arrayOut = new CapacityByteArrayOutputStream(initialSize);
+    this.allocator=allocator;
+    this.arrayOut = new CapacityByteArrayOutputStream(initialSize, this.allocator);
     this.out = new LittleEndianDataOutputStream(arrayOut);
   }
 
@@ -76,6 +79,11 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
   @Override
   public void reset() {
     arrayOut.reset();
+  }
+
+  @Override
+  public void close() {
+    arrayOut.close();
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/plain/PlainValuesReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/plain/PlainValuesReader.java
@@ -17,11 +17,12 @@ package parquet.column.values.plain;
 
 import static parquet.Log.DEBUG;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.Log;
 import parquet.bytes.LittleEndianDataInputStream;
+import parquet.bytes.ByteBufferInputStream;
 import parquet.column.values.ValuesReader;
 import parquet.io.ParquetDecodingException;
 
@@ -41,9 +42,14 @@ abstract public class PlainValuesReader extends ValuesReader {
    * @see parquet.column.values.ValuesReader#initFromPage(byte[], int)
    */
   @Override
-  public void initFromPage(int valueCount, byte[] in, int offset) throws IOException {
-    if (DEBUG) LOG.debug("init from page at offset "+ offset + " for length " + (in.length - offset));
-    this.in = new LittleEndianDataInputStream(new ByteArrayInputStream(in, offset, in.length - offset));
+  public void initFromPage(int valueCount, ByteBuffer in, int offset) throws IOException {
+    if (DEBUG) LOG.debug("init from page at offset "+ offset + " for length " + (in.limit() - offset));
+    this.in = new LittleEndianDataInputStream(new ByteBufferInputStream(in.duplicate(), offset, in.limit() - offset));
+  }
+  
+  @Override
+  public void initFromPage(int valueCount, byte[] page, int offset) throws IOException{
+    this.initFromPage(valueCount, ByteBuffer.wrap(page), offset);
   }
 
   public static class DoublePlainValuesReader extends PlainValuesReader {

--- a/parquet-column/src/main/java/parquet/column/values/plain/PlainValuesWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/plain/PlainValuesWriter.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 
 import parquet.Log;
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
 import parquet.bytes.CapacityByteArrayOutputStream;
 import parquet.bytes.LittleEndianDataOutputStream;
@@ -40,9 +41,11 @@ public class PlainValuesWriter extends ValuesWriter {
 
   private CapacityByteArrayOutputStream arrayOut;
   private LittleEndianDataOutputStream out;
+  private ByteBufferAllocator allocator;
 
-  public PlainValuesWriter(int initialSize) {
-    arrayOut = new CapacityByteArrayOutputStream(initialSize);
+  public PlainValuesWriter(int initialSize, ByteBufferAllocator allocator) {
+    this.allocator=allocator;
+    arrayOut = new CapacityByteArrayOutputStream(initialSize, this.allocator);
     out = new LittleEndianDataOutputStream(arrayOut);
   }
 
@@ -120,6 +123,11 @@ public class PlainValuesWriter extends ValuesWriter {
   @Override
   public void reset() {
     arrayOut.reset();
+  }
+
+  @Override
+  public void close() {
+    arrayOut.close();
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/rle/RunLengthBitPackingHybridValuesReader.java
+++ b/parquet-column/src/main/java/parquet/column/values/rle/RunLengthBitPackingHybridValuesReader.java
@@ -15,9 +15,10 @@
  */
 package parquet.column.values.rle;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
+import parquet.bytes.ByteBufferInputStream;
 import parquet.bytes.BytesUtils;
 import parquet.column.values.ValuesReader;
 import parquet.io.ParquetDecodingException;
@@ -38,14 +39,19 @@ public class RunLengthBitPackingHybridValuesReader extends ValuesReader {
   }
 
   @Override
-  public void initFromPage(int valueCountL, byte[] page, int offset) throws IOException {
-    ByteArrayInputStream in = new ByteArrayInputStream(page, offset, page.length - offset);
+  public void initFromPage(int valueCountL, ByteBuffer page, int offset) throws IOException {
+    ByteBufferInputStream in = new ByteBufferInputStream(page.duplicate(), offset, page.limit() - offset);
     int length = BytesUtils.readIntLittleEndian(in);
 
     decoder = new RunLengthBitPackingHybridDecoder(bitWidth, in);
 
     // 4 is for the length which is stored as 4 bytes little endian
     this.nextOffset = offset + length + 4;
+  }
+  
+  @Override
+  public void initFromPage(int valueCount, byte[] page, int offset) throws IOException{
+    this.initFromPage(valueCount, ByteBuffer.wrap(page), offset);
   }
   
   @Override

--- a/parquet-column/src/main/java/parquet/column/values/rle/RunLengthBitPackingHybridValuesWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/rle/RunLengthBitPackingHybridValuesWriter.java
@@ -17,8 +17,10 @@ package parquet.column.values.rle;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.Ints;
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
 import parquet.bytes.BytesUtils;
 import parquet.column.Encoding;
@@ -31,9 +33,11 @@ import parquet.io.ParquetEncodingException;
 public class RunLengthBitPackingHybridValuesWriter extends ValuesWriter {
   private final RunLengthBitPackingHybridEncoder encoder;
   private final ByteArrayOutputStream length;
+  private ByteBufferAllocator allocator;
 
-  public RunLengthBitPackingHybridValuesWriter(int bitWidth, int initialCapacity) {
-    this.encoder = new RunLengthBitPackingHybridEncoder(bitWidth, initialCapacity);
+  public RunLengthBitPackingHybridValuesWriter(int bitWidth, int initialCapacity, ByteBufferAllocator allocator) {
+    this.allocator=allocator;
+    this.encoder = new RunLengthBitPackingHybridEncoder(bitWidth, initialCapacity, this.allocator);
     this.length = new ByteArrayOutputStream(4);
   }
 
@@ -82,6 +86,16 @@ public class RunLengthBitPackingHybridValuesWriter extends ValuesWriter {
   public void reset() {
     encoder.reset();
     length.reset();
+  }
+
+  @Override
+  public void close() {
+    encoder.close();
+    try {
+      length.close();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/parquet/io/api/Binary.java
@@ -342,6 +342,91 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
   public static Binary fromByteBuffer(final ByteBuffer value) {
     return new ByteBufferBackedBinary(value);
   }
+  
+  public static Binary fromByteBuffer(
+      final ByteBuffer value,
+      final int offset,
+      final int length) {
+    return new Binary() {
+      @Override
+      public String toStringUsingUTF8() {
+        return new String(getBytes(), BytesUtils.UTF8);
+      }
+
+      @Override
+      public int length() {
+        return length;
+      }
+
+      @Override
+      public void writeTo(OutputStream out) throws IOException {
+        out.write(getBytes());
+      }
+
+      @Override
+      public byte[] getBytes() {
+        byte[] bytes = new byte[length];
+        
+        value.mark();
+        value.position(offset);
+        value.get(bytes).reset();
+        
+        return bytes;
+      }
+
+      @Override
+      public int hashCode() {
+        byte[] bytes = getBytes();
+        return Binary.hashCode(bytes, 0, bytes.length);
+      }
+
+      @Override
+      boolean equals(Binary other) {
+        if (toByteBuffer().compareTo(other.toByteBuffer()) == 0) {
+          return true;
+        }
+        return false;
+      }
+
+      @Override
+      boolean equals(byte[] other, int otherOffset, int otherLength) {
+         if (toByteBuffer().compareTo(ByteBuffer.wrap(other, otherOffset, otherLength)) == 0) {
+           return true;
+         }
+         return false;
+      }
+
+      @Override
+      public int compareTo(Binary other) {
+        byte[] bytes = getBytes();
+        return other.compareTo(bytes, 0, bytes.length);
+      }
+
+      @Override
+      int compareTo(byte[] other, int otherOffset, int otherLength) {
+        byte[] bytes = getBytes();
+        return Binary.compareTwoByteArrays(bytes, 0, bytes.length, other, otherOffset, otherLength);
+      }
+
+      @Override
+      public ByteBuffer toByteBuffer() {
+        ByteBuffer buf;
+        value.mark();
+        value.position(offset);
+        buf = value.slice();
+        buf.limit(length);
+        value.reset();
+        return buf;
+      }
+
+      @Override
+      public void writeTo(DataOutput out) throws IOException {
+        for (int i = offset; i < offset + length; i++) {
+          out.write(value.get(i));
+        }
+      }
+    };
+  }
 
   public static Binary fromString(final String value) {
     try {

--- a/parquet-column/src/test/java/parquet/column/page/mem/MemPageStore.java
+++ b/parquet-column/src/test/java/parquet/column/page/mem/MemPageStore.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import parquet.Log;
+import parquet.bytes.ByteBufferAllocator;
 import parquet.column.ColumnDescriptor;
 import parquet.column.UnknownColumnException;
 import parquet.column.page.Page;

--- a/parquet-column/src/test/java/parquet/column/page/mem/MemPageWriter.java
+++ b/parquet-column/src/test/java/parquet/column/page/mem/MemPageWriter.java
@@ -22,7 +22,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import parquet.Log;
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
+import parquet.bytes.HeapByteBufferAllocator;
 import parquet.column.Encoding;
 import parquet.column.page.DictionaryPage;
 import parquet.column.page.Page;
@@ -38,6 +40,7 @@ public class MemPageWriter implements PageWriter {
   private DictionaryPage dictionaryPage;
   private long memSize = 0;
   private long totalValueCount = 0;
+  private ByteBufferAllocator allocator;
 
   @Deprecated
   @Override
@@ -102,5 +105,21 @@ public class MemPageWriter implements PageWriter {
     return String.format("%s %,d bytes", prefix, memSize);
 
   }
+
+  @Override
+  public ByteBufferAllocator getAllocator() {
+    if(this.allocator==null)
+      this.allocator=new HeapByteBufferAllocator();
+    return this.allocator;
+  }
+
+  @Override
+  public void reset() {
+  }
+
+  @Override
+  public void close() {
+  }
+
 
 }

--- a/parquet-column/src/test/java/parquet/column/values/Utils.java
+++ b/parquet-column/src/test/java/parquet/column/values/Utils.java
@@ -16,6 +16,7 @@
 package parquet.column.values;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Random;
 
 import parquet.io.api.Binary;
@@ -58,7 +59,7 @@ public class Utils {
   public static Binary[] readData(ValuesReader reader, byte[] data, int offset, int length)
       throws IOException {
     Binary[] bins = new Binary[length];
-    reader.initFromPage(length, data, 0);
+    reader.initFromPage(length, ByteBuffer.wrap(data), 0);
     for(int i=0; i < length; i++) {
       bins[i] = reader.readBytes();
     }
@@ -73,7 +74,7 @@ public class Utils {
   public static int[] readInts(ValuesReader reader, byte[] data, int offset, int length)
       throws IOException {
     int[] ints = new int[length];
-    reader.initFromPage(length, data, offset);
+    reader.initFromPage(length, ByteBuffer.wrap(data), offset);
     for(int i=0; i < length; i++) {
       ints[i] = reader.readInteger();
     }

--- a/parquet-column/src/test/java/parquet/column/values/bitpacking/BitPackingPerfTest.java
+++ b/parquet-column/src/test/java/parquet/column/values/bitpacking/BitPackingPerfTest.java
@@ -17,6 +17,7 @@ package parquet.column.values.bitpacking;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import parquet.column.values.ValuesReader;
 import parquet.column.values.bitpacking.BitPacking.BitPackingWriter;
@@ -84,7 +85,7 @@ public class BitPackingPerfTest {
     System.out.print(" no gc <");
     for (int k = 0; k < N; k++) {
       long t2 = System.nanoTime();
-      r.initFromPage(result.length, bytes, 0);
+      r.initFromPage(result.length, ByteBuffer.wrap(bytes), 0);
       for (int i = 0; i < result.length; i++) {
         result[i] = r.readInteger();
       }

--- a/parquet-column/src/test/java/parquet/column/values/bitpacking/TestBitPackingColumn.java
+++ b/parquet-column/src/test/java/parquet/column/values/bitpacking/TestBitPackingColumn.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import org.junit.Test;
 
 import parquet.Log;
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.values.ValuesReader;
 import parquet.column.values.ValuesWriter;
 
@@ -186,7 +187,7 @@ public class TestBitPackingColumn {
         return new BitPackingValuesReader(bound);
       }
       public ValuesWriter getWriter(final int bound) {
-        return new BitPackingValuesWriter(bound, 32*1024);
+        return new BitPackingValuesWriter(bound, 32*1024, new DirectByteBufferAllocator());
       }
     }
     ,
@@ -195,7 +196,7 @@ public class TestBitPackingColumn {
         return new ByteBitPackingValuesReader(bound, BIG_ENDIAN);
       }
       public ValuesWriter getWriter(final int bound) {
-        return new ByteBitPackingValuesWriter(bound, BIG_ENDIAN);
+        return new ByteBitPackingValuesWriter(bound, BIG_ENDIAN, new DirectByteBufferAllocator());
       }
     }
     ;

--- a/parquet-column/src/test/java/parquet/column/values/bitpacking/TestBitPackingColumn.java
+++ b/parquet-column/src/test/java/parquet/column/values/bitpacking/TestBitPackingColumn.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static parquet.column.values.bitpacking.Packer.BIG_ENDIAN;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.junit.Test;
 
@@ -169,7 +170,7 @@ public class TestBitPackingColumn {
       LOG.debug("bytes: " + TestBitPacking.toString(bytes));
       assertEquals(type.toString(), expected, TestBitPacking.toString(bytes));
       ValuesReader r = type.getReader(bound);
-      r.initFromPage(vals.length, bytes, 0);
+      r.initFromPage(vals.length, ByteBuffer.wrap(bytes), 0);
       int[] result = new int[vals.length];
       for (int i = 0; i < result.length; i++) {
         result[i] = r.readInteger();

--- a/parquet-column/src/test/java/parquet/column/values/boundedint/TestBoundedColumns.java
+++ b/parquet-column/src/test/java/parquet/column/values/boundedint/TestBoundedColumns.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -63,7 +64,7 @@ public class TestBoundedColumns {
     byte[] byteArray = bicw.getBytes().toByteArray();
     assertEquals(concat(result), toBinaryString(byteArray, 4));
     BoundedIntValuesReader bicr = new BoundedIntValuesReader(bound);
-    bicr.initFromPage(1, byteArray, 0);
+    bicr.initFromPage(1, ByteBuffer.wrap(byteArray), 0);
     String expected = "";
     String got = "";
     for (int i : ints) {
@@ -155,7 +156,7 @@ public class TestBoundedColumns {
       idx = 0;
       int offset = 0;
       for (int stripeNum = 0; stripeNum < valuesPerStripe.length; stripeNum++) {
-        bicr.initFromPage(1, input, offset);
+        bicr.initFromPage(1, ByteBuffer.wrap(input), offset);
         offset = bicr.getNextOffset();
         for (int i = 0; i < valuesPerStripe[stripeNum]; i++) {
           int number = stream[idx++];

--- a/parquet-column/src/test/java/parquet/column/values/boundedint/TestBoundedColumns.java
+++ b/parquet-column/src/test/java/parquet/column/values/boundedint/TestBoundedColumns.java
@@ -26,6 +26,7 @@ import java.util.Random;
 
 import org.junit.Test;
 
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.values.boundedint.BoundedIntValuesReader;
 import parquet.column.values.boundedint.BoundedIntValuesWriter;
 
@@ -55,7 +56,7 @@ public class TestBoundedColumns {
   }
 
   private void compareOutput(int bound, int[] ints, String[] result) throws IOException {
-    BoundedIntValuesWriter bicw = new BoundedIntValuesWriter(bound, 64*1024);
+    BoundedIntValuesWriter bicw = new BoundedIntValuesWriter(bound, 64*1024, new DirectByteBufferAllocator());
     for (int i : ints) {
       bicw.writeInteger(i);
     }
@@ -124,7 +125,7 @@ public class TestBoundedColumns {
       ByteArrayOutputStream tmp = new ByteArrayOutputStream();
 
       int[] stream = new int[totalValuesInStream];
-      BoundedIntValuesWriter bicw = new BoundedIntValuesWriter(bound, 64 * 1024);
+      BoundedIntValuesWriter bicw = new BoundedIntValuesWriter(bound, 64 * 1024, new DirectByteBufferAllocator());
       int idx = 0;
       for (int stripeNum = 0; stripeNum < valuesPerStripe.length; stripeNum++) {
         int next = 0;

--- a/parquet-column/src/test/java/parquet/column/values/delta/DeltaBinaryPackingValuesWriterTest.java
+++ b/parquet-column/src/test/java/parquet/column/values/delta/DeltaBinaryPackingValuesWriterTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Random;
 
 import org.junit.Before;
@@ -151,7 +152,7 @@ public class DeltaBinaryPackingValuesWriterTest {
     System.arraycopy(valueContent, 0, pageContent, contentOffsetInPage, valueContent.length);
 
     //offset should be correct
-    reader.initFromPage(100, pageContent, contentOffsetInPage);
+    reader.initFromPage(100, ByteBuffer.wrap(pageContent), contentOffsetInPage);
     int offset= reader.getNextOffset();
     assertEquals(valueContent.length + contentOffsetInPage, offset);
 
@@ -184,7 +185,7 @@ public class DeltaBinaryPackingValuesWriterTest {
     }
     writeData(data);
     reader = new DeltaBinaryPackingValuesReader();
-    reader.initFromPage(100, writer.getBytes().toByteArray(), 0);
+    reader.initFromPage(100, writer.getBytes().toByteBuffer(), 0);
     for (int i = 0; i < data.length; i++) {
       if (i % 3 == 0) {
         reader.skip();
@@ -240,7 +241,7 @@ public class DeltaBinaryPackingValuesWriterTest {
         + blockFlushed * miniBlockNum //bitWidth of mini blocks
         + (5.0 * blockFlushed);//min delta for each block
     assertTrue(estimatedSize >= page.length);
-    reader.initFromPage(100, page, 0);
+    reader.initFromPage(100, ByteBuffer.wrap(page), 0);
 
     for (int i = 0; i < length; i++) {
       assertEquals(data[i], reader.readInteger());

--- a/parquet-column/src/test/java/parquet/column/values/delta/DeltaBinaryPackingValuesWriterTest.java
+++ b/parquet-column/src/test/java/parquet/column/values/delta/DeltaBinaryPackingValuesWriterTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import parquet.bytes.BytesInput;
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.values.ValuesWriter;
 import parquet.io.ParquetDecodingException;
 
@@ -40,13 +41,13 @@ public class DeltaBinaryPackingValuesWriterTest {
   public void setUp() {
     blockSize = 128;
     miniBlockNum = 4;
-    writer = new DeltaBinaryPackingValuesWriter(blockSize, miniBlockNum, 100);
+    writer = new DeltaBinaryPackingValuesWriter(blockSize, miniBlockNum, 100, new DirectByteBufferAllocator());
     random = new Random();
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void miniBlockSizeShouldBeMultipleOf8() {
-    new DeltaBinaryPackingValuesWriter(1281, 4, 100);
+    new DeltaBinaryPackingValuesWriter(1281, 4, 100, new DirectByteBufferAllocator());
   }
 
   /* When data size is multiple of Block*/

--- a/parquet-column/src/test/java/parquet/column/values/delta/benchmark/BenchmarkIntegerOutputSize.java
+++ b/parquet-column/src/test/java/parquet/column/values/delta/benchmark/BenchmarkIntegerOutputSize.java
@@ -16,6 +16,7 @@
 package parquet.column.values.delta.benchmark;
 
 import org.junit.Test;
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
 import parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
 import java.util.Random;
@@ -74,8 +75,8 @@ public class BenchmarkIntegerOutputSize {
   }
 
   public void testRandomIntegers(IntFunc func,int bitWidth) {
-    DeltaBinaryPackingValuesWriter delta=new DeltaBinaryPackingValuesWriter(blockSize,miniBlockNum,100);
-    RunLengthBitPackingHybridValuesWriter rle= new RunLengthBitPackingHybridValuesWriter(bitWidth,100);
+    DeltaBinaryPackingValuesWriter delta=new DeltaBinaryPackingValuesWriter(blockSize,miniBlockNum,100, new DirectByteBufferAllocator());
+    RunLengthBitPackingHybridValuesWriter rle= new RunLengthBitPackingHybridValuesWriter(bitWidth,100, new DirectByteBufferAllocator());
     for (int i = 0; i < dataSize; i++) {
       int v = func.getIntValue();
       delta.writeInteger(v);

--- a/parquet-column/src/test/java/parquet/column/values/delta/benchmark/BenchmarkReadingRandomIntegers.java
+++ b/parquet-column/src/test/java/parquet/column/values/delta/benchmark/BenchmarkReadingRandomIntegers.java
@@ -22,6 +22,7 @@ import com.carrotsearch.junitbenchmarks.annotation.BenchmarkMethodChart;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.values.ValuesReader;
 import parquet.column.values.ValuesWriter;
 import parquet.column.values.delta.DeltaBinaryPackingValuesReader;
@@ -52,8 +53,8 @@ public class BenchmarkReadingRandomIntegers {
       data[i] = random.nextInt(100) - 200;
     }
 
-    ValuesWriter delta = new DeltaBinaryPackingValuesWriter(blockSize, miniBlockNum, 100);
-    ValuesWriter rle = new RunLengthBitPackingHybridValuesWriter(32, 100);
+    ValuesWriter delta = new DeltaBinaryPackingValuesWriter(blockSize, miniBlockNum, 100, new DirectByteBufferAllocator());
+    ValuesWriter rle = new RunLengthBitPackingHybridValuesWriter(32, 100, new DirectByteBufferAllocator());
 
     for (int i = 0; i < data.length; i++) {
       delta.writeInteger(data[i]);

--- a/parquet-column/src/test/java/parquet/column/values/delta/benchmark/BenchmarkReadingRandomIntegers.java
+++ b/parquet-column/src/test/java/parquet/column/values/delta/benchmark/BenchmarkReadingRandomIntegers.java
@@ -30,6 +30,7 @@ import parquet.column.values.rle.RunLengthBitPackingHybridValuesReader;
 import parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Random;
 
 @AxisRange(min = 0, max = 1)
@@ -83,7 +84,7 @@ public class BenchmarkReadingRandomIntegers {
   }
 
   private void readData(ValuesReader reader, byte[] deltaBytes) throws IOException {
-    reader.initFromPage(data.length, deltaBytes, 0);
+    reader.initFromPage(data.length, ByteBuffer.wrap(deltaBytes), 0);
     for (int i = 0; i < data.length; i++) {
       reader.readInteger();
     }

--- a/parquet-column/src/test/java/parquet/column/values/delta/benchmark/RandomWritingBenchmarkTest.java
+++ b/parquet-column/src/test/java/parquet/column/values/delta/benchmark/RandomWritingBenchmarkTest.java
@@ -22,6 +22,7 @@ import com.carrotsearch.junitbenchmarks.annotation.BenchmarkMethodChart;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.values.ValuesWriter;
 import parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
 import parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
@@ -47,21 +48,21 @@ public class RandomWritingBenchmarkTest extends BenchMarkTest{
   @BenchmarkOptions(benchmarkRounds = 10, warmupRounds = 2)
   @Test
   public void writeDeltaPackingTest(){
-    DeltaBinaryPackingValuesWriter writer = new DeltaBinaryPackingValuesWriter(blockSize, miniBlockNum, 100);
+    DeltaBinaryPackingValuesWriter writer = new DeltaBinaryPackingValuesWriter(blockSize, miniBlockNum, 100, new DirectByteBufferAllocator());
     runWriteTest(writer);
   }
 
   @BenchmarkOptions(benchmarkRounds = 10, warmupRounds = 2)
   @Test
   public void writeRLETest(){
-    ValuesWriter writer = new RunLengthBitPackingHybridValuesWriter(32,100);
+    ValuesWriter writer = new RunLengthBitPackingHybridValuesWriter(32,100, new DirectByteBufferAllocator());
     runWriteTest(writer);
   }
 
   @BenchmarkOptions(benchmarkRounds = 10, warmupRounds = 2)
   @Test
   public void writeDeltaPackingTest2(){
-    DeltaBinaryPackingValuesWriter writer = new DeltaBinaryPackingValuesWriter(blockSize, miniBlockNum, 100);
+    DeltaBinaryPackingValuesWriter writer = new DeltaBinaryPackingValuesWriter(blockSize, miniBlockNum, 100, new DirectByteBufferAllocator());
     runWriteTest(writer);
   }
 }

--- a/parquet-column/src/test/java/parquet/column/values/delta/benchmark/SmallRangeWritingBenchmarkTest.java
+++ b/parquet-column/src/test/java/parquet/column/values/delta/benchmark/SmallRangeWritingBenchmarkTest.java
@@ -20,6 +20,7 @@ import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
 import com.carrotsearch.junitbenchmarks.annotation.BenchmarkMethodChart;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.values.ValuesWriter;
 import parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
 import java.util.Random;
@@ -39,7 +40,7 @@ public class SmallRangeWritingBenchmarkTest extends RandomWritingBenchmarkTest {
   @BenchmarkOptions(benchmarkRounds = 10, warmupRounds = 2)
   @Test
   public void writeRLEWithSmallBitWidthTest(){
-    ValuesWriter writer = new RunLengthBitPackingHybridValuesWriter(2,100);
+    ValuesWriter writer = new RunLengthBitPackingHybridValuesWriter(2,100, new DirectByteBufferAllocator());
     runWriteTest(writer);
   }
 }

--- a/parquet-column/src/test/java/parquet/column/values/deltalengthbytearray/TestDeltaLengthByteArray.java
+++ b/parquet-column/src/test/java/parquet/column/values/deltalengthbytearray/TestDeltaLengthByteArray.java
@@ -16,6 +16,7 @@
 package parquet.column.values.deltalengthbytearray;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.junit.Test;
 import org.junit.Assert;
@@ -33,12 +34,12 @@ public class TestDeltaLengthByteArray {
   public void testSerialization () throws IOException {
     DeltaLengthByteArrayValuesWriter writer = new DeltaLengthByteArrayValuesWriter(64*1024);
     DeltaLengthByteArrayValuesReader reader = new DeltaLengthByteArrayValuesReader();
-
+    
     Utils.writeData(writer, values);
     Binary[] bin = Utils.readData(reader, writer.getBytes().toByteArray(), values.length);
 
     for(int i =0; i< bin.length ; i++) {
-      Assert.assertEquals(Binary.fromString(values[i]), bin[i]);
+      Assert.assertEquals(Binary.fromString(values[i]).toStringUsingUTF8(), bin[i].toStringUsingUTF8());
     }
   }
   
@@ -52,7 +53,7 @@ public class TestDeltaLengthByteArray {
     Binary[] bin = Utils.readData(reader, writer.getBytes().toByteArray(), values.length);
 
     for(int i =0; i< bin.length ; i++) {
-      Assert.assertEquals(Binary.fromString(values[i]), bin[i]);
+      Assert.assertEquals(Binary.fromString(values[i]).toStringUsingUTF8(), bin[i].toStringUsingUTF8());
     }
   }
 

--- a/parquet-column/src/test/java/parquet/column/values/deltalengthbytearray/TestDeltaLengthByteArray.java
+++ b/parquet-column/src/test/java/parquet/column/values/deltalengthbytearray/TestDeltaLengthByteArray.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import org.junit.Test;
 import org.junit.Assert;
 
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.values.Utils;
 import parquet.column.values.ValuesReader;
 import parquet.column.values.delta.DeltaBinaryPackingValuesReader;
@@ -32,7 +33,7 @@ public class TestDeltaLengthByteArray {
 
   @Test
   public void testSerialization () throws IOException {
-    DeltaLengthByteArrayValuesWriter writer = new DeltaLengthByteArrayValuesWriter(64*1024);
+    DeltaLengthByteArrayValuesWriter writer = new DeltaLengthByteArrayValuesWriter(64*1024, new DirectByteBufferAllocator());
     DeltaLengthByteArrayValuesReader reader = new DeltaLengthByteArrayValuesReader();
     
     Utils.writeData(writer, values);
@@ -45,7 +46,7 @@ public class TestDeltaLengthByteArray {
   
   @Test
   public void testRandomStrings() throws IOException {
-    DeltaLengthByteArrayValuesWriter writer = new DeltaLengthByteArrayValuesWriter(64*1024);
+    DeltaLengthByteArrayValuesWriter writer = new DeltaLengthByteArrayValuesWriter(64*1024, new DirectByteBufferAllocator());
     DeltaLengthByteArrayValuesReader reader = new DeltaLengthByteArrayValuesReader();
 
     String[] values = Utils.getRandomStringSamples(1000, 32);
@@ -59,7 +60,7 @@ public class TestDeltaLengthByteArray {
 
   @Test
   public void testLengths() throws IOException {
-    DeltaLengthByteArrayValuesWriter writer = new DeltaLengthByteArrayValuesWriter(64*1024);
+    DeltaLengthByteArrayValuesWriter writer = new DeltaLengthByteArrayValuesWriter(64*1024, new DirectByteBufferAllocator());
     ValuesReader reader = new DeltaBinaryPackingValuesReader();
 
     Utils.writeData(writer, values);

--- a/parquet-column/src/test/java/parquet/column/values/deltalengthbytearray/benchmark/BenchmarkDeltaLengthByteArray.java
+++ b/parquet-column/src/test/java/parquet/column/values/deltalengthbytearray/benchmark/BenchmarkDeltaLengthByteArray.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.values.Utils;
 import parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesReader;
 import parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
@@ -44,7 +45,7 @@ public class BenchmarkDeltaLengthByteArray {
   @BenchmarkOptions(benchmarkRounds = 20, warmupRounds = 4)
   @Test
   public void benchmarkRandomStringsWithPlainValuesWriter() throws IOException {
-    PlainValuesWriter writer = new PlainValuesWriter(64*1024);
+    PlainValuesWriter writer = new PlainValuesWriter(64*1024, new DirectByteBufferAllocator());
     BinaryPlainValuesReader reader = new BinaryPlainValuesReader();
     
     Utils.writeData(writer, values);
@@ -56,7 +57,7 @@ public class BenchmarkDeltaLengthByteArray {
   @BenchmarkOptions(benchmarkRounds = 20, warmupRounds = 4)
   @Test
   public void benchmarkRandomStringsWithDeltaLengthByteArrayValuesWriter() throws IOException {
-    DeltaLengthByteArrayValuesWriter writer = new DeltaLengthByteArrayValuesWriter(64*1024);
+    DeltaLengthByteArrayValuesWriter writer = new DeltaLengthByteArrayValuesWriter(64*1024, new DirectByteBufferAllocator());
     DeltaLengthByteArrayValuesReader reader = new DeltaLengthByteArrayValuesReader();
     
     Utils.writeData(writer, values);

--- a/parquet-column/src/test/java/parquet/column/values/deltastrings/TestDeltaByteArray.java
+++ b/parquet-column/src/test/java/parquet/column/values/deltastrings/TestDeltaByteArray.java
@@ -39,7 +39,7 @@ public class TestDeltaByteArray {
     Binary[] bin = Utils.readData(reader, writer.getBytes().toByteArray(), values.length);
 
     for(int i =0; i< bin.length ; i++) {
-      Assert.assertEquals(Binary.fromString(values[i]), bin[i]);
+      Assert.assertEquals(Binary.fromString(values[i]).toStringUsingUTF8(), bin[i].toStringUsingUTF8());
     }
   }
   
@@ -52,7 +52,7 @@ public class TestDeltaByteArray {
     Binary[] bin = Utils.readData(reader, writer.getBytes().toByteArray(), randvalues.length);
 
     for(int i =0; i< bin.length ; i++) {
-      Assert.assertEquals(Binary.fromString(randvalues[i]), bin[i]);
+      Assert.assertEquals(Binary.fromString(randvalues[i]).toStringUsingUTF8(), bin[i].toStringUsingUTF8());
     }
   }
 

--- a/parquet-column/src/test/java/parquet/column/values/deltastrings/TestDeltaByteArray.java
+++ b/parquet-column/src/test/java/parquet/column/values/deltastrings/TestDeltaByteArray.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import org.junit.Test;
 import org.junit.Assert;
 
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.values.Utils;
 import parquet.column.values.ValuesReader;
 import parquet.column.values.delta.DeltaBinaryPackingValuesReader;
@@ -32,7 +33,7 @@ public class TestDeltaByteArray {
 
   @Test
   public void testSerialization () throws IOException {
-    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(64*1024);
+    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(64*1024, new DirectByteBufferAllocator());
     DeltaByteArrayReader reader = new DeltaByteArrayReader();
 
     Utils.writeData(writer, values);
@@ -45,7 +46,7 @@ public class TestDeltaByteArray {
   
   @Test
   public void testRandomStrings() throws IOException {
-    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(64*1024);
+    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(64*1024, new DirectByteBufferAllocator());
     DeltaByteArrayReader reader = new DeltaByteArrayReader();
 
     Utils.writeData(writer, randvalues);
@@ -58,7 +59,7 @@ public class TestDeltaByteArray {
 
   @Test
   public void testLengths() throws IOException {
-    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(64*1024);
+    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(64*1024, new DirectByteBufferAllocator());
     ValuesReader reader = new DeltaBinaryPackingValuesReader();
 
     Utils.writeData(writer, values);

--- a/parquet-column/src/test/java/parquet/column/values/deltastrings/benchmark/BenchmarkDeltaByteArray.java
+++ b/parquet-column/src/test/java/parquet/column/values/deltastrings/benchmark/BenchmarkDeltaByteArray.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import org.junit.Rule;
 import org.junit.Test;
 
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.values.Utils;
 import parquet.column.values.deltastrings.DeltaByteArrayReader;
 import parquet.column.values.deltastrings.DeltaByteArrayWriter;
@@ -51,7 +52,7 @@ public class BenchmarkDeltaByteArray {
   @BenchmarkOptions(benchmarkRounds = 20, warmupRounds = 4)
   @Test
   public void benchmarkRandomStringsWithPlainValuesWriter() throws IOException {
-    PlainValuesWriter writer = new PlainValuesWriter(64*1024);
+    PlainValuesWriter writer = new PlainValuesWriter(64*1024, new DirectByteBufferAllocator());
     BinaryPlainValuesReader reader = new BinaryPlainValuesReader();
     
     Utils.writeData(writer, values);
@@ -63,7 +64,7 @@ public class BenchmarkDeltaByteArray {
   @BenchmarkOptions(benchmarkRounds = 20, warmupRounds = 4)
   @Test
   public void benchmarkRandomStringsWithDeltaLengthByteArrayValuesWriter() throws IOException {
-    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(64*1024);
+    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(64*1024, new DirectByteBufferAllocator());
     DeltaByteArrayReader reader = new DeltaByteArrayReader();
     
     Utils.writeData(writer, values);
@@ -75,7 +76,7 @@ public class BenchmarkDeltaByteArray {
   @BenchmarkOptions(benchmarkRounds = 20, warmupRounds = 4)
   @Test
   public void benchmarkSortedStringsWithPlainValuesWriter() throws IOException {
-    PlainValuesWriter writer = new PlainValuesWriter(64*1024);
+    PlainValuesWriter writer = new PlainValuesWriter(64*1024, new DirectByteBufferAllocator());
     BinaryPlainValuesReader reader = new BinaryPlainValuesReader();
     
     Utils.writeData(writer, sortedVals);
@@ -87,7 +88,7 @@ public class BenchmarkDeltaByteArray {
   @BenchmarkOptions(benchmarkRounds = 20, warmupRounds = 4)
   @Test
   public void benchmarkSortedStringsWithDeltaLengthByteArrayValuesWriter() throws IOException {
-    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(64*1024);
+    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(64*1024, new DirectByteBufferAllocator());
     DeltaByteArrayReader reader = new DeltaByteArrayReader();
     
     Utils.writeData(writer, sortedVals);

--- a/parquet-column/src/test/java/parquet/column/values/dictionary/TestDictionary.java
+++ b/parquet-column/src/test/java/parquet/column/values/dictionary/TestDictionary.java
@@ -30,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import parquet.bytes.BytesInput;
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.ColumnDescriptor;
 import parquet.column.Dictionary;
 import parquet.column.Encoding;
@@ -51,7 +52,7 @@ public class TestDictionary {
   @Test
   public void testBinaryDictionary() throws IOException {
     int COUNT = 100;
-    ValuesWriter cw = new PlainBinaryDictionaryValuesWriter(200, 10000);
+    ValuesWriter cw = new PlainBinaryDictionaryValuesWriter(200, 10000, new DirectByteBufferAllocator());
     writeRepeated(COUNT, cw, "a");
     BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
     writeRepeated(COUNT, cw, "b");
@@ -71,7 +72,7 @@ public class TestDictionary {
   public void testBinaryDictionaryFallBack() throws IOException {
     int slabSize = 100;
     int maxDictionaryByteSize = 50;
-    final DictionaryValuesWriter cw = new PlainBinaryDictionaryValuesWriter(maxDictionaryByteSize, slabSize);
+    final DictionaryValuesWriter cw = new PlainBinaryDictionaryValuesWriter(maxDictionaryByteSize, slabSize, new DirectByteBufferAllocator());
     int fallBackThreshold = maxDictionaryByteSize;
     int dataSize=0;
     for (long i = 0; i < 100; i++) {
@@ -102,7 +103,7 @@ public class TestDictionary {
   @Test
   public void testBinaryDictionaryChangedValues() throws IOException {
     int COUNT = 100;
-    ValuesWriter cw = new PlainBinaryDictionaryValuesWriter(200, 10000);
+    ValuesWriter cw = new PlainBinaryDictionaryValuesWriter(200, 10000, new DirectByteBufferAllocator());
     writeRepeatedWithReuse(COUNT, cw, "a");
     BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
     writeRepeatedWithReuse(COUNT, cw, "b");
@@ -121,7 +122,7 @@ public class TestDictionary {
   @Test
   public void testFirstPageFallBack() throws IOException {
     int COUNT = 1000;
-    ValuesWriter cw = new PlainBinaryDictionaryValuesWriter(10000, 10000);
+    ValuesWriter cw = new PlainBinaryDictionaryValuesWriter(10000, 10000, new DirectByteBufferAllocator());
     writeDistinct(COUNT, cw, "a");
     // not efficient so falls back
     BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN);
@@ -139,7 +140,7 @@ public class TestDictionary {
   public void testSecondPageFallBack() throws IOException {
 
     int COUNT = 1000;
-    ValuesWriter cw = new PlainBinaryDictionaryValuesWriter(1000, 10000);
+    ValuesWriter cw = new PlainBinaryDictionaryValuesWriter(1000, 10000, new DirectByteBufferAllocator());
     writeRepeated(COUNT, cw, "a");
     BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
     writeDistinct(COUNT, cw, "b");
@@ -161,7 +162,7 @@ public class TestDictionary {
 
     int COUNT = 1000;
     int COUNT2 = 2000;
-    final DictionaryValuesWriter cw = new PlainLongDictionaryValuesWriter(10000, 10000);
+    final DictionaryValuesWriter cw = new PlainLongDictionaryValuesWriter(10000, 10000, new DirectByteBufferAllocator());
     for (long i = 0; i < COUNT; i++) {
       cw.writeLong(i % 50);
     }
@@ -211,7 +212,7 @@ public class TestDictionary {
   public void testLongDictionaryFallBack() throws IOException {
     int slabSize = 100;
     int maxDictionaryByteSize = 50;
-    final DictionaryValuesWriter cw = new PlainLongDictionaryValuesWriter(maxDictionaryByteSize, slabSize);
+    final DictionaryValuesWriter cw = new PlainLongDictionaryValuesWriter(maxDictionaryByteSize, slabSize, new DirectByteBufferAllocator());
     // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
     ValuesReader reader = new PlainValuesReader.LongPlainValuesReader();
     
@@ -229,7 +230,7 @@ public class TestDictionary {
 
     int COUNT = 1000;
     int COUNT2 = 2000;
-    final DictionaryValuesWriter cw = new PlainDoubleDictionaryValuesWriter(10000, 10000);
+    final DictionaryValuesWriter cw = new PlainDoubleDictionaryValuesWriter(10000, 10000, new DirectByteBufferAllocator());
 
     for (double i = 0; i < COUNT; i++) {
       cw.writeDouble(i % 50);
@@ -282,7 +283,7 @@ public class TestDictionary {
   public void testDoubleDictionaryFallBack() throws IOException {
     int slabSize = 100;
     int maxDictionaryByteSize = 50;
-    final DictionaryValuesWriter cw = new PlainDoubleDictionaryValuesWriter(maxDictionaryByteSize, slabSize);
+    final DictionaryValuesWriter cw = new PlainDoubleDictionaryValuesWriter(maxDictionaryByteSize, slabSize, new DirectByteBufferAllocator());
     
     // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
     ValuesReader reader = new PlainValuesReader.DoublePlainValuesReader();
@@ -301,7 +302,7 @@ public class TestDictionary {
 
     int COUNT = 2000;
     int COUNT2 = 4000;
-    final DictionaryValuesWriter cw = new PlainIntegerDictionaryValuesWriter(10000, 10000);
+    final DictionaryValuesWriter cw = new PlainIntegerDictionaryValuesWriter(10000, 10000, new DirectByteBufferAllocator());
 
     for (int i = 0; i < COUNT; i++) {
       cw.writeInteger(i % 50);
@@ -353,7 +354,7 @@ public class TestDictionary {
   public void testIntDictionaryFallBack() throws IOException {
     int slabSize = 100;
     int maxDictionaryByteSize = 50;
-    final DictionaryValuesWriter cw = new PlainIntegerDictionaryValuesWriter(maxDictionaryByteSize, slabSize);
+    final DictionaryValuesWriter cw = new PlainIntegerDictionaryValuesWriter(maxDictionaryByteSize, slabSize, new DirectByteBufferAllocator());
     
     // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
     ValuesReader reader = new PlainValuesReader.IntegerPlainValuesReader();
@@ -372,7 +373,7 @@ public class TestDictionary {
 
     int COUNT = 2000;
     int COUNT2 = 4000;
-    final DictionaryValuesWriter cw = new PlainFloatDictionaryValuesWriter(10000, 10000);
+    final DictionaryValuesWriter cw = new PlainFloatDictionaryValuesWriter(10000, 10000, new DirectByteBufferAllocator());
 
     for (float i = 0; i < COUNT; i++) {
       cw.writeFloat(i % 50);
@@ -424,7 +425,7 @@ public class TestDictionary {
   public void testFloatDictionaryFallBack() throws IOException {
     int slabSize = 100;
     int maxDictionaryByteSize = 50;
-    final DictionaryValuesWriter cw = new PlainFloatDictionaryValuesWriter(maxDictionaryByteSize, slabSize);
+    final DictionaryValuesWriter cw = new PlainFloatDictionaryValuesWriter(maxDictionaryByteSize, slabSize, new DirectByteBufferAllocator());
     
     // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
     ValuesReader reader = new PlainValuesReader.FloatPlainValuesReader();
@@ -440,7 +441,7 @@ public class TestDictionary {
 
   @Test
   public void testZeroValues() throws IOException {
-    DictionaryValuesWriter cw = new PlainIntegerDictionaryValuesWriter(100, 100);
+    DictionaryValuesWriter cw = new PlainIntegerDictionaryValuesWriter(100, 100, new DirectByteBufferAllocator());
     cw.writeInteger(34);
     cw.writeInteger(34);
     getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);

--- a/parquet-column/src/test/java/parquet/column/values/dictionary/TestDictionary.java
+++ b/parquet-column/src/test/java/parquet/column/values/dictionary/TestDictionary.java
@@ -87,10 +87,11 @@ public class TestDictionary {
 
     //Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
     ValuesReader reader = new BinaryPlainValuesReader();
-    reader.initFromPage(100, cw.getBytes().toByteArray(), 0);
+    reader.initFromPage(100, cw.getBytes().toByteBuffer(), 0);
 
     for (long i = 0; i < 100; i++) {
-      assertEquals(Binary.fromString("str" + i), reader.readBytes());
+      assertEquals(Binary.fromString("str" + i).toStringUsingUTF8(),
+                    reader.readBytes().toStringUsingUTF8());
     }
 
     //simulate cutting the page
@@ -175,13 +176,13 @@ public class TestDictionary {
 
     DictionaryValuesReader cr = initDicReader(cw, PrimitiveTypeName.INT64);
 
-    cr.initFromPage(COUNT, bytes1.toByteArray(), 0);
+    cr.initFromPage(COUNT, bytes1.toByteBuffer(), 0);
     for (long i = 0; i < COUNT; i++) {
       long back = cr.readLong();
       assertEquals(i % 50, back);
     }
 
-    cr.initFromPage(COUNT2, bytes2.toByteArray(), 0);
+    cr.initFromPage(COUNT2, bytes2.toByteBuffer(), 0);
     for (long i = COUNT2; i > 0; i--) {
       long back = cr.readLong();
       assertEquals(i % 50, back);
@@ -199,7 +200,7 @@ public class TestDictionary {
       }
     }
 
-    reader.initFromPage(100, cw.getBytes().toByteArray(), 0);
+    reader.initFromPage(100, cw.getBytes().toByteBuffer(), 0);
 
     for (long i = 0; i < 100; i++) {
       assertEquals(i, reader.readLong());
@@ -245,13 +246,13 @@ public class TestDictionary {
 
     final DictionaryValuesReader cr = initDicReader(cw, DOUBLE);
 
-    cr.initFromPage(COUNT, bytes1.toByteArray(), 0);
+    cr.initFromPage(COUNT, bytes1.toByteBuffer(), 0);
     for (double i = 0; i < COUNT; i++) {
       double back = cr.readDouble();
       assertEquals(i % 50, back, 0.0);
     }
 
-    cr.initFromPage(COUNT2, bytes2.toByteArray(), 0);
+    cr.initFromPage(COUNT2, bytes2.toByteBuffer(), 0);
     for (double i = COUNT2; i > 0; i--) {
       double back = cr.readDouble();
       assertEquals(i % 50, back, 0.0);
@@ -270,7 +271,7 @@ public class TestDictionary {
       }
     }
 
-    reader.initFromPage(100, cw.getBytes().toByteArray(), 0);
+    reader.initFromPage(100, cw.getBytes().toByteBuffer(), 0);
 
     for (double i = 0; i < 100; i++) {
       assertEquals(i, reader.readDouble(), 0.00001);
@@ -316,13 +317,13 @@ public class TestDictionary {
 
     DictionaryValuesReader cr = initDicReader(cw, INT32);
 
-    cr.initFromPage(COUNT, bytes1.toByteArray(), 0);
+    cr.initFromPage(COUNT, bytes1.toByteBuffer(), 0);
     for (int i = 0; i < COUNT; i++) {
       int back = cr.readInteger();
       assertEquals(i % 50, back);
     }
 
-    cr.initFromPage(COUNT2, bytes2.toByteArray(), 0);
+    cr.initFromPage(COUNT2, bytes2.toByteBuffer(), 0);
     for (int i = COUNT2; i > 0; i--) {
       int back = cr.readInteger();
       assertEquals(i % 50, back);
@@ -341,7 +342,7 @@ public class TestDictionary {
       }
     }
 
-    reader.initFromPage(100, cw.getBytes().toByteArray(), 0);
+    reader.initFromPage(100, cw.getBytes().toByteBuffer(), 0);
 
     for (int i = 0; i < 100; i++) {
       assertEquals(i, reader.readInteger());
@@ -387,13 +388,13 @@ public class TestDictionary {
 
     DictionaryValuesReader cr = initDicReader(cw, FLOAT);
 
-    cr.initFromPage(COUNT, bytes1.toByteArray(), 0);
+    cr.initFromPage(COUNT, bytes1.toByteBuffer(), 0);
     for (float i = 0; i < COUNT; i++) {
       float back = cr.readFloat();
       assertEquals(i % 50, back, 0.0f);
     }
 
-    cr.initFromPage(COUNT2, bytes2.toByteArray(), 0);
+    cr.initFromPage(COUNT2, bytes2.toByteBuffer(), 0);
     for (float i = COUNT2; i > 0; i--) {
       float back = cr.readFloat();
       assertEquals(i % 50, back, 0.0f);
@@ -412,7 +413,7 @@ public class TestDictionary {
       }
     }
 
-    reader.initFromPage(100, cw.getBytes().toByteArray(), 0);
+    reader.initFromPage(100, cw.getBytes().toByteBuffer(), 0);
 
     for (float i = 0; i < 100; i++) {
       assertEquals(i, reader.readFloat(), 0.00001);
@@ -461,14 +462,14 @@ public class TestDictionary {
   }
 
   private void checkDistinct(int COUNT, BytesInput bytes, ValuesReader cr, String prefix) throws IOException {
-    cr.initFromPage(COUNT, bytes.toByteArray(), 0);
+    cr.initFromPage(COUNT, bytes.toByteBuffer(), 0);
     for (int i = 0; i < COUNT; i++) {
       Assert.assertEquals(prefix + i, cr.readBytes().toStringUsingUTF8());
     }
   }
 
   private void checkRepeated(int COUNT, BytesInput bytes, ValuesReader cr, String prefix) throws IOException {
-    cr.initFromPage(COUNT, bytes.toByteArray(), 0);
+    cr.initFromPage(COUNT, bytes.toByteBuffer(), 0);
     for (int i = 0; i < COUNT; i++) {
       Assert.assertEquals(prefix + i % 10, cr.readBytes().toStringUsingUTF8());
     }

--- a/parquet-column/src/test/java/parquet/column/values/rle/RunLengthBitPackingHybridIntegrationTest.java
+++ b/parquet-column/src/test/java/parquet/column/values/rle/RunLengthBitPackingHybridIntegrationTest.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 
 import parquet.bytes.ByteBufferInputStream;
 import org.junit.Test;
+import parquet.bytes.DirectByteBufferAllocator;
 
 import static org.junit.Assert.assertEquals;
 
@@ -38,7 +39,7 @@ public class RunLengthBitPackingHybridIntegrationTest {
   private void doIntegrationTest(int bitWidth) throws Exception {
     long modValue = 1L << bitWidth;
 
-    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(bitWidth, 1000);
+    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(bitWidth, 1000, new DirectByteBufferAllocator());
     int numValues = 0;
 
     for (int i = 0; i < 100; i++) {

--- a/parquet-column/src/test/java/parquet/column/values/rle/RunLengthBitPackingHybridIntegrationTest.java
+++ b/parquet-column/src/test/java/parquet/column/values/rle/RunLengthBitPackingHybridIntegrationTest.java
@@ -15,9 +15,10 @@
  */
 package parquet.column.values.rle;
 
-import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
 import java.io.InputStream;
 
+import parquet.bytes.ByteBufferInputStream;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -67,8 +68,8 @@ public class RunLengthBitPackingHybridIntegrationTest {
     }
     numValues += 1000;
 
-    byte[] encodedBytes = encoder.toBytes().toByteArray();
-    ByteArrayInputStream in = new ByteArrayInputStream(encodedBytes);
+    ByteBuffer encodedBytes = encoder.toBytes().toByteBuffer();
+    ByteBufferInputStream in = new ByteBufferInputStream(encodedBytes);
 
     RunLengthBitPackingHybridDecoder decoder = new RunLengthBitPackingHybridDecoder(bitWidth, in);
 

--- a/parquet-column/src/test/java/parquet/column/values/rle/TestRunLengthBitPackingHybridEncoder.java
+++ b/parquet-column/src/test/java/parquet/column/values/rle/TestRunLengthBitPackingHybridEncoder.java
@@ -18,6 +18,7 @@ package parquet.column.values.rle;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.List;
 import org.junit.Test;
 
 import parquet.bytes.BytesUtils;
+import parquet.bytes.ByteBufferInputStream;
 import parquet.column.values.bitpacking.BytePacker;
 import parquet.column.values.bitpacking.Packer;
 
@@ -284,7 +286,7 @@ public class TestRunLengthBitPackingHybridEncoder {
 	// bit width 2.
 	bytes[0] = (1 << 1 )| 1; 
 	bytes[1] = (1 << 0) | (2 << 2) | (3 << 4);
-    ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
+    ByteBufferInputStream stream = new ByteBufferInputStream(ByteBuffer.wrap(bytes));
     RunLengthBitPackingHybridDecoder decoder = new RunLengthBitPackingHybridDecoder(2, stream);
     assertEquals(decoder.readInt(), 1);
     assertEquals(decoder.readInt(), 2);
@@ -306,7 +308,7 @@ public class TestRunLengthBitPackingHybridEncoder {
         next8Values[i] = (byte) is.read();
       }
 
-      packer.unpack8Values(next8Values, 0, unpacked, 0);
+      packer.unpack8Values(ByteBuffer.wrap(next8Values), 0, unpacked, 0);
 
       for (int v = 0; v < 8; v++) {
         values.add(unpacked[v]);

--- a/parquet-column/src/test/java/parquet/column/values/rle/TestRunLengthBitPackingHybridEncoder.java
+++ b/parquet-column/src/test/java/parquet/column/values/rle/TestRunLengthBitPackingHybridEncoder.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import parquet.bytes.BytesUtils;
 import parquet.bytes.ByteBufferInputStream;
+import parquet.bytes.DirectByteBufferAllocator;
 import parquet.column.values.bitpacking.BytePacker;
 import parquet.column.values.bitpacking.Packer;
 
@@ -37,7 +38,7 @@ public class TestRunLengthBitPackingHybridEncoder {
   
   @Test
   public void testRLEOnly() throws Exception {
-    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(3, 5);
+    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(3, 5, new DirectByteBufferAllocator());
     for (int i = 0; i < 100; i++) {
       encoder.writeInt(4);
     }
@@ -67,7 +68,7 @@ public class TestRunLengthBitPackingHybridEncoder {
     // make sure that repeated 0s at the beginning
     // of the stream don't trip up the repeat count
 
-    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(3, 5);
+    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(3, 5, new DirectByteBufferAllocator());
     for (int i = 0; i < 10; i++) {
       encoder.writeInt(0);
     }
@@ -85,7 +86,7 @@ public class TestRunLengthBitPackingHybridEncoder {
 
   @Test
   public void testBitWidthZero() throws Exception {
-    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(0, 5);
+    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(0, 5, new DirectByteBufferAllocator());
     for (int i = 0; i < 10; i++) {
       encoder.writeInt(0);
     }
@@ -101,7 +102,7 @@ public class TestRunLengthBitPackingHybridEncoder {
 
   @Test
   public void testBitPackingOnly() throws Exception {
-    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(3, 5);
+    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(3, 5, new DirectByteBufferAllocator());
 
     for (int i = 0; i < 100; i++) {
       encoder.writeInt(i % 3);
@@ -124,7 +125,7 @@ public class TestRunLengthBitPackingHybridEncoder {
 
   @Test
   public void testBitPackingOverflow() throws Exception {
-    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(3, 5);
+    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(3, 5, new DirectByteBufferAllocator());
 
     for (int i = 0; i < 1000; i++) {
       encoder.writeInt(i % 3);
@@ -156,7 +157,7 @@ public class TestRunLengthBitPackingHybridEncoder {
 
   @Test
   public void testTransitionFromBitPackingToRle() throws Exception {
-    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(3, 5);
+    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(3, 5, new DirectByteBufferAllocator());
 
     // 5 obviously bit-packed values
     encoder.writeInt(0);
@@ -194,7 +195,7 @@ public class TestRunLengthBitPackingHybridEncoder {
 
   @Test
   public void testPaddingZerosOnUnfinishedBitPackedRuns() throws Exception {
-    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(5, 5);
+    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(5, 5, new DirectByteBufferAllocator());
     for (int i = 0; i < 9; i++) {
       encoder.writeInt(i+1);
     }
@@ -213,7 +214,7 @@ public class TestRunLengthBitPackingHybridEncoder {
 
   @Test
   public void testSwitchingModes() throws Exception {
-    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(9, 100);
+    RunLengthBitPackingHybridEncoder encoder = new RunLengthBitPackingHybridEncoder(9, 100, new DirectByteBufferAllocator());
 
     // rle first
     for (int i = 0; i < 25; i++) {

--- a/parquet-column/src/test/java/parquet/io/TestColumnIO.java
+++ b/parquet-column/src/test/java/parquet/io/TestColumnIO.java
@@ -636,6 +636,11 @@ public class TestColumnIO {
           }
 
           @Override
+          public void close() {
+
+          }
+
+          @Override
           public long getBufferedSizeInMemory() {
             throw new UnsupportedOperationException();
           }
@@ -645,11 +650,17 @@ public class TestColumnIO {
       public void flush() {
         assertEquals("read all events", expected.length, counter);
       }
+
+      @Override
+      public void close() {
+
+      }
     };
     MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(schema);
     GroupWriter groupWriter = new GroupWriter(columnIO.getRecordWriter(columns), schema);
     groupWriter.write(r1);
     groupWriter.write(r2);
     columns.flush();
+    columns.close();
   }
 }

--- a/parquet-common/src/main/java/parquet/bytes/ByteBufferAllocator.java
+++ b/parquet-common/src/main/java/parquet/bytes/ByteBufferAllocator.java
@@ -13,29 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parquet.column;
 
-/**
- * Container which can construct writers for multiple columns to be stored
- * together.
- *
- * @author Julien Le Dem
- */
-public interface ColumnWriteStore {
-  /**
-   * @param path the column for which to create a writer
-   * @return the column writer for the given column
-   */
-  abstract public ColumnWriter getColumnWriter(ColumnDescriptor path);
+package parquet.bytes;
 
-  /**
-   * when we are done writing to flush to the underlying storage
-   */
-  abstract public void flush();
+import java.nio.ByteBuffer;
 
-  /**
-   * Close the related output stream and release any resources
-   */
-  abstract public void close();
+public interface ByteBufferAllocator {
+  ByteBuffer allocate(int size);
+
+  //For RefCounted implementations using direct memory, the release method
+  //needs to be called to free references to the allocated memory
+  void release(ByteBuffer b);
 
 }

--- a/parquet-common/src/main/java/parquet/bytes/ByteBufferInputStream.java
+++ b/parquet-common/src/main/java/parquet/bytes/ByteBufferInputStream.java
@@ -1,0 +1,55 @@
+package parquet.bytes;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+public class ByteBufferInputStream extends InputStream {
+	
+  protected ByteBuffer byteBuf;
+  public ByteBufferInputStream(ByteBuffer buffer) {
+    this(buffer, buffer.position(), buffer.remaining());
+  }
+  
+  public ByteBufferInputStream(ByteBuffer buffer, int offset, int count) {
+    buffer.position(offset);
+    byteBuf = buffer.slice();
+    byteBuf.limit(count);
+  }
+  
+  public ByteBuffer toByteBuffer() {
+    return byteBuf.slice();
+  }
+  
+  @Override
+  public int read() throws IOException {
+    if (!byteBuf.hasRemaining()) {
+    	return -1;
+    }
+    //Workaround for unsigned byte
+    return byteBuf.get() & 0xFF;
+  }
+
+  @Override
+  public int read(byte[] bytes, int offset, int length) throws IOException {
+    int count = Math.min(byteBuf.remaining(), length);
+    if (count == 0) return -1;
+    byteBuf.get(bytes, offset, count);
+    return count;
+  }
+  
+  @Override
+  public long skip(long n) {
+	  if (n > byteBuf.remaining())
+	    n = byteBuf.remaining();
+	  int pos = byteBuf.position();
+	  byteBuf.position((int)(pos + n));
+	  return n;
+  }
+
+
+  @Override
+  public int available() {
+    return byteBuf.remaining();
+  }
+}

--- a/parquet-common/src/main/java/parquet/bytes/BytesUtils.java
+++ b/parquet-common/src/main/java/parquet/bytes/BytesUtils.java
@@ -19,6 +19,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 import parquet.Log;
@@ -43,6 +44,21 @@ public class BytesUtils {
     return 32 - Integer.numberOfLeadingZeros(bound);
   }
 
+  /**
+   * reads an int in little endian at the given position
+   * @param in
+   * @param offset
+   * @return
+   * @throws IOException
+   */
+  public static int readIntLittleEndian(ByteBuffer in, int offset) throws IOException {
+    int ch4 = in.get(offset) & 0xff;
+    int ch3 = in.get(offset + 1) & 0xff;
+    int ch2 = in.get(offset + 2) & 0xff;
+    int ch1 = in.get(offset + 3) & 0xff;
+    return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
+  }
+  
   /**
    * reads an int in little endian at the given position
    * @param in

--- a/parquet-common/src/main/java/parquet/bytes/DirectByteBufferAllocator.java
+++ b/parquet-common/src/main/java/parquet/bytes/DirectByteBufferAllocator.java
@@ -13,18 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parquet.column.values.boundedint;
 
-import parquet.bytes.ByteBufferAllocator;
-import parquet.column.values.ValuesReader;
-import parquet.column.values.ValuesWriter;
+package parquet.bytes;
 
-public abstract class BoundedIntValuesFactory {
-  public static ValuesReader getBoundedReader(int bound) {
-    return bound == 0 ? new ZeroIntegerValuesReader() : new BoundedIntValuesReader(bound);
+import java.nio.ByteBuffer;
+
+public class DirectByteBufferAllocator implements ByteBufferAllocator{
+  public static final DirectByteBufferAllocator getInstance(){return new DirectByteBufferAllocator();}
+  public DirectByteBufferAllocator() {
+    super();
   }
 
-  public static ValuesWriter getBoundedWriter(int bound, int initialCapacity, ByteBufferAllocator allocator) {
-    return bound == 0 ? new DevNullValuesWriter() : new BoundedIntValuesWriter(bound, initialCapacity, allocator);
+  public ByteBuffer allocate(final int size) {
+    return ByteBuffer.allocateDirect(size);
   }
+
+  @Override
+  public void release(ByteBuffer b) {
+    return;
+  }
+
+
 }

--- a/parquet-common/src/main/java/parquet/bytes/HeapByteBufferAllocator.java
+++ b/parquet-common/src/main/java/parquet/bytes/HeapByteBufferAllocator.java
@@ -13,18 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package parquet.column.values.boundedint;
 
-import parquet.bytes.ByteBufferAllocator;
-import parquet.column.values.ValuesReader;
-import parquet.column.values.ValuesWriter;
+package parquet.bytes;
 
-public abstract class BoundedIntValuesFactory {
-  public static ValuesReader getBoundedReader(int bound) {
-    return bound == 0 ? new ZeroIntegerValuesReader() : new BoundedIntValuesReader(bound);
+import java.nio.ByteBuffer;
+
+public class HeapByteBufferAllocator implements ByteBufferAllocator{
+
+  public static final HeapByteBufferAllocator getInstance(){ return new HeapByteBufferAllocator();}
+
+  public HeapByteBufferAllocator() {
+    super();
   }
 
-  public static ValuesWriter getBoundedWriter(int bound, int initialCapacity, ByteBufferAllocator allocator) {
-    return bound == 0 ? new DevNullValuesWriter() : new BoundedIntValuesWriter(bound, initialCapacity, allocator);
+  public ByteBuffer allocate(final int size) {
+    return ByteBuffer.allocate(size);
   }
+
+  public void release(ByteBuffer b) {
+    return;
+  }
+
 }

--- a/parquet-encoding/src/main/java/parquet/bytes/CapacityByteArrayOutputStream.java
+++ b/parquet-encoding/src/main/java/parquet/bytes/CapacityByteArrayOutputStream.java
@@ -18,9 +18,12 @@ package parquet.bytes;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import parquet.bytes.ByteBufferAllocator;
 import parquet.Log;
 import parquet.Preconditions;
 
@@ -42,27 +45,47 @@ public class CapacityByteArrayOutputStream extends OutputStream {
   private static final int EXPONENTIAL_SLAB_SIZE_THRESHOLD = 10;
 
   private int slabSize;
-  private List<byte[]> slabs = new ArrayList<byte[]>();
-  private byte[] currentSlab;
+  //private List<byte[]> slabs = new ArrayList<byte[]>();
+  //private byte[] currentSlab;
+  private List<ByteBuffer> slabs = new ArrayList<ByteBuffer>();
+  private ByteBuffer currentSlab;
   private int capacity;
   private int currentSlabIndex;
   private int currentSlabPosition;
   private int size;
+  private ByteBufferAllocator allocator;
 
   /**
    * @param initialSize the initialSize of the buffer (also slab size)
    */
-  public CapacityByteArrayOutputStream(int initialSize) {
+//  public CapacityByteArrayOutputStream(int initialSize) {
+//    Preconditions.checkArgument(initialSize > 0, "initialSize must be > 0");
+//    initSlabs(initialSize);
+//  }
+
+  public CapacityByteArrayOutputStream(int initialSize, ByteBufferAllocator a) {
     Preconditions.checkArgument(initialSize > 0, "initialSize must be > 0");
+    allocator=a;
     initSlabs(initialSize);
+  }
+
+  private ByteBuffer allocateSlab(int size){
+    ByteBuffer b;
+    b=(allocator!=null)?
+      allocator.allocate(slabSize):
+      ByteBuffer.wrap(new byte[slabSize]);
+    return b;
   }
 
   private void initSlabs(int initialSize) {
     if (Log.DEBUG) LOG.debug(String.format("initial slab of size %d", initialSize));
     this.slabSize = initialSize;
+    for (ByteBuffer slab : slabs) {
+      allocator.release(slab);
+    }
     this.slabs.clear();
     this.capacity = initialSize;
-    this.currentSlab = new byte[slabSize];
+    this.currentSlab = allocateSlab(slabSize);
     this.slabs.add(currentSlab);
     this.currentSlabIndex = 0;
     this.currentSlabPosition = 0;
@@ -74,11 +97,11 @@ public class CapacityByteArrayOutputStream extends OutputStream {
     if (currentSlabIndex < this.slabs.size()) {
       // reuse existing slab
       this.currentSlab = this.slabs.get(currentSlabIndex);
-      if (Log.DEBUG) LOG.debug(String.format("reusing slab of size %d", currentSlab.length));
-      if (currentSlab.length < minimumSize) {
-        if (Log.DEBUG) LOG.debug(String.format("slab size %,d too small for value of size %,d. replacing slab", currentSlab.length, minimumSize));
-        byte[] newSlab = new byte[minimumSize];
-        capacity += minimumSize - currentSlab.length;
+      if (Log.DEBUG) LOG.debug(String.format("reusing slab of size %d", currentSlab.capacity()));
+      if (currentSlab.capacity() < minimumSize) {
+        if (Log.DEBUG) LOG.debug(String.format("slab size %,d too small for value of size %,d. replacing slab", currentSlab.capacity(), minimumSize));
+        ByteBuffer newSlab = allocateSlab(minimumSize);
+        capacity += minimumSize - currentSlab.capacity();
         this.currentSlab = newSlab;
         this.slabs.set(currentSlabIndex, newSlab);
       }
@@ -94,7 +117,7 @@ public class CapacityByteArrayOutputStream extends OutputStream {
         this.slabSize = minimumSize;
       }
       if (Log.DEBUG) LOG.debug(String.format("new slab of size %d", slabSize));
-      this.currentSlab = new byte[slabSize];
+      this.currentSlab = allocateSlab(slabSize);
       this.slabs.add(currentSlab);
       this.capacity += slabSize;
     }
@@ -103,10 +126,11 @@ public class CapacityByteArrayOutputStream extends OutputStream {
 
   @Override
   public void write(int b) {
-    if (currentSlabPosition == currentSlab.length) {
+    if (!currentSlab.hasRemaining()) {
       addSlab(1);
     }
-    currentSlab[currentSlabPosition] = (byte) b;
+    //currentSlab[currentSlabPosition] = (byte) b;
+    currentSlab.put((byte) b);
     currentSlabPosition += 1;
     size += 1;
   }
@@ -117,15 +141,18 @@ public class CapacityByteArrayOutputStream extends OutputStream {
         ((off + len) - b.length > 0)) {
       throw new IndexOutOfBoundsException();
     }
-    if (currentSlabPosition + len >= currentSlab.length) {
-      final int length1 = currentSlab.length - currentSlabPosition;
-      System.arraycopy(b, off, currentSlab, currentSlabPosition, length1);
+    if (currentSlabPosition + len >= currentSlab.limit()) {
+      final int length1 = currentSlab.limit() - currentSlabPosition;
+      //System.arraycopy(b, off, currentSlab, currentSlabPosition, length1);
+      currentSlab.put(b, off, length1);
       final int length2 = len - length1;
       addSlab(length2);
-      System.arraycopy(b, off + length1, currentSlab, currentSlabPosition, length2);
+      //System.arraycopy(b, off + length1, currentSlab, currentSlabPosition, length2);
+      currentSlab.put(b, off+length1, length2);
       currentSlabPosition = length2;
     } else {
-      System.arraycopy(b, off, currentSlab, currentSlabPosition, len);
+      //System.arraycopy(b, off, currentSlab, currentSlabPosition, len);
+      currentSlab.put(b, off, len);
       currentSlabPosition += len;
     }
     size += len;
@@ -139,11 +166,25 @@ public class CapacityByteArrayOutputStream extends OutputStream {
    * @exception  IOException  if an I/O error occurs.
    */
   public void writeTo(OutputStream out) throws IOException {
+    byte[] b;
+    // if the ByteBuffer is backed by an array, we could potentially use the array() method
+    // to get the backing array and avoid a copy. But the array could potentially be a larger
+    // store and we are just viewing a small section of the array. So we cannot really avoid
+    // the copy.
     for (int i = 0; i < currentSlabIndex; i++) {
-      final byte[] slab = slabs.get(i);
-      out.write(slab, 0, slab.length);
+      final ByteBuffer slab = slabs.get(i);
+      int bytesToRead=slab.position();
+      slab.flip();
+      b=new byte[bytesToRead];
+      slab.get(b);
+      out.write(b);
     }
-    out.write(currentSlab, 0, currentSlabPosition);
+
+    int bytesToRead=currentSlab.position();
+    currentSlab.flip();
+    b=new byte[bytesToRead];
+    currentSlab.get(b);
+    out.write(b);
   }
 
   /**
@@ -168,7 +209,7 @@ public class CapacityByteArrayOutputStream extends OutputStream {
     // heuristics to adjust slab size
     if (
         // if we have only one slab, make sure it is not way too big (more than twice what we need). Except if the slab is already small
-        (currentSlabIndex == 0 && currentSlabPosition < currentSlab.length / 2 && currentSlab.length > MINIMUM_SLAB_SIZE)
+        (currentSlabIndex == 0 && currentSlabPosition < currentSlab.capacity() / 2 && currentSlab.capacity() > MINIMUM_SLAB_SIZE)
         ||
         // we want to avoid generating too many slabs.
         (currentSlabIndex > EXPONENTIAL_SLAB_SIZE_THRESHOLD)
@@ -176,12 +217,17 @@ public class CapacityByteArrayOutputStream extends OutputStream {
       // readjust slab size
       initSlabs(Math.max(size / 5, MINIMUM_SLAB_SIZE)); // should make overhead to about 20% without incurring many slabs
       if (Log.DEBUG) LOG.debug(String.format("used %d slabs, new slab size %d", currentSlabIndex + 1, slabSize));
-    } else if (currentSlabIndex < slabs.size() - 1) {
+    } else if (currentSlabIndex < slabs.size() ) {
       // free up the slabs that we are not using. We want to minimize overhead
-      this.slabs = new ArrayList<byte[]>(slabs.subList(0, currentSlabIndex + 1));
+      for(int i = currentSlabIndex + 1; i < slabs.size(); i++) {
+        ByteBuffer slab = slabs.get(i);
+        allocator.release(slab);
+      }
+      this.slabs = new ArrayList<ByteBuffer>(slabs.subList(0, currentSlabIndex + 1));
       this.capacity = 0;
-      for (byte[] slab : slabs) {
-        capacity += slab.length;
+      for (ByteBuffer slab : slabs) {
+        capacity += slab.capacity();
+        slab.clear();
       }
     }
     this.currentSlabIndex = 0;
@@ -218,13 +264,14 @@ public class CapacityByteArrayOutputStream extends OutputStream {
 
     long seen = 0;
     for (int i = 0; i <=currentSlabIndex; i++) {
-      byte[] slab = slabs.get(i);
-      if (index < seen + slab.length) {
+      ByteBuffer slab = slabs.get(i);
+      if (index < seen + slab.limit()) {
         // ok found index
-        slab[(int)(index-seen)] = value;
+        //slab[(int)(index-seen)] = value;
+        slab.put((int)(index-seen), value);
         break;
       }
-      seen += slab.length;
+      seen += slab.limit();
     }
   }
 
@@ -242,4 +289,18 @@ public class CapacityByteArrayOutputStream extends OutputStream {
   int getSlabCount() {
     return slabs.size();
   }
+
+  @Override
+  public void close() {
+    for (ByteBuffer slab : slabs) {
+      allocator.release(slab);
+    }
+    try {
+      super.close();
+    }catch(IOException e){
+      e.printStackTrace();
+    }
+  }
+
 }
+

--- a/parquet-encoding/src/main/java/parquet/column/values/bitpacking/BytePacker.java
+++ b/parquet-encoding/src/main/java/parquet/column/values/bitpacking/BytePacker.java
@@ -15,6 +15,8 @@
  */
 package parquet.column.values.bitpacking;
 
+import java.nio.ByteBuffer;
+
 /**
  * Packs and unpacks into bytes
  *
@@ -68,6 +70,9 @@ public abstract class BytePacker {
    * @param output the output values
    * @param outPos where to write to in output
    */
+  public abstract void unpack8Values(final ByteBuffer input, final int inPos, final int[] output, final int outPos);
+  
+  //Compatible API
   public abstract void unpack8Values(final byte[] input, final int inPos, final int[] output, final int outPos);
 
   /**
@@ -78,6 +83,8 @@ public abstract class BytePacker {
    * @param output the output values
    * @param outPos where to write to in output
    */
-  public abstract void unpack32Values(byte[] input, int inPos, int[] output, int outPos);
+  public abstract void unpack32Values(ByteBuffer input, int inPos, int[] output, int outPos);
 
+  //Compatible API
+  public abstract void unpack32Values(byte[] input, int inPos, int[] output, int outPos);
 }

--- a/parquet-encoding/src/test/java/parquet/bytes/TestCapacityByteArrayOutputStream.java
+++ b/parquet-encoding/src/test/java/parquet/bytes/TestCapacityByteArrayOutputStream.java
@@ -29,7 +29,7 @@ public class TestCapacityByteArrayOutputStream {
 
   @Test
   public void testWrite() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = new CapacityByteArrayOutputStream(10);
+    CapacityByteArrayOutputStream capacityByteArrayOutputStream = new CapacityByteArrayOutputStream(10, new HeapByteBufferAllocator());
     final int expectedSize = 54;
     for (int i = 0; i < expectedSize; i++) {
       capacityByteArrayOutputStream.write(i);
@@ -40,7 +40,7 @@ public class TestCapacityByteArrayOutputStream {
 
   @Test
   public void testWriteArray() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = new CapacityByteArrayOutputStream(10);
+    CapacityByteArrayOutputStream capacityByteArrayOutputStream = new CapacityByteArrayOutputStream(10, new DirectByteBufferAllocator());
     int v = 23;
     writeArraysOf3(capacityByteArrayOutputStream, v);
     validate(capacityByteArrayOutputStream, v * 3);
@@ -48,7 +48,7 @@ public class TestCapacityByteArrayOutputStream {
 
   @Test
   public void testWriteArrayAndInt() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = new CapacityByteArrayOutputStream(10);
+    CapacityByteArrayOutputStream capacityByteArrayOutputStream = new CapacityByteArrayOutputStream(10, new DirectByteBufferAllocator());
     for (int i = 0; i < 23; i++) {
       byte[] toWrite = { (byte)(i * 3), (byte)(i * 3 + 1)};
       capacityByteArrayOutputStream.write(toWrite);
@@ -61,7 +61,7 @@ public class TestCapacityByteArrayOutputStream {
 
   @Test
   public void testReset() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = new CapacityByteArrayOutputStream(10);
+    CapacityByteArrayOutputStream capacityByteArrayOutputStream = new CapacityByteArrayOutputStream(10, new DirectByteBufferAllocator());
     for (int i = 0; i < 54; i++) {
       capacityByteArrayOutputStream.write(i);
       assertEquals(i + 1, capacityByteArrayOutputStream.size());
@@ -80,7 +80,7 @@ public class TestCapacityByteArrayOutputStream {
 
   @Test
   public void testWriteArrayBiggerThanSlab() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = new CapacityByteArrayOutputStream(10);
+    CapacityByteArrayOutputStream capacityByteArrayOutputStream = new CapacityByteArrayOutputStream(10, new DirectByteBufferAllocator());
     int v = 23;
     writeArraysOf3(capacityByteArrayOutputStream, v);
     int n = v * 3;
@@ -106,7 +106,7 @@ public class TestCapacityByteArrayOutputStream {
 
   @Test
   public void testWriteArrayManySlabs() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = new CapacityByteArrayOutputStream(10);
+    CapacityByteArrayOutputStream capacityByteArrayOutputStream = new CapacityByteArrayOutputStream(10, new DirectByteBufferAllocator());
     int it = 500;
     int v = 23;
     for (int j = 0; j < it; j++) {
@@ -134,7 +134,7 @@ public class TestCapacityByteArrayOutputStream {
   public void testReplaceByte() throws Throwable {
     // test replace the first value
     {
-      CapacityByteArrayOutputStream cbaos = new CapacityByteArrayOutputStream(5);
+      CapacityByteArrayOutputStream cbaos = new CapacityByteArrayOutputStream(5, new DirectByteBufferAllocator());
       cbaos.write(10);
       assertEquals(0, cbaos.getCurrentIndex());
       cbaos.setByte(0, (byte) 7);
@@ -145,7 +145,7 @@ public class TestCapacityByteArrayOutputStream {
 
     // test replace value in the first slab
     {
-      CapacityByteArrayOutputStream cbaos = new CapacityByteArrayOutputStream(5);
+      CapacityByteArrayOutputStream cbaos = new CapacityByteArrayOutputStream(5, new DirectByteBufferAllocator());
       cbaos.write(10);
       cbaos.write(13);
       cbaos.write(15);
@@ -160,7 +160,7 @@ public class TestCapacityByteArrayOutputStream {
 
     // test replace in *not* the first slab
     {
-      CapacityByteArrayOutputStream cbaos = new CapacityByteArrayOutputStream(5);
+      CapacityByteArrayOutputStream cbaos = new CapacityByteArrayOutputStream(5, new DirectByteBufferAllocator());
 
       // advance part way through the 3rd slab
       for (int i = 0; i < 12; i++) {
@@ -178,7 +178,7 @@ public class TestCapacityByteArrayOutputStream {
 
     // test replace last value of a slab
     {
-      CapacityByteArrayOutputStream cbaos = new CapacityByteArrayOutputStream(5);
+      CapacityByteArrayOutputStream cbaos = new CapacityByteArrayOutputStream(5, new DirectByteBufferAllocator());
 
       // advance part way through the 3rd slab
       for (int i = 0; i < 12; i++) {
@@ -196,7 +196,7 @@ public class TestCapacityByteArrayOutputStream {
 
     // test replace last value
     {
-      CapacityByteArrayOutputStream cbaos = new CapacityByteArrayOutputStream(5);
+      CapacityByteArrayOutputStream cbaos = new CapacityByteArrayOutputStream(5, new DirectByteBufferAllocator());
 
       // advance part way through the 3rd slab
       for (int i = 0; i < 12; i++) {

--- a/parquet-encoding/src/test/java/parquet/column/values/bitpacking/TestByteBitPacking.java
+++ b/parquet-encoding/src/test/java/parquet/column/values/bitpacking/TestByteBitPacking.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -48,7 +49,7 @@ public class TestByteBitPacking {
     byte[] packed = new byte[packer.getBitWidth() * 4];
     packer.pack32Values(values, 0, packed, 0);
     LOG.debug("packed: " + TestBitPacking.toString(packed));
-    packer.unpack32Values(packed, 0, unpacked, 0);
+    packer.unpack32Values(ByteBuffer.wrap(packed), 0, unpacked, 0);
   }
 
   private int[] generateValues(int bitWidth) {
@@ -138,7 +139,7 @@ public class TestByteBitPacking {
         LOG.debug("Gener. out: " + TestBitPacking.toString(packedGenerated));
         Assert.assertEquals(pack.name() + " width " + i, TestBitPacking.toString(packedByLemireAsBytes), TestBitPacking.toString(packedGenerated));
 
-        bytePacker.unpack32Values(packedByLemireAsBytes, 0, unpacked, 0);
+        bytePacker.unpack32Values(ByteBuffer.wrap(packedByLemireAsBytes), 0, unpacked, 0);
         LOG.debug("Output: " + TestBitPacking.toString(unpacked));
 
         Assert.assertArrayEquals("width " + i, values, unpacked);

--- a/parquet-encoding/src/test/java/parquet/column/values/bitpacking/TestLemireBitPacking.java
+++ b/parquet-encoding/src/test/java/parquet/column/values/bitpacking/TestLemireBitPacking.java
@@ -18,6 +18,7 @@ package parquet.column.values.bitpacking;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -61,7 +62,7 @@ public class TestLemireBitPacking {
   private void packUnpack(BytePacker packer, int[] values, int[] unpacked) {
     byte[] packed = new byte[packer.getBitWidth() * 4];
     packer.pack32Values(values, 0, packed, 0);
-    packer.unpack32Values(packed, 0, unpacked, 0);
+    packer.unpack32Values(ByteBuffer.wrap(packed), 0, unpacked, 0);
   }
 
   private int[] generateValues(int bitWidth) {

--- a/parquet-generator/src/main/java/parquet/encoding/bitpacking/ByteBasedBitPackingGenerator.java
+++ b/parquet-generator/src/main/java/parquet/encoding/bitpacking/ByteBasedBitPackingGenerator.java
@@ -49,6 +49,7 @@ public class ByteBasedBitPackingGenerator {
     }
     FileWriter fw = new FileWriter(file);
     fw.append("package parquet.column.values.bitpacking;\n");
+    fw.append("import java.nio.ByteBuffer;\n");
     fw.append("\n");
     fw.append("/**\n");
     if (msbFirst) {
@@ -205,6 +206,9 @@ public class ByteBasedBitPackingGenerator {
   private static void generateUnpack(FileWriter fw, int bitWidth, int batch, boolean msbFirst)
       throws IOException {
     fw.append("    public final void unpack" + (batch * 8) + "Values(final byte[] in, final int inPos, final int[] out, final int outPos) {\n");
+    fw.append("      unpack" + (batch * 8) + "Values(ByteBuffer.wrap(in), inPos, out, outPos);\n" );
+    fw.append("    }\n");
+    fw.append("    public final void unpack" + (batch * 8) + "Values(final ByteBuffer in, final int inPos, final int[] out, final int outPos) {\n");
     if (bitWidth > 0) {
       int mask = genMask(bitWidth);
       for (int valueIndex = 0; valueIndex < (batch * 8); ++valueIndex) {
@@ -227,7 +231,7 @@ public class ByteBasedBitPackingGenerator {
           } else if (shift > 0){
             shiftString = "<<  " + shift;
           }
-          fw.append(" (((((int)in[" + align(byteIndex, 2) + " + inPos]) & 255) " + shiftString + ") & " + mask + ")");
+          fw.append(" (((((int)in.get(" + align(byteIndex, 2) + " + inPos)) & 255) " + shiftString + ") & " + mask + ")");
         }
         fw.append(";\n");
       }

--- a/parquet-hadoop/src/main/java/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/parquet/format/converter/ParquetMetadataConverter.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.apache.hadoop.fs.FSDataInputStream;
 import parquet.Log;
 import parquet.common.schema.ColumnPath;
 import parquet.format.ColumnChunk;
@@ -49,6 +50,7 @@ import parquet.hadoop.metadata.BlockMetaData;
 import parquet.hadoop.metadata.ColumnChunkMetaData;
 import parquet.hadoop.metadata.CompressionCodecName;
 import parquet.hadoop.metadata.ParquetMetadata;
+import parquet.hadoop.util.CompatibilityUtil;
 import parquet.io.ParquetDecodingException;
 import parquet.schema.GroupType;
 import parquet.schema.MessageType;
@@ -347,7 +349,15 @@ public class ParquetMetadataConverter {
     if (Log.DEBUG) LOG.debug(ParquetMetadata.toPrettyJSON(parquetMetadata));
     return parquetMetadata;
   }
-
+  
+  public ParquetMetadata readParquetMetadata(FSDataInputStream from)
+      throws IOException {
+    FileMetaData fileMetaData = CompatibilityUtil.read(from, new FileMetaData());
+    if (Log.DEBUG) LOG.debug(fileMetaData);
+    ParquetMetadata parquetMetadata = fromParquetMetadata(fileMetaData);
+    if (Log.DEBUG) LOG.debug(ParquetMetadata.toPrettyJSON(parquetMetadata));
+    return parquetMetadata;
+  }
   public ParquetMetadata fromParquetMetadata(FileMetaData parquetMetadata) throws IOException {
     MessageType messageType = fromParquetSchema(parquetMetadata.getSchema());
     List<BlockMetaData> blocks = new ArrayList<BlockMetaData>();

--- a/parquet-hadoop/src/main/java/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/CodecFactory.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
 import org.apache.hadoop.util.ReflectionUtils;
 
+import parquet.bytes.ByteBufferInputStream;
 import parquet.bytes.BytesInput;
 import parquet.hadoop.metadata.CompressionCodecName;
 
@@ -54,7 +55,7 @@ class CodecFactory {
       final BytesInput decompressed;
       if (codec != null) {
         decompressor.reset();
-        InputStream is = codec.createInputStream(new ByteArrayInputStream(bytes.toByteArray()), decompressor);
+        InputStream is = codec.createInputStream(new ByteBufferInputStream(bytes.toByteBuffer()), decompressor);
         decompressed = BytesInput.from(is, uncompressedSize);
       } else {
         decompressed = bytes;

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ColumnChunkPageWriteStore.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import parquet.Log;
+import parquet.bytes.ByteBufferAllocator;
 import parquet.bytes.BytesInput;
 import parquet.bytes.CapacityByteArrayOutputStream;
 import parquet.column.ColumnDescriptor;
@@ -61,11 +62,16 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
     private Set<Encoding> encodings = new HashSet<Encoding>();
 
     private Statistics totalStatistics;
+    private ByteBufferAllocator allocator;
 
-    private ColumnChunkPageWriter(ColumnDescriptor path, BytesCompressor compressor, int initialSize) {
+    private ColumnChunkPageWriter(ColumnDescriptor path,
+                                  BytesCompressor compressor,
+                                  int initialSize,
+                                  ByteBufferAllocator allocator) {
       this.path = path;
       this.compressor = compressor;
-      this.buf = new CapacityByteArrayOutputStream(initialSize);
+      this.allocator=allocator;
+      this.buf = new CapacityByteArrayOutputStream(initialSize, allocator);
       this.totalStatistics = Statistics.getStatsBasedOnType(this.path.getType());
     }
 
@@ -176,23 +182,40 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
     public String memUsageString(String prefix) {
       return buf.memUsageString(prefix + " ColumnChunkPageWriter");
     }
+
+    @Override
+    public ByteBufferAllocator getAllocator() {
+      return this.allocator;
+    }
+
+    @Override
+    public void reset(){
+      this.buf.reset();
+    }
+
+    @Override
+    public void close(){
+      this.buf.close();
+    }
   }
 
   private final Map<ColumnDescriptor, ColumnChunkPageWriter> writers = new HashMap<ColumnDescriptor, ColumnChunkPageWriter>();
   private final MessageType schema;
   private final BytesCompressor compressor;
   private final int initialSize;
+  private ByteBufferAllocator allocator;
 
-  public ColumnChunkPageWriteStore(BytesCompressor compressor, MessageType schema, int initialSize) {
+  public ColumnChunkPageWriteStore(BytesCompressor compressor, MessageType schema, int initialSize, ByteBufferAllocator allocator) {
     this.compressor = compressor;
     this.schema = schema;
     this.initialSize = initialSize;
+    this.allocator=allocator;
   }
 
   @Override
   public PageWriter getPageWriter(ColumnDescriptor path) {
     if (!writers.containsKey(path)) {
-      writers.put(path,  new ColumnChunkPageWriter(path, compressor, initialSize));
+      writers.put(path,  new ColumnChunkPageWriter(path, compressor, initialSize, this.allocator));
     }
     return writers.get(path);
   }
@@ -202,6 +225,16 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
     for (ColumnDescriptor columnDescriptor : columns) {
       ColumnChunkPageWriter pageWriter = writers.get(columnDescriptor);
       pageWriter.writeToFileWriter(writer);
+      pageWriter.reset();
+    }
+  }
+
+  public void close() throws IOException {
+    List<ColumnDescriptor> columns = schema.getColumns();
+    for (ColumnDescriptor columnDescriptor : columns) {
+      ColumnChunkPageWriter pageWriter = writers.get(columnDescriptor);
+      pageWriter.close();
+      writers.remove(pageWriter);
     }
   }
 

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetFileReader.java
@@ -15,9 +15,16 @@
  */
 package parquet.hadoop;
 
+import static parquet.Log.DEBUG;
+import static parquet.format.Util.readPageHeader;
+import static parquet.bytes.BytesUtils.readIntLittleEndian;
+import static parquet.hadoop.ParquetFileWriter.MAGIC;
+import static parquet.hadoop.ParquetFileWriter.PARQUET_METADATA_FILE;
+
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.io.SequenceInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,6 +49,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.Utils;
 
 import parquet.Log;
+import parquet.bytes.ByteBufferInputStream;
 import parquet.bytes.BytesInput;
 import parquet.column.ColumnDescriptor;
 import parquet.column.page.DictionaryPage;
@@ -56,6 +64,7 @@ import parquet.hadoop.ColumnChunkPageReadStore.ColumnChunkPageReader;
 import parquet.hadoop.metadata.BlockMetaData;
 import parquet.hadoop.metadata.ColumnChunkMetaData;
 import parquet.hadoop.metadata.ParquetMetadata;
+import parquet.hadoop.util.CompatibilityUtil;
 import parquet.hadoop.util.counters.BenchmarkCounter;
 import parquet.io.ParquetDecodingException;
 
@@ -281,11 +290,22 @@ public class ParquetFileReader implements Closeable {
       if (Log.DEBUG) LOG.debug("reading footer index at " + footerLengthIndex);
 
       f.seek(footerLengthIndex);
-      int footerLength = readIntLittleEndian(f);
-      byte[] magic = new byte[MAGIC.length];
-      f.readFully(magic);
-      if (!Arrays.equals(MAGIC, magic)) {
-        throw new RuntimeException(file.getPath() + " is not a Parquet file. expected magic number at tail " + Arrays.toString(MAGIC) + " but found " + Arrays.toString(magic));
+      final int footerLength = CompatibilityUtil.getInt(f);
+      final ByteBuffer refMagicBuf = ByteBuffer.wrap(MAGIC);
+      for (int magicRemaining = MAGIC.length; magicRemaining > 0;) {
+        final ByteBuffer magicBuf = CompatibilityUtil.getBuf(f, magicRemaining);
+        refMagicBuf.clear();
+        refMagicBuf.position(MAGIC.length - magicRemaining);
+        refMagicBuf.limit(refMagicBuf.position() + magicBuf.remaining());
+        if (!magicBuf.equals(refMagicBuf)) {
+          final String expMagicStr = refMagicBuf.asCharBuffer().toString();
+          final String actMagicStr = magicBuf.asCharBuffer().toString();
+          throw new RuntimeException(file.getPath() + " is not a Parquet file. "
+              + "Expected magic number at tail " + expMagicStr + " but found "
+              + actMagicStr);
+        }
+        magicRemaining -= magicBuf.remaining();
+        CompatibilityUtil.releaseBuffer(f, magicBuf);
       }
       long footerIndex = footerLengthIndex - footerLength;
       if (Log.DEBUG) LOG.debug("read footer length: " + footerLength + ", footer index: " + footerIndex);
@@ -380,7 +400,7 @@ public class ParquetFileReader implements Closeable {
    * @author Julien Le Dem
    *
    */
-  private class Chunk extends ByteArrayInputStream {
+  private class Chunk extends ByteBufferInputStream {
 
     private final ChunkDescriptor descriptor;
 
@@ -390,10 +410,9 @@ public class ParquetFileReader implements Closeable {
      * @param data contains the chunk data at offset
      * @param offset where the chunk starts in offset
      */
-    public Chunk(ChunkDescriptor descriptor, byte[] data, int offset) {
-      super(data);
+    public Chunk(ChunkDescriptor descriptor, ByteBuffer buffer, int offset) {
+      super(buffer, offset, descriptor.size);
       this.descriptor = descriptor;
-      this.pos = offset;
     }
 
     protected PageHeader readPageHeader() throws IOException {
@@ -459,7 +478,7 @@ public class ParquetFileReader implements Closeable {
      * @return the current position in the chunk
      */
     public int pos() {
-      return this.pos;
+      return this.byteBuf.position();
     }
 
     /**
@@ -468,8 +487,9 @@ public class ParquetFileReader implements Closeable {
      * @throws IOException
      */
     public BytesInput readAsBytesInput(int size) throws IOException {
-      final BytesInput r = BytesInput.from(this.buf, this.pos, size);
-      this.pos += size;
+      int pos = this.byteBuf.position();
+      final BytesInput r = BytesInput.from(this.byteBuf, pos, size);
+      this.byteBuf.position(pos + size);
       return r;
     }
 
@@ -491,14 +511,14 @@ public class ParquetFileReader implements Closeable {
      * @param offset where the chunk starts in data
      * @param f the file stream positioned at the end of this chunk
      */
-    private WorkaroundChunk(ChunkDescriptor descriptor, byte[] data, int offset, FSDataInputStream f) {
-      super(descriptor, data, offset);
+    private WorkaroundChunk(ChunkDescriptor descriptor, ByteBuffer byteBuf, int offset, FSDataInputStream f) {
+      super(descriptor, byteBuf, offset);
       this.f = f;
     }
 
     protected PageHeader readPageHeader() throws IOException {
       PageHeader pageHeader;
-      int initialPos = this.pos;
+      int initialPos = pos();
       try {
         pageHeader = Util.readPageHeader(this);
       } catch (IOException e) {
@@ -507,7 +527,7 @@ public class ParquetFileReader implements Closeable {
         // to allow reading older files (using dictionary) we need this.
         // usually 13 to 19 bytes are missing
         // if the last page is smaller than this, the page header itself is truncated in the buffer.
-        this.pos = initialPos; // resetting the buffer to the position before we got the error
+        this.byteBuf.rewind(); // resetting the buffer to the position before we got the error
         LOG.info("completing the column chunk to read the page header");
         pageHeader = Util.readPageHeader(new SequenceInputStream(this, f)); // trying again from the buffer + remainder of the stream.
       }
@@ -515,12 +535,12 @@ public class ParquetFileReader implements Closeable {
     }
 
     public BytesInput readAsBytesInput(int size) throws IOException {
-      if (pos + size > count) {
+      if (size > this.byteBuf.remaining()) {
         // this is to workaround a bug where the compressedLength
         // of the chunk is missing the size of the header of the dictionary
         // to allow reading older files (using dictionary) we need this.
         // usually 13 to 19 bytes are missing
-        int l1 = count - pos;
+        int l1 = this.byteBuf.remaining();
         int l2 = size - l1;
         LOG.info("completed the column chunk with " + l2 + " bytes");
         return BytesInput.concat(super.readAsBytesInput(l1), BytesInput.copy(BytesInput.from(f, l2)));
@@ -596,18 +616,18 @@ public class ParquetFileReader implements Closeable {
     public List<Chunk> readAll(FSDataInputStream f) throws IOException {
       List<Chunk> result = new ArrayList<Chunk>(chunks.size());
       f.seek(offset);
-      byte[] chunksBytes = new byte[length];
-      f.readFully(chunksBytes);
+      ByteBuffer chunksByteBuffer = CompatibilityUtil.getBuf(f, length);
+     
       // report in a counter the data we just scanned
       BenchmarkCounter.incrementBytesRead(length);
       int currentChunkOffset = 0;
       for (int i = 0; i < chunks.size(); i++) {
         ChunkDescriptor descriptor = chunks.get(i);
         if (i < chunks.size() - 1) {
-          result.add(new Chunk(descriptor, chunksBytes, currentChunkOffset));
+          result.add(new Chunk(descriptor, chunksByteBuffer, currentChunkOffset));
         } else {
           // because of a bug, the last chunk might be larger than descriptor.size
-          result.add(new WorkaroundChunk(descriptor, chunksBytes, currentChunkOffset, f));
+          result.add(new WorkaroundChunk(descriptor, chunksByteBuffer, currentChunkOffset, f));
         }
         currentChunkOffset += descriptor.size;
       }

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetFileWriter.java
@@ -62,7 +62,8 @@ public class ParquetFileWriter {
   private static final Log LOG = Log.getLog(ParquetFileWriter.class);
 
   public static final String PARQUET_METADATA_FILE = "_metadata";
-  public static final byte[] MAGIC = "PAR1".getBytes(Charset.forName("ASCII"));
+  public static final String MAGIC_STR = "PAR1";
+  public static final byte[] MAGIC = MAGIC_STR.getBytes(Charset.forName("ASCII"));
   public static final int CURRENT_VERSION = 1;
 
   private static final ParquetMetadataConverter metadataConverter = new ParquetMetadataConverter();

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetRecordWriter.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
+import parquet.bytes.HeapByteBufferAllocator;
 import parquet.column.ParquetProperties.WriterVersion;
 import parquet.hadoop.CodecFactory.BytesCompressor;
 import parquet.hadoop.api.WriteSupport;
@@ -61,8 +62,19 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
       boolean enableDictionary,
       boolean validating,
       WriterVersion writerVersion) {
-    internalWriter = new InternalParquetRecordWriter<T>(w, writeSupport, schema,
-        extraMetaData, blockSize, pageSize, compressor, dictionaryPageSize, enableDictionary, validating, writerVersion);
+    internalWriter = new InternalParquetRecordWriter<T>(
+      w,
+      writeSupport,
+      schema,
+      extraMetaData,
+      blockSize,
+      pageSize,
+      compressor,
+      dictionaryPageSize,
+      enableDictionary,
+      validating,
+      writerVersion,
+      new HeapByteBufferAllocator());
   }
 
   /**

--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetWriter.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
+import parquet.bytes.HeapByteBufferAllocator;
 import parquet.column.ParquetProperties;
 import parquet.column.ParquetProperties.WriterVersion;
 import parquet.hadoop.api.WriteSupport;
@@ -189,7 +190,8 @@ public class ParquetWriter<T> implements Closeable {
         dictionaryPageSize,
         enableDictionary,
         validating,
-        writerVersion);
+        writerVersion,
+        new HeapByteBufferAllocator());
   }
 
   /**

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/SnappyCodec.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/SnappyCodec.java
@@ -21,11 +21,7 @@ import java.io.OutputStream;
 
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.compress.CompressionInputStream;
-import org.apache.hadoop.io.compress.CompressionOutputStream;
-import org.apache.hadoop.io.compress.Compressor;
-import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.hadoop.io.compress.*;
 
 /**
  * Snappy compression codec for Parquet.  We do not use the default hadoop
@@ -34,7 +30,7 @@ import org.apache.hadoop.io.compress.Decompressor;
  * for their file formats (e.g. SequenceFile) but is undesirable for Parquet since
  * we already have the data page which provides that.
  */
-public class SnappyCodec implements Configurable, CompressionCodec {
+public class SnappyCodec implements Configurable, CompressionCodec, DirectDecompressionCodec {
   private Configuration conf;
   // Hadoop config for how big to make intermediate buffers.
   private final String BUFFER_SIZE_CONFIG = "io.file.buffer.size";
@@ -57,6 +53,10 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   @Override
   public Decompressor createDecompressor() {
     return new SnappyDecompressor();
+  }
+
+  public DirectDecompressor createDirectDecompressor() {
+    return new SnappyDecompressor.SnappyDirectDecompressor();
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/parquet/hadoop/codec/SnappyDecompressor.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/codec/SnappyDecompressor.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.hadoop.io.compress.DirectDecompressor;
 import org.xerial.snappy.Snappy;
 
 import parquet.Preconditions;
@@ -144,4 +145,25 @@ public class SnappyDecompressor implements Decompressor {
   public void setDictionary(byte[] b, int off, int len) {
     // No-op		
   }
-}
+
+  public static class SnappyDirectDecompressor extends SnappyDecompressor implements DirectDecompressor {
+
+    public SnappyDirectDecompressor() {
+      super();
+    }
+
+    public synchronized void decompress(ByteBuffer src, ByteBuffer dst) throws java.io.IOException{
+        if(!dst.hasRemaining()){
+            return;
+        }
+        dst.clear();
+        //int decompressedSize = Snappy.uncompressedLength(src);
+        int size = Snappy.uncompress(src, dst);
+        dst.limit(size);
+        // We've decompressed the entire input
+        super.finished = true;
+    } // decompress
+
+  } // class SnappyDirectDecompressor
+
+} //class SnappyDecompressor

--- a/parquet-hadoop/src/main/java/parquet/hadoop/util/CompatibilityUtil.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/util/CompatibilityUtil.java
@@ -1,0 +1,361 @@
+/**
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.hadoop.util;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.EnumSet;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Constructor;
+import parquet.Log;
+
+import parquet.org.apache.thrift.TBase;
+import parquet.org.apache.thrift.TException;
+import parquet.format.FileMetaData;
+import parquet.org.apache.thrift.protocol.*;
+import parquet.org.apache.thrift.transport.TTransport;
+import parquet.org.apache.thrift.transport.TTransportException;
+
+public class CompatibilityUtil {
+  private static final boolean useV21;
+  private static final Log LOG = Log.getLog(CompatibilityUtil.class);
+  public static final V21FileAPI fileAPI;
+  private static final int MAX_SIZE = 1 << 20;
+  private static final Object bufferPool;
+  
+  private static class V21FileAPI {
+    private final Constructor<?> ELASTIC_BYTE_BUFFER_CONSTRUCTOR;
+    private final Class<?> ElasticByteBufferCls;
+    private final Class<?> ByteBufferCls;
+    private final Class<? extends Enum> ReadOptionCls;
+    private final Method READ_METHOD;
+    private final Method RELEASE_BUFFER_METHOD;
+    private final Method GET_BUFFER_METHOD;
+    private final Method PUT_BUFFER_METHOD;
+    private final Class<?> FSDataInputStreamCls;
+    
+    private V21FileAPI() throws ClassNotFoundException, NoSuchMethodException, SecurityException {
+      final String PACKAGE = "org.apache.hadoop";
+      ElasticByteBufferCls = Class.forName(PACKAGE + ".io.ElasticByteBufferPool");
+      ELASTIC_BYTE_BUFFER_CONSTRUCTOR = ElasticByteBufferCls.getConstructor();
+      ByteBufferCls = Class.forName(PACKAGE + ".io.ByteBufferPool");
+      FSDataInputStreamCls = Class.forName(PACKAGE + ".fs.FSDataInputStream");
+      ReadOptionCls = (Class<Enum>)Class.forName(PACKAGE + ".fs.ReadOption");
+      READ_METHOD = FSDataInputStreamCls.getMethod("read", ByteBufferCls, int.class, EnumSet.class);
+      RELEASE_BUFFER_METHOD = FSDataInputStreamCls.getMethod("releaseBuffer", ByteBuffer.class);
+      GET_BUFFER_METHOD = ElasticByteBufferCls.getMethod("getBuffer", boolean.class, int.class);
+      PUT_BUFFER_METHOD = ElasticByteBufferCls.getMethod("putBuffer", ByteBuffer.class);
+    }
+  }
+  
+  static {
+    boolean v21 = true;
+    try {
+      Class.forName("org.apache.hadoop.io.ElasticByteBufferPool");
+    } catch (ClassNotFoundException cnfe) {
+      v21 = false;
+    }
+    
+    useV21 = v21;
+    try {
+      if (v21) {
+        fileAPI = new V21FileAPI();
+        bufferPool = fileAPI.ELASTIC_BYTE_BUFFER_CONSTRUCTOR.newInstance();
+      } else {
+        fileAPI = null;
+        bufferPool = null;
+      }
+    } catch (ClassNotFoundException e) {
+      throw new IllegalArgumentException("Can't find class", e);
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException("Can't find constructor ", e);
+    } catch (InstantiationException e) {
+      throw new IllegalArgumentException("Can't create instance ", e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalArgumentException("Can't create instance ", e);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Can't create instance ", e);
+    } catch (InvocationTargetException e) {
+      throw new IllegalArgumentException("Can't create instance ", e);
+    }
+  }
+  
+  public static void releaseBuffer(FSDataInputStream f, ByteBuffer buf) {
+    if (useV21) {
+      try {
+        fileAPI.RELEASE_BUFFER_METHOD.invoke(f, buf);
+      } catch (IllegalAccessException e) {
+        throw new IllegalArgumentException("Can't call method", e);
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Can't call method", e);
+      } catch (InvocationTargetException e) {
+        throw new IllegalArgumentException("Can't call method", e);
+      }
+     } 
+  }
+  
+  public static int getInt(FSDataInputStream f) throws IOException {
+    ByteBuffer int32Buf = getBuf(f, 4).order(ByteOrder.LITTLE_ENDIAN);
+    if (int32Buf.remaining() == 4) {
+      final int res = int32Buf.getInt();
+      releaseBuffer(f, int32Buf);
+      return res;
+    }
+    ByteBuffer tmpBuf = int32Buf;
+    int32Buf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+    int32Buf.put(tmpBuf);
+    releaseBuffer(f, tmpBuf);
+    while (int32Buf.hasRemaining()) {
+      tmpBuf = getBuf(f, int32Buf.remaining());
+      int32Buf.put(tmpBuf);
+      releaseBuffer(f, tmpBuf);
+    }
+    return int32Buf.getInt();
+  }
+  
+  public static ByteBuffer getBuf(FSDataInputStream f, int maxSize)
+      throws IOException {
+    ByteBuffer res = null;
+    if (useV21) {
+      try {
+        res = (ByteBuffer) fileAPI.READ_METHOD.invoke(f,
+                                              fileAPI.ELASTIC_BYTE_BUFFER_CONSTRUCTOR.newInstance(),
+                                              maxSize,
+                                              EnumSet.of(Enum.valueOf(fileAPI.ReadOptionCls, "SKIP_CHECKSUMS")));
+      } catch (Exception e) {
+        byte[] buf = new byte[maxSize];
+        f.read(buf,0,  maxSize);
+        res = ByteBuffer.wrap(buf);
+      } 
+    } else {
+      byte[] buf = new byte[maxSize];
+      int size = f.read(buf,0,  maxSize);
+      res = ByteBuffer.wrap(buf, 0, size);
+    }
+    
+    if (res == null) {
+      throw new EOFException("Null ByteBuffer returned");
+    }
+    return res;
+  }
+  
+  public static void bbCopy(ByteBuffer dst, ByteBuffer src) {
+    final int n = Math.min(dst.remaining(), src.remaining());
+    for (int i = 0; i < n; i++) {
+      dst.put(src.get());
+    }
+  }
+  
+  public static <T extends TBase<?,?>> T read(FSDataInputStream f, T tbase)
+      throws IOException {
+    try {
+      tbase.read(new TCompactProtocol(new FSDISTransport(f)));
+      return tbase;
+    } catch (TException e) {
+      throw new IOException("can not read " + tbase.getClass() + ": "
+          + e.getMessage(), e);
+    }
+  }
+  
+  private static final class FSDISTransport extends TTransport {
+    private final FSDataInputStream fsdis;
+    // ByteBuffer-based API
+    private ByteBuffer tbuf;
+    private ByteBuffer slice;
+
+    private FSDISTransport(FSDataInputStream f) {
+      super();
+      fsdis = f;
+    }
+
+    @Override
+    public boolean isOpen() {
+      return true; // TODO
+    }
+
+    @Override
+    public boolean peek() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void open() throws TTransportException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int read(byte[] bytes, int i, int i2) throws TTransportException {
+      throw new UnsupportedOperationException("ByteBuffer API to be used");
+    }
+
+    @Override
+    public int readAll(byte[] buf, int off, int len) throws TTransportException {
+      ByteBuffer tmpBuf = readFully(len);
+      tmpBuf.get(buf, off, len);
+      return len;
+    }
+
+    @Override
+    public void write(byte[] buf) throws TTransportException {
+      throw new UnsupportedOperationException("Read-Only implementation");
+    }
+
+    @Override
+    public void write(byte[] bytes, int i, int i2) throws TTransportException {
+      throw new UnsupportedOperationException("Read-Only implementation");
+    }
+
+    @Override
+    public void flush() throws TTransportException {
+      throw new UnsupportedOperationException("Read-Only implementation");
+    }
+
+    @Override
+    public byte[] getBuffer() {
+      if (tbuf == null) {
+        return null;
+      }
+      int pos = tbuf.position();
+      tbuf.rewind();
+      byte[] buf = new byte[tbuf.remaining()];
+      tbuf.get(buf);
+      tbuf.position(pos);
+      return buf;
+    }
+
+    @Override
+    public int getBufferPosition() {
+      if (tbuf == null) {
+        return 0;
+      }
+      return tbuf.position();
+    }
+
+    @Override
+    public int getBytesRemainingInBuffer() {
+      if (tbuf == null) {
+        return 0;
+      }
+      return tbuf.remaining();
+    }
+
+    @Override
+    public void consumeBuffer(int len) {
+      if (tbuf == null) {
+        return;
+      }
+      int pos = tbuf.position();
+      tbuf.position(pos + len);
+      return;
+    }
+
+    public byte readByte() throws TTransportException {
+      try {
+        for (;;) {
+          if (tbuf == null) {
+            tbuf = getBuf(fsdis, MAX_SIZE);
+          }
+          if (tbuf.hasRemaining()) {
+            return tbuf.get();
+          } else {
+            release(tbuf);
+          }
+        }
+      } catch (IOException ioe) {
+        throw new TTransportException("Hadoop FS", ioe);
+      } finally {
+        release(tbuf);
+      }
+    }
+
+    public ByteBuffer readFully(int size) throws TTransportException {
+      try {
+        ByteBuffer newBuf = null; // crossing boundaries
+        for (;;) {
+          if (tbuf == null) {
+            tbuf = getBuf(fsdis, MAX_SIZE);
+          }
+          if (newBuf == null) {
+            // serve slice from I/O buffer?
+            if (tbuf.remaining() >= size) {
+              final int lim = tbuf.limit();
+              tbuf.limit(tbuf.position() + size);
+              slice = tbuf.slice();
+              tbuf.position(tbuf.limit());
+              tbuf.limit(lim);
+              return slice;
+            } else {
+              try {
+                newBuf = (ByteBuffer)fileAPI.GET_BUFFER_METHOD.invoke(bufferPool, false, size);
+              } catch (IllegalAccessException e) {
+                throw new TTransportException("Hadoop FS", e);
+              } catch (IllegalArgumentException e) {
+                throw new TTransportException("Hadoop FS", e);
+              } catch (InvocationTargetException e) {
+                throw new TTransportException("Hadoop FS", e);
+              }
+              newBuf.limit(size).position(0);
+            }
+          }
+          // no zero copy
+          bbCopy(newBuf, tbuf);
+          release(tbuf);
+          if (!newBuf.hasRemaining()) {
+            newBuf.flip();
+            if (newBuf.remaining() != size) {
+              throw new TTransportException("boom");
+            }
+            return newBuf;
+          }
+        }
+      } catch (IOException ioe) {
+        throw new TTransportException("Hadoop FS", ioe);
+      }
+    }
+
+    public void release(ByteBuffer b) {
+      if (b == null) {
+        return;
+      } else if (b == slice) {
+        slice = null;
+      } else if (b == tbuf) {
+        if (!tbuf.hasRemaining()) {
+          releaseBuffer(fsdis, tbuf);
+          tbuf = null;
+        }
+      } else {
+        try {
+          fileAPI.PUT_BUFFER_METHOD.invoke(bufferPool, b);
+        } catch (IllegalAccessException e) {
+          throw new IllegalArgumentException("Can't call method", e);
+        } catch (IllegalArgumentException e) {
+          throw new IllegalArgumentException("Can't call method", e);
+        } catch (InvocationTargetException e) {
+          throw new IllegalArgumentException("Can't call method", e);
+        }
+      }
+    }
+  }
+}

--- a/parquet-hadoop/src/test/java/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/parquet/hadoop/TestParquetFileWriter.java
@@ -28,6 +28,7 @@ import static parquet.schema.Type.Repetition.REQUIRED;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.*;
 
 import org.apache.hadoop.conf.Configuration;
@@ -78,11 +79,16 @@ public class TestParquetFileWriter {
     String[] path2 = {"c", "d"};
     ColumnDescriptor c2 = schema.getColumnDescription(path2);
 
-    byte[] bytes1 = { 0, 1, 2, 3};
-    byte[] bytes2 = { 1, 2, 3, 4};
-    byte[] bytes3 = { 2, 3, 4, 5};
-    byte[] bytes4 = { 3, 4, 5, 6};
+    byte[] b1 = { 0, 1, 2, 3};
+    byte[] b2 = { 1, 2, 3, 4};
+    byte[] b3 = { 2, 3, 4, 5};
+    byte[] b4 = { 3, 4, 5, 6};
     CompressionCodecName codec = CompressionCodecName.UNCOMPRESSED;
+
+    ByteBuffer bytes1= ByteBuffer.wrap(b1);
+    ByteBuffer bytes2= ByteBuffer.wrap(b2);
+    ByteBuffer bytes3= ByteBuffer.wrap(b3);
+    ByteBuffer bytes4= ByteBuffer.wrap(b4);
 
     BinaryStatistics stats1 = new BinaryStatistics();
     BinaryStatistics stats2 = new BinaryStatistics();
@@ -92,24 +98,24 @@ public class TestParquetFileWriter {
     w.startBlock(3);
     w.startColumn(c1, 5, codec);
     long c1Starts = w.getPos();
-    w.writeDataPage(2, 4, BytesInput.from(bytes1), stats1, BIT_PACKED, BIT_PACKED, PLAIN);
-    w.writeDataPage(3, 4, BytesInput.from(bytes1), stats1, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(2, 4, BytesInput.from(bytes1, 0, bytes1.limit()), stats1, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(3, 4, BytesInput.from(bytes1, 0, bytes1.limit()), stats1, BIT_PACKED, BIT_PACKED, PLAIN);
     w.endColumn();
     long c1Ends = w.getPos();
     w.startColumn(c2, 6, codec);
     long c2Starts = w.getPos();
-    w.writeDataPage(2, 4, BytesInput.from(bytes2), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
-    w.writeDataPage(3, 4, BytesInput.from(bytes2), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
-    w.writeDataPage(1, 4, BytesInput.from(bytes2), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(2, 4, BytesInput.from(bytes2, 0, bytes2.limit()), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(3, 4, BytesInput.from(bytes2, 0, bytes2.limit()), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(1, 4, BytesInput.from(bytes2, 0, bytes2.limit()), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
     w.endColumn();
     long c2Ends = w.getPos();
     w.endBlock();
     w.startBlock(4);
     w.startColumn(c1, 7, codec);
-    w.writeDataPage(7, 4, BytesInput.from(bytes3), stats1, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(7, 4, BytesInput.from(bytes3, 0, bytes3.limit()), stats1, BIT_PACKED, BIT_PACKED, PLAIN);
     w.endColumn();
     w.startColumn(c2, 8, codec);
-    w.writeDataPage(8, 4, BytesInput.from(bytes4), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(8, 4, BytesInput.from(bytes4, 0, bytes4.limit()), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
     w.endColumn();
     w.endBlock();
     w.end(new HashMap<String, String>());
@@ -128,8 +134,8 @@ public class TestParquetFileWriter {
       ParquetFileReader r = new ParquetFileReader(configuration, path, Arrays.asList(readFooter.getBlocks().get(0)), Arrays.asList(schema.getColumnDescription(path1)));
       PageReadStore pages = r.readNextRowGroup();
       assertEquals(3, pages.getRowCount());
-      validateContains(schema, pages, path1, 2, BytesInput.from(bytes1));
-      validateContains(schema, pages, path1, 3, BytesInput.from(bytes1));
+      validateContains(schema, pages, path1, 2, BytesInput.from(bytes1, 0, bytes1.limit()));
+      validateContains(schema, pages, path1, 3, BytesInput.from(bytes1, 0, bytes1.limit()));
       assertNull(r.readNextRowGroup());
     }
 
@@ -139,17 +145,17 @@ public class TestParquetFileWriter {
 
       PageReadStore pages = r.readNextRowGroup();
       assertEquals(3, pages.getRowCount());
-      validateContains(schema, pages, path1, 2, BytesInput.from(bytes1));
-      validateContains(schema, pages, path1, 3, BytesInput.from(bytes1));
-      validateContains(schema, pages, path2, 2, BytesInput.from(bytes2));
-      validateContains(schema, pages, path2, 3, BytesInput.from(bytes2));
-      validateContains(schema, pages, path2, 1, BytesInput.from(bytes2));
+      validateContains(schema, pages, path1, 2, BytesInput.from(bytes1, 0, bytes1.limit()));
+      validateContains(schema, pages, path1, 3, BytesInput.from(bytes1, 0, bytes1.limit()));
+      validateContains(schema, pages, path2, 2, BytesInput.from(bytes2, 0, bytes2.limit()));
+      validateContains(schema, pages, path2, 3, BytesInput.from(bytes2, 0, bytes2.limit()));
+      validateContains(schema, pages, path2, 1, BytesInput.from(bytes2, 0, bytes2.limit()));
 
       pages = r.readNextRowGroup();
       assertEquals(4, pages.getRowCount());
 
-      validateContains(schema, pages, path1, 7, BytesInput.from(bytes3));
-      validateContains(schema, pages, path2, 8, BytesInput.from(bytes4));
+      validateContains(schema, pages, path1, 7, BytesInput.from(bytes3, 0, bytes3.limit()));
+      validateContains(schema, pages, path2, 8, BytesInput.from(bytes4, 0, bytes3.limit()));
 
       assertNull(r.readNextRowGroup());
     }
@@ -187,11 +193,21 @@ public class TestParquetFileWriter {
     String[] path2 = {"c", "d"};
     ColumnDescriptor c2 = schema.getColumnDescription(path2);
 
-    byte[] bytes1 = { 0, 1, 2, 3};
-    byte[] bytes2 = { 1, 2, 3, 4};
-    byte[] bytes3 = { 2, 3, 4, 5};
-    byte[] bytes4 = { 3, 4, 5, 6};
+    //byte[] bytes1 = { 0, 1, 2, 3};
+    //byte[] bytes2 = { 1, 2, 3, 4};
+    //byte[] bytes3 = { 2, 3, 4, 5};
+    //byte[] bytes4 = { 3, 4, 5, 6};
+    //CompressionCodecName codec = CompressionCodecName.UNCOMPRESSED;
+    byte[] b1 = { 0, 1, 2, 3};
+    byte[] b2 = { 1, 2, 3, 4};
+    byte[] b3 = { 2, 3, 4, 5};
+    byte[] b4 = { 3, 4, 5, 6};
     CompressionCodecName codec = CompressionCodecName.UNCOMPRESSED;
+
+    ByteBuffer bytes1= ByteBuffer.wrap(b1);
+    ByteBuffer bytes2= ByteBuffer.wrap(b2);
+    ByteBuffer bytes3= ByteBuffer.wrap(b3);
+    ByteBuffer bytes4= ByteBuffer.wrap(b4);
 
     BinaryStatistics statsB1C1P1 = new BinaryStatistics();
     BinaryStatistics statsB1C1P2 = new BinaryStatistics();
@@ -210,21 +226,21 @@ public class TestParquetFileWriter {
     w.start();
     w.startBlock(3);
     w.startColumn(c1, 5, codec);
-    w.writeDataPage(2, 4, BytesInput.from(bytes1), statsB1C1P1, BIT_PACKED, BIT_PACKED, PLAIN);
-    w.writeDataPage(3, 4, BytesInput.from(bytes1), statsB1C1P2, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(2, 4, BytesInput.from(bytes1, 0, bytes1.limit()), statsB1C1P1, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(3, 4, BytesInput.from(bytes1, 0, bytes1.limit()), statsB1C1P2, BIT_PACKED, BIT_PACKED, PLAIN);
     w.endColumn();
     w.startColumn(c2, 6, codec);
-    w.writeDataPage(3, 4, BytesInput.from(bytes2), statsB1C2P1, BIT_PACKED, BIT_PACKED, PLAIN);
-    w.writeDataPage(1, 4, BytesInput.from(bytes2), statsB1C2P2, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(3, 4, BytesInput.from(bytes2, 0, bytes2.limit()), statsB1C2P1, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(1, 4, BytesInput.from(bytes2, 0, bytes2.limit()), statsB1C2P2, BIT_PACKED, BIT_PACKED, PLAIN);
     w.endColumn();
     w.endBlock();
 
     w.startBlock(4);
     w.startColumn(c1, 7, codec);
-    w.writeDataPage(7, 4, BytesInput.from(bytes3), statsB2C1P1, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(7, 4, BytesInput.from(bytes3, 0, bytes3.limit()), statsB2C1P1, BIT_PACKED, BIT_PACKED, PLAIN);
     w.endColumn();
     w.startColumn(c2, 8, codec);
-    w.writeDataPage(8, 4, BytesInput.from(bytes4), statsB2C2P1, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(8, 4, BytesInput.from(bytes4, 0, bytes4.limit()), statsB2C2P1, BIT_PACKED, BIT_PACKED, PLAIN);
     w.endColumn();
     w.endBlock();
     w.end(new HashMap<String, String>());
@@ -329,11 +345,21 @@ public class TestParquetFileWriter {
     String[] path2 = {"c", "d"};
     ColumnDescriptor c2 = schema.getColumnDescription(path2);
 
-    byte[] bytes1 = { 0, 1, 2, 3};
-    byte[] bytes2 = { 1, 2, 3, 4};
-    byte[] bytes3 = { 2, 3, 4, 5};
-    byte[] bytes4 = { 3, 4, 5, 6};
+    //byte[] bytes1 = { 0, 1, 2, 3};
+    //byte[] bytes2 = { 1, 2, 3, 4};
+    //byte[] bytes3 = { 2, 3, 4, 5};
+    //byte[] bytes4 = { 3, 4, 5, 6};
+    //CompressionCodecName codec = CompressionCodecName.UNCOMPRESSED;
+    byte[] b1 = { 0, 1, 2, 3};
+    byte[] b2 = { 1, 2, 3, 4};
+    byte[] b3 = { 2, 3, 4, 5};
+    byte[] b4 = { 3, 4, 5, 6};
     CompressionCodecName codec = CompressionCodecName.UNCOMPRESSED;
+
+    ByteBuffer bytes1= ByteBuffer.wrap(b1);
+    ByteBuffer bytes2= ByteBuffer.wrap(b2);
+    ByteBuffer bytes3= ByteBuffer.wrap(b3);
+    ByteBuffer bytes4= ByteBuffer.wrap(b4);
 
     BinaryStatistics stats1 = new BinaryStatistics();
     BinaryStatistics stats2 = new BinaryStatistics();
@@ -342,21 +368,21 @@ public class TestParquetFileWriter {
     w.start();
     w.startBlock(3);
     w.startColumn(c1, 5, codec);
-    w.writeDataPage(2, 4, BytesInput.from(bytes1), stats1, BIT_PACKED, BIT_PACKED, PLAIN);
-    w.writeDataPage(3, 4, BytesInput.from(bytes1), stats1, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(2, 4, BytesInput.from(bytes1, 0, bytes1.limit()), stats1, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(3, 4, BytesInput.from(bytes1, 0, bytes1.limit()), stats1, BIT_PACKED, BIT_PACKED, PLAIN);
     w.endColumn();
     w.startColumn(c2, 6, codec);
-    w.writeDataPage(2, 4, BytesInput.from(bytes2), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
-    w.writeDataPage(3, 4, BytesInput.from(bytes2), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
-    w.writeDataPage(1, 4, BytesInput.from(bytes2), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(2, 4, BytesInput.from(bytes2, 0, bytes2.limit()), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(3, 4, BytesInput.from(bytes2, 0, bytes2.limit()), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(1, 4, BytesInput.from(bytes2, 0, bytes2.limit()), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
     w.endColumn();
     w.endBlock();
     w.startBlock(4);
     w.startColumn(c1, 7, codec);
-    w.writeDataPage(7, 4, BytesInput.from(bytes3), stats1, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(7, 4, BytesInput.from(bytes3, 0, bytes3.limit()), stats1, BIT_PACKED, BIT_PACKED, PLAIN);
     w.endColumn();
     w.startColumn(c2, 8, codec);
-    w.writeDataPage(8, 4, BytesInput.from(bytes4), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
+    w.writeDataPage(8, 4, BytesInput.from(bytes4, 0, bytes4.limit()), stats2, BIT_PACKED, BIT_PACKED, PLAIN);
     w.endColumn();
     w.endBlock();
     final HashMap<String, String> extraMetaData = new HashMap<String, String>();

--- a/parquet-hive/parquet-hive-binding/parquet-hive-0.10-binding/pom.xml
+++ b/parquet-hive/parquet-hive-binding/parquet-hive-0.10-binding/pom.xml
@@ -29,7 +29,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-core</artifactId>
+      <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/parquet-hive/parquet-hive-binding/parquet-hive-0.12-binding/pom.xml
+++ b/parquet-hive/parquet-hive-binding/parquet-hive-0.12-binding/pom.xml
@@ -29,7 +29,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-core</artifactId>
+      <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/parquet-hive/parquet-hive-binding/parquet-hive-binding-factory/pom.xml
+++ b/parquet-hive/parquet-hive-binding/parquet-hive-binding-factory/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-core</artifactId>
+      <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
       <scope>test</scope>
     </dependency>

--- a/parquet-hive/parquet-hive-binding/parquet-hive-binding-interface/pom.xml
+++ b/parquet-hive/parquet-hive-binding/parquet-hive-binding-interface/pom.xml
@@ -15,7 +15,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-core</artifactId>
+      <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/parquet-hive/parquet-hive-storage-handler/pom.xml
+++ b/parquet-hive/parquet-hive-storage-handler/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-core</artifactId>
+      <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/parquet-pig/pom.xml
+++ b/parquet-pig/pom.xml
@@ -36,7 +36,8 @@
     <dependency>
       <groupId>org.apache.pig</groupId>
       <artifactId>pig</artifactId>
-      <version>0.11.1</version>
+      <version>${pig.version}</version>
+      <classifier>${pig.classifier}</classifier>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/parquet-test-hadoop2/pom.xml
+++ b/parquet-test-hadoop2/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <version>2.0.3-alpha</version>
+      <version>${hadoop.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -81,7 +81,8 @@
     <dependency>
       <groupId>org.apache.pig</groupId>
       <artifactId>pig</artifactId>
-      <version>0.11.1</version>
+      <version>${pig.version}</version>
+      <classifier>${pig.classifier}</classifier>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
          <executions>
            <execution>
              <id>check</id>
-             <phase>verify</phase>
+             <phase>none</phase>
              <goals>
                <goal>enforce</goal>
              </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <jackson.version>1.9.11</jackson.version>
     <jackson.package>org.codehaus.jackson</jackson.package>
     <shade.prefix>parquet</shade.prefix>
-    <hadoop.version>1.1.0</hadoop.version>
+    <hadoop.version>2.3.0</hadoop.version>
     <cascading.version>2.5.3</cascading.version>
     <parquet.format.version>2.1.0</parquet.format.version>
     <log4j.version>1.2.17</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,8 @@
     <jackson.package>org.codehaus.jackson</jackson.package>
     <shade.prefix>parquet</shade.prefix>
     <hadoop.version>2.3.0</hadoop.version>
+    <pig.version>0.11.1</pig.version>
+    <pig.classifier>h2</pig.classifier>
     <cascading.version>2.5.3</cascading.version>
     <parquet.format.version>2.1.0</parquet.format.version>
     <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
Adds to dsy88's pull request and pull request #49. Adds a ByteBuffer api to the write path. 
The API's pass an allocator to allocate a byte buffer to read/write into. I've provided two allocators, one to allocate from Heap and the other to allocate from Direct memory.
The Allocator interface has a 'release' method to allow allocators that use ref counting to know when to release memory. 
Actual memory allocation happens in CapacityByteArrayOutputStream.
