### PR TITLE
PARQUET-110: Pig schema bug

### DIFF
--- a/parquet-pig/src/test/java/parquet/pig/TestTupleConversion.java
+++ b/parquet-pig/src/test/java/parquet/pig/TestTupleConversion.java
@@ -1,0 +1,36 @@
+package parquet.pig;
+
+import org.apache.pig.impl.logicalLayer.schema.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+import parquet.schema.MessageType;
+import parquet.schema.MessageTypeParser;
+
+public class TestTupleConversion {
+  @Test
+  public void testSimple() throws Exception {
+    String parquetSchemaStr = "message FilterListAsBag {\n" +
+        "  optional group my_list (LIST) {\n" +
+        "    repeated group array {\n" +
+        "      optional group array_element {\n" +
+        "        required int32 num1;\n" +
+        "        required int32 num2;\n" +
+        "      }\n" +
+        "    }\n" +
+        "  }\n" +
+        "}\n";
+
+    PigSchemaConverter converter = new PigSchemaConverter();
+
+    MessageType parquetSchema = MessageTypeParser.parseMessageType(parquetSchemaStr);
+    Schema pigSchema = converter.convert(parquetSchema);
+
+    String intermediatePigSchemaStr = PigSchemaConverter.pigSchemaToString(pigSchema);
+    Schema reparsedSchema = PigSchemaConverter.parsePigSchema(intermediatePigSchemaStr);
+
+    MessageType projectedSchema = converter.filter(parquetSchema, reparsedSchema);
+
+    MessageTypeParser.parseMessageType(projectedSchema.toString());
+    Assert.assertEquals(parquetSchema, projectedSchema);
+  }
+}


### PR DESCRIPTION
Pig is removing some bags if they only have one element. To compensate
for this, when filtering tuples against the Pig schema, we have to
detect whether the bag is missing and filter the inner Parqet type
instead. This detects the situation when matching a bag and the inner
Parquet type is a repeated group with 1 element. If the inner Pig type
does not have a matching name, then this assumes it has been removed.