### PR TITLE
PARQUET-127: Point to Maven Central for Thrift artifacts.

### DIFF
--- a/parquet-cascading/pom.xml
+++ b/parquet-cascading/pom.xml
@@ -82,7 +82,7 @@
       <plugin>
         <groupId>org.apache.thrift.tools</groupId>
         <artifactId>maven-thrift-plugin</artifactId>
-        <version>0.1.10</version>
+        <version>0.1.11</version>
         <configuration>
           <thriftExecutable>${thrift.executable}</thriftExecutable>
         </configuration>

--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -110,7 +110,7 @@
         <plugin>
             <groupId>org.apache.thrift.tools</groupId>
             <artifactId>maven-thrift-plugin</artifactId>
-            <version>0.1.10</version>
+            <version>0.1.11</version>
             <configuration>
                 <thriftExecutable>${thrift.executable}</thriftExecutable>
             </configuration>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -97,7 +97,11 @@
       <version>3.4</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>0.9.1</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -113,7 +117,7 @@
       <plugin>
         <groupId>org.apache.thrift.tools</groupId>
         <artifactId>maven-thrift-plugin</artifactId>
-        <version>0.1.10</version>
+        <version>0.1.11</version>
         <configuration>
           <thriftExecutable>${thrift.executable}</thriftExecutable>
         </configuration>

--- a/parquet-thrift/src/main/java/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
+++ b/parquet-thrift/src/main/java/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
@@ -118,14 +118,6 @@ public class ThriftBytesWriteSupport extends WriteSupport<BytesWritable> {
 
   private TProtocol protocol(BytesWritable record) {
     TProtocol protocol = protocolFactory.getProtocol(new TIOStreamTransport(new ByteArrayInputStream(record.getBytes())));
-
-    /* Reduce the chance of OOM when data is corrupted. When readBinary is called on TBinaryProtocol, it reads the length of the binary first,
-     so if the data is corrupted, it could read a big integer as the length of the binary and therefore causes OOM to happen.
-     Currently this fix only applies to TBinaryProtocol which has the setReadLength defined.
-      */
-    if (protocol instanceof TBinaryProtocol) {
-      ((TBinaryProtocol)protocol).setReadLength(record.getLength());
-    }
     return protocol;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
       <name>Nexus Release Repository</name>
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
-
   </distributionManagement>
 
   <repositories>
@@ -64,15 +63,6 @@
       </snapshots>
      </repository>
   </repositories>
-
-  <!-- this is needed for maven-thrift-plugin, would like to remove this.
-   see: https://issues.apache.org/jira/browse/THRIFT-1536  -->
-  <pluginRepositories>
-    <pluginRepository>
-      <id>Twitter public Maven repo</id>
-      <url>http://maven.twttr.com</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <properties>
     <targetJavaVersion>1.6</targetJavaVersion>


### PR DESCRIPTION
Fixes [PARQUET-127](https://issues.apache.org/jira/browse/PARQUET-127) by updating several pom.xml's to point to the published Maven artifacts for thrift-tools and libthrift.
