### PR TITLE
PARQUET-128: Optimize the parquet RecordReader implementation when: A. filterpredicate is pushed down , B. filterpredicate is pushed down on a flat schema

### DIFF
--- a/parquet-column/src/main/java/parquet/filter2/predicate/Operators.java
+++ b/parquet-column/src/main/java/parquet/filter2/predicate/Operators.java
@@ -99,7 +99,7 @@ public final class Operators {
   }
 
   // base class for Eq, NotEq, Lt, Gt, LtEq, GtEq
-  static abstract class ColumnFilterPredicate<T extends Comparable<T>> implements FilterPredicate, Serializable  {
+  public static abstract class ColumnFilterPredicate<T extends Comparable<T>> implements FilterPredicate, Serializable  {
     private final Column<T> column;
     private final T value;
     private final String toString;
@@ -232,7 +232,7 @@ public final class Operators {
   }
 
   // base class for And, Or
-  private static abstract class BinaryLogicalFilterPredicate implements FilterPredicate, Serializable {
+  public static abstract class BinaryLogicalFilterPredicate implements FilterPredicate, Serializable {
     private final FilterPredicate left;
     private final FilterPredicate right;
     private final String toString;

--- a/parquet-column/src/main/java/parquet/filter2/recordlevel/FilteringRecordMaterializer.java
+++ b/parquet-column/src/main/java/parquet/filter2/recordlevel/FilteringRecordMaterializer.java
@@ -89,13 +89,13 @@ public class FilteringRecordMaterializer<T> extends RecordMaterializer<T> {
     // reset the stateful predicate no matter what
     IncrementallyUpdatedFilterPredicateResetter.reset(filterPredicate);
 
-     if (keep) {
-       return delegate.getCurrentRecord();
-     } else {
-       // signals a skip
-       return null;
-     }
-  }  
+    if (keep) {
+      return delegate.getCurrentRecord();
+    } else {
+      // signals a skip
+      return null;
+    }
+  } 
 
   @Override
   public void skipCurrentRecord() {

--- a/parquet-column/src/main/java/parquet/filter2/recordlevel/FilteringRecordMaterializer.java
+++ b/parquet-column/src/main/java/parquet/filter2/recordlevel/FilteringRecordMaterializer.java
@@ -66,7 +66,19 @@ public class FilteringRecordMaterializer<T> extends RecordMaterializer<T> {
     return list;
   }
 
+  public boolean getFilterResult() {
+    // find out if the predicate thinks we should keep this record
+    boolean keep = IncrementallyUpdatedFilterPredicateEvaluator.evaluate(filterPredicate);
 
+    // reset the stateful predicate no matter what
+    IncrementallyUpdatedFilterPredicateResetter.reset(filterPredicate);
+    
+    return keep;
+  }
+
+  public T getFilteredCurrentRecord() {
+    return delegate.getCurrentRecord();
+  }
 
   @Override
   public T getCurrentRecord() {
@@ -77,13 +89,13 @@ public class FilteringRecordMaterializer<T> extends RecordMaterializer<T> {
     // reset the stateful predicate no matter what
     IncrementallyUpdatedFilterPredicateResetter.reset(filterPredicate);
 
-    if (keep) {
-      return delegate.getCurrentRecord();
-    } else {
-      // signals a skip
-      return null;
-    }
-  }
+     if (keep) {
+       return delegate.getCurrentRecord();
+     } else {
+       // signals a skip
+       return null;
+     }
+  }  
 
   @Override
   public void skipCurrentRecord() {

--- a/parquet-column/src/main/java/parquet/io/FlatSchemaRecordReaderImplementation.java
+++ b/parquet-column/src/main/java/parquet/io/FlatSchemaRecordReaderImplementation.java
@@ -164,13 +164,9 @@ class FlatSchemaRecordReaderImplementation<T> extends RecordReader<T> {
     }
      
     recordRootConverter.end();
-    T record = recordMaterializer.getFilteredCurrentRecord();
-    shouldSkipCurrentRecord = record == null;
-    if (shouldSkipCurrentRecord) {
-      recordMaterializer.skipCurrentRecord();
-    }
+    shouldSkipCurrentRecord = false;
      
-    return record;
+    return recordMaterializer.getFilteredCurrentRecord();
   }
 
   @Override

--- a/parquet-column/src/main/java/parquet/io/FlatSchemaRecordReaderImplementation.java
+++ b/parquet-column/src/main/java/parquet/io/FlatSchemaRecordReaderImplementation.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import parquet.Log;
+import parquet.column.ColumnReader;
+import parquet.column.impl.ColumnReadStoreImpl;
+import parquet.io.api.Converter;
+import parquet.io.api.GroupConverter;
+import parquet.io.api.PrimitiveConverter;
+import parquet.io.api.RecordConsumer;
+import parquet.io.api.RecordMaterializer;
+import parquet.schema.MessageType;
+import parquet.schema.PrimitiveType.PrimitiveTypeName;
+import parquet.filter2.recordlevel.FilteringRecordMaterializer;
+
+/**
+ * used to read reassembled records after filtering
+ * reads only the required columns for evaluating the filter
+ * further optimized for db applications that use flat schema
+ * most of the times.
+ * assumes a flat schema of record (No nested columns)
+ *
+ * @author Yash Datta
+ *
+ * @param <T> the type of the materialized record
+ */
+class FlatSchemaRecordReaderImplementation<T> extends RecordReader<T> {
+  private static final Log LOG = Log.getLog(FlatSchemaRecordReaderImplementation.class);
+  private int filterStatesOffset;
+  private int numCols; 
+
+  private final GroupConverter recordRootConverter;
+  private final FilteringRecordMaterializer<T> recordMaterializer;
+  
+  int[] maxDefinitionLevel;
+  private ColumnReader[] columnReaders;
+
+  private boolean shouldSkipCurrentRecord = false;
+
+  /**
+   * @param root the root of the schema
+   * @param recordMaterializer responsible of materializing the records
+   * @param validating whether we should validate against the schema
+   * @param columnStore where to read the column data from
+   * @param fColsPath all columns part of the filter
+   */
+  public FlatSchemaRecordReaderImplementation(MessageColumnIO root, FilteringRecordMaterializer<T> recordMaterializer, boolean validating, ColumnReadStoreImpl columnStore, HashSet<String> fColsPath) {
+    this.filterStatesOffset = fColsPath.size();
+    this.recordMaterializer = recordMaterializer;
+    this.recordRootConverter = recordMaterializer.getRootConverter(); // TODO: validator(wrap(recordMaterializer), validating, root.getType());
+    PrimitiveColumnIO[] leaves = root.getLeaves().toArray(new PrimitiveColumnIO[root.getLeaves().size()]);
+    numCols = leaves.length;
+    columnReaders = new ColumnReader[leaves.length];
+    int[] order = new int[leaves.length];
+    maxDefinitionLevel = new int[leaves.length];
+    for(int i=0;i < leaves.length; i++)
+        order[i] = i;
+    int temp = 0;
+    // set the order to access the columns!
+    for (int i = 0; i < leaves.length; i++ ) {
+      PrimitiveColumnIO leafColumnIO = leaves[i];
+      String[] path = leafColumnIO.getColumnDescriptor().getPath();
+      // path[0] will give the column name
+      if(fColsPath.contains(path[0])){
+        int pCtemp = order[temp];
+        order[temp] = order[i];
+        order[i] = pCtemp;
+        ++temp;
+      }
+    }
+
+    for(int i = 0; i < leaves.length; i++) {
+      PrimitiveColumnIO leafColumnIO = leaves[i];
+      maxDefinitionLevel[order[i]] = leafColumnIO.getDefinitionLevel();
+      columnReaders[order[i]] = columnStore.getColumnReader(leafColumnIO.getColumnDescriptor());
+    }
+  }
+
+  //TODO: have those wrappers for a converter
+  private RecordConsumer validator(RecordConsumer recordConsumer, boolean validating, MessageType schema) {
+    return validating ? new ValidatingRecordConsumer(recordConsumer, schema) : recordConsumer;
+  }
+
+  private RecordConsumer wrap(RecordConsumer recordConsumer) {
+    if (Log.DEBUG) {
+      return new RecordConsumerLoggingWrapper(recordConsumer);
+    }
+    return recordConsumer;
+  }
+
+  /**
+   * @see parquet.io.RecordReader#read()
+   */
+  @Override
+  public T read() {
+    recordRootConverter.start();
+    // read all columns part of the filter first
+    for(int i = 0; i < filterStatesOffset; i++) {
+        ColumnReader columnReader = columnReaders[i];
+        int d = columnReader.getCurrentDefinitionLevel();
+        int m = maxDefinitionLevel[i];
+        if (d >= m) {
+          // not null
+          columnReader.writeCurrentValueToConverter();
+        }
+        columnReader.consume();    
+    }
+    
+    // evaluate the filter
+    if(!recordMaterializer.getFilterResult()) {
+      
+      // row is rejected, skip the rest of the read
+      for(int i = filterStatesOffset; i < numCols; i++) {
+        ColumnReader columnReader = columnReaders[i];
+        int d = columnReader.getCurrentDefinitionLevel();
+        int m = maxDefinitionLevel[i];
+        if (d >= m) {
+          // not null
+          columnReader.skip();
+        }
+        columnReader.consume();    
+      }
+      
+      recordRootConverter.end(); 
+      shouldSkipCurrentRecord = true;
+      recordMaterializer.skipCurrentRecord();
+      // signal a skip
+      return null;
+    }
+    
+    // filter passes the row, need to assemble the complete row    
+    for(int i = filterStatesOffset; i < numCols; i++) {
+      ColumnReader columnReader = columnReaders[i];
+      int d = columnReader.getCurrentDefinitionLevel();
+      int m = maxDefinitionLevel[i];
+      if (d >= m) {
+            // not null
+        columnReader.writeCurrentValueToConverter();
+       }
+       columnReader.consume();    
+    }
+     
+    recordRootConverter.end();
+    T record = recordMaterializer.getFilteredCurrentRecord();
+    shouldSkipCurrentRecord = record == null;
+    if (shouldSkipCurrentRecord) {
+      recordMaterializer.skipCurrentRecord();
+    }
+     
+    return record;
+  }
+
+  @Override
+  public boolean shouldSkipCurrentRecord() {
+    return shouldSkipCurrentRecord;
+  }
+
+  private static void log(String string) {
+    LOG.debug(string);
+  }
+  
+  protected RecordMaterializer<T> getMaterializer() {
+    return recordMaterializer;
+  }
+
+  protected Converter getRecordConsumer() {
+    return recordRootConverter;
+  }
+
+  protected Iterable<ColumnReader> getColumnReaders() {
+    // Converting the array to an iterable ensures that the array cannot be altered
+    return Arrays.asList(columnReaders);
+  }
+}

--- a/parquet-column/src/main/java/parquet/io/FlatSchemaRecordReaderImplementation.java
+++ b/parquet-column/src/main/java/parquet/io/FlatSchemaRecordReaderImplementation.java
@@ -93,9 +93,9 @@ class FlatSchemaRecordReaderImplementation<T> extends RecordReader<T> {
     }
 
     for(int i = 0; i < leaves.length; i++) {
-      PrimitiveColumnIO leafColumnIO = leaves[i];
-      maxDefinitionLevel[order[i]] = leafColumnIO.getDefinitionLevel();
-      columnReaders[order[i]] = columnStore.getColumnReader(leafColumnIO.getColumnDescriptor());
+      PrimitiveColumnIO leafColumnIO = leaves[order[i]];
+      maxDefinitionLevel[i] = leafColumnIO.getDefinitionLevel();
+      columnReaders[i] = columnStore.getColumnReader(leafColumnIO.getColumnDescriptor());
     }
   }
 
@@ -122,6 +122,7 @@ class FlatSchemaRecordReaderImplementation<T> extends RecordReader<T> {
         ColumnReader columnReader = columnReaders[i];
         int d = columnReader.getCurrentDefinitionLevel();
         int m = maxDefinitionLevel[i];
+
         if (d >= m) {
           // not null
           columnReader.writeCurrentValueToConverter();
@@ -131,7 +132,6 @@ class FlatSchemaRecordReaderImplementation<T> extends RecordReader<T> {
     
     // evaluate the filter
     if(!recordMaterializer.getFilterResult()) {
-      
       // row is rejected, skip the rest of the read
       for(int i = filterStatesOffset; i < numCols; i++) {
         ColumnReader columnReader = columnReaders[i];

--- a/parquet-column/src/main/java/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/parquet/io/MessageColumnIO.java
@@ -131,7 +131,6 @@ public class MessageColumnIO extends GroupColumnIO {
         } 
          
         getFilterColumnNames(predicate, hSet);
-        System.out.println(hSet.toString());
         IncrementallyUpdatedFilterPredicateBuilder builder = new IncrementallyUpdatedFilterPredicateBuilder();
         IncrementallyUpdatedFilterPredicate streamingPredicate = builder.build(predicate);
         FilteringRecordMaterializer<T> filteringRecordMaterializer = new FilteringRecordMaterializer<T>(

--- a/parquet-column/src/main/java/parquet/io/OptFilteredRecordReaderImplementation.java
+++ b/parquet-column/src/main/java/parquet/io/OptFilteredRecordReaderImplementation.java
@@ -1,0 +1,553 @@
+/**
+ * Copyright 2012 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package parquet.io;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import parquet.Log;
+import parquet.column.ColumnReader;
+import parquet.column.impl.ColumnReadStoreImpl;
+import parquet.io.api.Converter;
+import parquet.io.api.GroupConverter;
+import parquet.io.api.PrimitiveConverter;
+import parquet.io.api.RecordConsumer;
+import parquet.io.api.RecordMaterializer;
+import parquet.schema.MessageType;
+import parquet.schema.PrimitiveType.PrimitiveTypeName;
+import parquet.filter2.recordlevel.FilteringRecordMaterializer;
+
+/**
+ * used to read reassembled records
+ * Optimized version, reads only the columns required
+ * for evaluating the filter, then proceeds to skip
+ * or read the rest of the columns, depending on
+ * whether filter rejects or accepts the row.
+ *
+ * @author Julien Le Dem
+ *
+ * @param <T> the type of the materialized record
+ */
+class OptFilteredRecordReaderImplementation<T> extends RecordReader<T> {
+  private static final Log LOG = Log.getLog(OptFilteredRecordReaderImplementation.class);
+  private int filterStatesOffsetId;
+  private int numCols; 
+  int[] order;
+
+  public static class Case {
+
+    private int id;
+    private final int startLevel;
+    private final int depth;
+    private final int nextLevel;
+    private final boolean goingUp;
+    private final boolean goingDown;
+    private final int nextState;
+    private final boolean defined;
+
+    public Case(int startLevel, int depth, int nextLevel, int nextState, boolean defined) {
+      this.startLevel = startLevel;
+      this.depth = depth;
+      this.nextLevel = nextLevel;
+      this.nextState = nextState;
+      this.defined = defined;
+      // means going up the tree (towards the leaves) of the record
+      // true if we need to open up groups in this case
+      goingUp = startLevel <= depth;
+      // means going down the tree (towards the root) of the record
+      // true if we need to close groups in this case
+      goingDown = depth + 1 > nextLevel;
+    }
+
+    public void setID(int id) {
+      this.id = id;
+    }
+
+    @Override
+    // this implementation is buggy but the simpler one bellow has duplicates.
+    // it still works but generates more code than necessary
+    // a middle ground is necessary
+//    public int hashCode() {
+//      int hashCode = 0;
+//      if (goingUp) {
+//        hashCode += 1 * (1 + startLevel) + 2 * (1 + depth);
+//      }
+//      if (goingDown) {
+//        hashCode += 3 * (1 + depth) + 5 * (1 + nextLevel);
+//      }
+//      return hashCode;
+//    }
+
+    public int hashCode() {
+      int hashCode = 17;
+      hashCode += 31 * startLevel;
+      hashCode += 31 * depth;
+      hashCode += 31 * nextLevel;
+      hashCode += 31 * nextState;
+      hashCode += 31 * (defined ? 0 : 1);
+      return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj instanceof Case) {
+        return equals((Case)obj);
+      }
+      return false;
+    };
+
+    // see comment for hashCode above
+//    public boolean equals(Case other) {
+//      if (goingUp && !other.goingUp || !goingUp && other.goingUp) {
+//        return false;
+//      }
+//      if (goingUp && other.goingUp && (startLevel != other.startLevel || depth != other.depth)) {
+//        return false;
+//      }
+//      if (goingDown && !other.goingDown || !goingDown && other.goingDown) {
+//        return false;
+//      }
+//      if (goingDown && other.goingDown && (depth != other.depth || nextLevel != other.nextLevel)) {
+//        return false;
+//      }
+//      return true;
+//    }
+
+    public boolean equals(Case other) {
+      return startLevel == other.startLevel
+          && depth == other.depth
+          && nextLevel == other.nextLevel
+          && nextState == other.nextState
+          && ((defined && other.defined) || (!defined && !other.defined));
+    }
+
+    public int getID() {
+      return id;
+    }
+
+    public int getStartLevel() {
+      return startLevel;
+    }
+
+    public int getDepth() {
+      return depth;
+    }
+    public int getNextLevel() {
+      return nextLevel;
+    }
+
+    public int getNextState() {
+      return nextState;
+    }
+
+    public boolean isGoingUp() {
+      return goingUp;
+    }
+
+    public boolean isGoingDown() {
+      return goingDown;
+    }
+
+    public boolean isDefined() {
+      return defined;
+    }
+
+    @Override
+    public String toString() {
+      return "Case " + startLevel + " -> " + depth + " -> " + nextLevel + "; goto sate_"+getNextState();
+    }
+
+  }
+
+  public static class State {
+
+    public final int id;
+    public final PrimitiveColumnIO primitiveColumnIO;
+    public final int maxDefinitionLevel;
+    public final int maxRepetitionLevel;
+    public final PrimitiveTypeName primitive;
+    public final ColumnReader column;
+    public final String[] fieldPath; // indexed by currentLevel
+    public final int[] indexFieldPath; // indexed by currentLevel
+    public final GroupConverter[] groupConverterPath;
+    public final PrimitiveConverter primitiveConverter;
+    public final String primitiveField;
+    public final int primitiveFieldIndex;
+    public final int[] nextLevel; //indexed by next r
+
+    private int[] definitionLevelToDepth; // indexed by current d
+    private State[] nextState; // indexed by next r
+    private Case[][][] caseLookup;
+    private List<Case> definedCases;
+    private List<Case> undefinedCases;
+
+    private State(int id, PrimitiveColumnIO primitiveColumnIO, ColumnReader column, int[] nextLevel, GroupConverter[] groupConverterPath, PrimitiveConverter primitiveConverter) {
+      this.id = id;
+      this.primitiveColumnIO = primitiveColumnIO;
+      this.maxDefinitionLevel = primitiveColumnIO.getDefinitionLevel();
+      this.maxRepetitionLevel = primitiveColumnIO.getRepetitionLevel();
+      this.column = column;
+      this.nextLevel = nextLevel;
+      this.groupConverterPath = groupConverterPath;
+      this.primitiveConverter = primitiveConverter;
+      this.primitive = primitiveColumnIO.getType().asPrimitiveType().getPrimitiveTypeName();
+      this.fieldPath = primitiveColumnIO.getFieldPath();
+      this.primitiveField = fieldPath[fieldPath.length - 1];
+      this.indexFieldPath = primitiveColumnIO.getIndexFieldPath();
+      this.primitiveFieldIndex = indexFieldPath[indexFieldPath.length - 1];
+    }
+
+    public int getDepth(int definitionLevel) {
+      return definitionLevelToDepth[definitionLevel];
+    }
+
+    public List<Case> getDefinedCases() {
+      return definedCases;
+    }
+
+    public List<Case> getUndefinedCases() {
+      return undefinedCases;
+    } 
+
+    public Case getCase(int currentLevel, int d, int nextR) {
+      return caseLookup[currentLevel][d][nextR];
+    }
+
+    public State getNextState(int nextR) {
+      return nextState[nextR];
+    }
+  }
+
+  private final GroupConverter recordRootConverter;
+  private final FilteringRecordMaterializer<T> recordMaterializer;
+
+  private State[] states;
+  private ColumnReader[] columnReaders;
+
+  private boolean shouldSkipCurrentRecord = false;
+
+  /**
+   * @param root the root of the schema
+   * @param recordMaterializer responsible of materializing the records
+   * @param validating whether we should validate against the schema
+   * @param columnStore where to read the column data from
+   */
+  public OptFilteredRecordReaderImplementation(MessageColumnIO root, FilteringRecordMaterializer<T> recordMaterializer, boolean validating, ColumnReadStoreImpl columnStore, HashSet<String> fColsPath) {
+    this.recordMaterializer = recordMaterializer;
+    this.recordRootConverter = recordMaterializer.getRootConverter(); // TODO: validator(wrap(recordMaterializer), validating, root.getType());
+    PrimitiveColumnIO[] leaves = root.getLeaves().toArray(new PrimitiveColumnIO[root.getLeaves().size()]);
+    numCols = leaves.length;
+    columnReaders = new ColumnReader[leaves.length];
+    int[][] nextColumnIdxForRepLevel = new int[leaves.length][];
+    int[][] levelToClose = new int[leaves.length][];
+    GroupConverter[][] groupConverterPaths = new GroupConverter[leaves.length][];
+    PrimitiveConverter[] leafConverters = new PrimitiveConverter[leaves.length];
+    int[] firstIndexForLevel  = new int[256]; // "256 levels of nesting ought to be enough for anybody"
+    // rearrange the leaves!
+    order = new int[leaves.length+1];
+    for(int i=0;i <= leaves.length; i++)
+        order[i] = i;
+    int temp = 0;
+    for (int i = 0; i < leaves.length; i++ ) {
+      PrimitiveColumnIO leafColumnIO = leaves[i];
+      String[] path = leafColumnIO.getColumnDescriptor().getPath();
+      // path[0] will give the root name ?
+      if(fColsPath.contains(path[0])){
+        int pCtemp = order[temp];
+        order[temp] = order[i];
+        order[i] = pCtemp;
+        ++temp;
+      }
+    }
+    this.filterStatesOffsetId = order[temp];
+    // build the automaton in the 'order' order
+    for (int k = 0; k < leaves.length; k++) {
+      int i = order[k];
+      PrimitiveColumnIO leafColumnIO = leaves[i];
+      //generate converters along the path from root to leaf
+      final int[] indexFieldPath = leafColumnIO.getIndexFieldPath();
+      groupConverterPaths[i] = new GroupConverter[indexFieldPath.length - 1];
+      GroupConverter current = this.recordRootConverter;
+      for (int j = 0; j < indexFieldPath.length - 1; j++) {
+        current = current.getConverter(indexFieldPath[j]).asGroupConverter();
+        groupConverterPaths[i][j] = current;
+      }
+      leafConverters[i] = current.getConverter(indexFieldPath[indexFieldPath.length - 1]).asPrimitiveConverter();
+      columnReaders[i] = columnStore.getColumnReader(leafColumnIO.getColumnDescriptor());
+      int maxRepetitionLevel = leafColumnIO.getRepetitionLevel();
+      nextColumnIdxForRepLevel[i] = new int[maxRepetitionLevel+1];
+
+      levelToClose[i] = new int[maxRepetitionLevel+1]; //next level
+      for (int nextRepLevel = 0; nextRepLevel <= maxRepetitionLevel; ++nextRepLevel) {
+        // remember which is the first for this level
+        if (leafColumnIO.isFirst(nextRepLevel)) {
+          firstIndexForLevel[nextRepLevel] = i;
+        }
+        int nextColIdx;
+        //TODO: when we use nextColumnIdxForRepLevel, should we provide current rep level or the rep level for next item
+        // figure out automaton transition
+        if (nextRepLevel == 0) { // 0 always means jump to the next (the last one being a special case)
+          nextColIdx =  order[k + 1];
+        } else if (leafColumnIO.isLast(nextRepLevel)) { // when we are at the last of the next repetition level we jump back to the first
+          nextColIdx = firstIndexForLevel[nextRepLevel];
+        } else { // otherwise we just go back to the next.
+          nextColIdx = order[k + 1];
+        }
+        // figure out which level down the tree we need to go back
+        if (nextColIdx == leaves.length) { // reached the end of the record => close all levels
+          levelToClose[i][nextRepLevel] = 0;
+        } else if (leafColumnIO.isLast(nextRepLevel)) { // reached the end of this level => close the repetition level
+          ColumnIO parent = leafColumnIO.getParent(nextRepLevel);
+          levelToClose[i][nextRepLevel] = parent.getFieldPath().length == 0 ? 0 : parent.getFieldPath().length - 1;
+        } else { // otherwise close until the next common parent
+          levelToClose[i][nextRepLevel] = getCommonParentLevel(
+              leafColumnIO.getFieldPath(),
+              leaves[nextColIdx].getFieldPath());
+        }
+        // sanity check: that would be a bug
+        if (levelToClose[i][nextRepLevel] > leaves[i].getFieldPath().length-1) {
+          throw new ParquetEncodingException(Arrays.toString(leaves[i].getFieldPath())+" -("+nextRepLevel+")-> "+levelToClose[i][nextRepLevel]);
+        }
+        nextColumnIdxForRepLevel[i][nextRepLevel] = nextColIdx;
+      }
+    }
+    states = new State[leaves.length];
+    for (int k = 0; k < leaves.length; k++) {
+      int i = order[k];
+      states[i] = new State(i, leaves[i], columnReaders[i], levelToClose[i], groupConverterPaths[i], leafConverters[i]);
+      int[] definitionLevelToDepth = new int[states[i].primitiveColumnIO.getDefinitionLevel() + 1];
+      // for each possible definition level, determine the depth at which to create groups
+      final ColumnIO[] path = states[i].primitiveColumnIO.getPath();
+      int depth = 0;
+      for (int d = 0; d < definitionLevelToDepth.length; ++d) {
+        while (depth < (states[i].fieldPath.length - 1)
+          && d >= path[depth + 1].getDefinitionLevel()
+          ) {
+          ++ depth;
+        }
+        definitionLevelToDepth[d] = depth - 1;
+      }
+      states[i].definitionLevelToDepth = definitionLevelToDepth;
+    }
+    for (int k = 0; k < leaves.length; k++) {
+      int i = order[k];
+      State state = states[i];
+      int[] nextStateIds = nextColumnIdxForRepLevel[i];
+      state.nextState = new State[nextStateIds.length];
+      for (int j = 0; j < nextStateIds.length; j++) {
+        state.nextState[j] = nextStateIds[j] == states.length ? null : states[nextStateIds[j]];
+      }
+    }
+    for (int k = 0; k < states.length; k++) {
+      int i = order[k];
+      State state = states[i];
+      final Map<Case, Case> definedCases = new HashMap<Case, Case>();
+      final Map<Case, Case> undefinedCases = new HashMap<Case, Case>();
+      Case[][][] caseLookup = new Case[state.fieldPath.length][][];
+      for (int currentLevel = 0; currentLevel < state.fieldPath.length; ++ currentLevel) {
+        caseLookup[currentLevel] = new Case[state.maxDefinitionLevel+1][];
+        for (int d = 0; d <= state.maxDefinitionLevel; ++ d) {
+          caseLookup[currentLevel][d] = new Case[state.maxRepetitionLevel+1];
+          for (int nextR = 0; nextR <= state.maxRepetitionLevel; ++ nextR) {
+            int caseStartLevel = currentLevel;
+            int caseDepth = Math.max(state.getDepth(d), caseStartLevel - 1);
+            int caseNextLevel = Math.min(state.nextLevel[nextR], caseDepth + 1);
+            Case currentCase = new Case(caseStartLevel, caseDepth, caseNextLevel, getNextReader(state.id, nextR), d == state.maxDefinitionLevel);
+            Map<Case, Case> cases = currentCase.isDefined() ? definedCases : undefinedCases;
+            if (!cases.containsKey(currentCase)) {
+              currentCase.setID(cases.size());
+              cases.put(currentCase, currentCase);
+            } else {
+              currentCase = cases.get(currentCase);
+            }
+            caseLookup[currentLevel][d][nextR] = currentCase;
+          }
+        }
+      }
+      state.caseLookup = caseLookup;
+      state.definedCases = new ArrayList<Case>(definedCases.values());
+      state.undefinedCases = new ArrayList<Case>(undefinedCases.values());
+      Comparator<Case> caseComparator = new Comparator<Case>() {
+        @Override
+        public int compare(Case o1, Case o2) {
+          return o1.id - o2.id;
+        }
+      };
+      Collections.sort(state.definedCases, caseComparator);
+      Collections.sort(state.undefinedCases, caseComparator);
+    }
+  }
+
+  //TODO: have those wrappers for a converter
+  private RecordConsumer validator(RecordConsumer recordConsumer, boolean validating, MessageType schema) {
+    return validating ? new ValidatingRecordConsumer(recordConsumer, schema) : recordConsumer;
+  }
+
+  private RecordConsumer wrap(RecordConsumer recordConsumer) {
+    if (Log.DEBUG) {
+      return new RecordConsumerLoggingWrapper(recordConsumer);
+    }
+    return recordConsumer;
+  }
+
+  /**
+   * @see parquet.io.RecordReader#read()
+   */
+  @Override
+  public T read() {
+    int currentLevel = 0;
+    recordRootConverter.start();
+    State currentState = states[order[0]];
+    // reconstruct the required rows
+    do {
+      ColumnReader columnReader = currentState.column;
+      int d = columnReader.getCurrentDefinitionLevel();
+      // creating needed nested groups until the current field (opening tags)
+      int depth = currentState.definitionLevelToDepth[d];
+        for (; currentLevel <= depth; ++currentLevel) {
+        currentState.groupConverterPath[currentLevel].start();
+      }
+      // currentLevel = depth + 1 at this point
+      // set the current value
+       if (d >= currentState.maxDefinitionLevel) {
+         // not null
+         columnReader.writeCurrentValueToConverter();
+       }
+      columnReader.consume();
+
+      int nextR = currentState.maxRepetitionLevel == 0 ? 0 : columnReader.getCurrentRepetitionLevel();
+      // level to go to close current groups
+      int next = currentState.nextLevel[nextR];
+      for (; currentLevel > next; currentLevel--) {
+        currentState.groupConverterPath[currentLevel - 1].end();
+      }
+
+      currentState = currentState.nextState[nextR];
+    } while (currentState.id != filterStatesOffsetId);
+
+    // evaluate the filter
+    if(!recordMaterializer.getFilterResult()) {
+      // filter rejects the row, skip reading rest of the columns
+      while(currentState!=null) {
+        ColumnReader columnReader = currentState.column;
+        int d = columnReader.getCurrentDefinitionLevel();
+        if (d >= currentState.maxDefinitionLevel) {
+                // not null
+          columnReader.skip();
+        }
+
+        columnReader.consume();
+        int nextR = currentState.maxRepetitionLevel == 0 ? 0 : columnReader.getCurrentRepetitionLevel();
+        currentState = currentState.nextState[nextR];
+      }
+
+      shouldSkipCurrentRecord = true;
+      recordMaterializer.skipCurrentRecord();
+      // signal a skip
+      return null;
+    }
+    
+    // filter passes the row, assemble the rest of the row
+    while(currentState!=null) {
+      ColumnReader columnReader = currentState.column;
+      int d = columnReader.getCurrentDefinitionLevel();
+      // creating needed nested groups until the current field (opening tags)
+      int depth = currentState.definitionLevelToDepth[d];
+      for (; currentLevel <= depth; ++currentLevel) {
+        currentState.groupConverterPath[currentLevel].start();
+      }
+      // currentLevel = depth + 1 at this point
+      // set the current value
+      if (d >= currentState.maxDefinitionLevel) {
+        // not null
+        columnReader.writeCurrentValueToConverter();
+      }
+ 
+      columnReader.consume();
+      int nextR = currentState.maxRepetitionLevel == 0 ? 0 : columnReader.getCurrentRepetitionLevel();
+      // level to go to close current groups
+      int next = currentState.nextLevel[nextR];
+      for (; currentLevel > next; currentLevel--) {
+        currentState.groupConverterPath[currentLevel - 1].end();
+      }
+
+      currentState = currentState.nextState[nextR];
+    }
+
+    recordRootConverter.end();
+    T record = recordMaterializer.getFilteredCurrentRecord();
+    shouldSkipCurrentRecord = record == null;
+    if (shouldSkipCurrentRecord) {
+      recordMaterializer.skipCurrentRecord();
+    }
+
+    return record;
+  }
+
+
+  @Override
+  public boolean shouldSkipCurrentRecord() {
+    return shouldSkipCurrentRecord;
+  }
+
+  private static void log(String string) {
+    LOG.debug(string);
+  }
+
+  int getNextReader(int current, int nextRepetitionLevel) {
+    State nextState = states[current].nextState[nextRepetitionLevel];
+    return nextState == null ? states.length : nextState.id;
+  }
+
+  int getNextLevel(int current, int nextRepetitionLevel) {
+    return states[current].nextLevel[nextRepetitionLevel];
+  }
+
+  private int getCommonParentLevel(String[] previous, String[] next) {
+    int i = 0;
+    while (i < Math.min(previous.length, next.length) && previous[i].equals(next[i])) {
+      ++i;
+    }
+    return i;
+  }
+
+  protected int getStateCount() {
+    return states.length;
+  }
+
+  protected State getState(int i) {
+    return states[i];
+  }
+
+  protected RecordMaterializer<T> getMaterializer() {
+    return recordMaterializer;
+  }
+
+  protected Converter getRecordConsumer() {
+    return recordRootConverter;
+  }
+
+  protected Iterable<ColumnReader> getColumnReaders() {
+    // Converting the array to an iterable ensures that the array cannot be altered
+    return Arrays.asList(columnReaders);
+  }
+}

--- a/parquet-column/src/main/java/parquet/io/OptFilteredRecordReaderImplementation.java
+++ b/parquet-column/src/main/java/parquet/io/OptFilteredRecordReaderImplementation.java
@@ -494,13 +494,9 @@ class OptFilteredRecordReaderImplementation<T> extends RecordReader<T> {
     }
 
     recordRootConverter.end();
-    T record = recordMaterializer.getFilteredCurrentRecord();
-    shouldSkipCurrentRecord = record == null;
-    if (shouldSkipCurrentRecord) {
-      recordMaterializer.skipCurrentRecord();
-    }
-
-    return record;
+    shouldSkipCurrentRecord = false;
+    
+    return recordMaterializer.getFilteredCurrentRecord();
   }
 
 

--- a/parquet-hadoop/src/test/java/parquet/filter2/recordlevel/FlatSchemaWriter.java
+++ b/parquet-hadoop/src/test/java/parquet/filter2/recordlevel/FlatSchemaWriter.java
@@ -1,0 +1,180 @@
+package parquet.filter2.recordlevel;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import parquet.example.data.Group;
+import parquet.example.data.simple.SimpleGroup;
+import parquet.filter2.compat.FilterCompat.Filter;
+import parquet.hadoop.ParquetReader;
+import parquet.hadoop.ParquetWriter;
+import parquet.hadoop.example.GroupReadSupport;
+import parquet.hadoop.example.GroupWriteSupport;
+import parquet.schema.MessageType;
+import parquet.schema.MessageTypeParser;
+
+public class FlatSchemaWriter {
+    private static final String schemaString =
+            "message flatschema {\n"
+                    + "  required int32 col0;\n"
+                    + "  required int32 col1;\n"
+                    + "  optional binary col2 (UTF8);\n"
+                    + "  optional binary col3 (UTF8);\n"
+                    + "  optional int32 col4;\n"
+                    + "  optional double col5;\n"
+                    + "  optional int32 col6;\n"
+                    + "}\n";
+
+    private static final MessageType schema = MessageTypeParser.parseMessageType(schemaString);
+
+    public static class FlatSchema {
+        private final int col0;
+        private final int col1;
+        private final String col2;
+        private final String col3;
+        private final int col4;
+        private final double col5;
+        private final int col6;
+
+        public FlatSchema(int pcol0, int pcol1, String pcol2, String pcol3, int pcol4, double pcol5, int pcol6) {
+            this.col0 = pcol0;
+            this.col1 = pcol1;
+            this.col2 = pcol2;
+            this.col3 = pcol3;
+            this.col4 = pcol4;
+            this.col5 = pcol5;
+            this.col6 = pcol6;
+        }
+
+        public int col0() {
+            return col0;
+        }
+
+        public int col1() {
+            return col1;
+        }
+
+        public int col4() {
+            return col4;
+        }
+
+        public int col6() {
+            return col6;
+        }
+
+        public double col5() {
+            return col5;
+        }
+
+        public String getCol2() {
+            return col2;
+        }
+
+        public String getCol3() {
+            return col3;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            FlatSchema user = (FlatSchema) o;
+
+            if (col0 != user.col0) return false;
+            if (col1 != user.col1) return false;
+            if (col4 != user.col4) return false;
+            if (col5 != user.col5) return false;
+            if (col6 != user.col6) return false;
+
+            if (col2 != null ? !col2.equals(user.col2) : user.col2 != null) return false;
+            if (col3 != null ? !col3.equals(user.col3) : user.col3 != null) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = (int) (col0 ^ (col0 >>> 32));
+            result = 31 * result + (col2 != null ? col2.hashCode() : 0);
+            result = 31 * result + (col3 != null ? col3.hashCode() : 0);
+            result = 31 * result + (int)(col6 ^ (col6 >>> 32));
+            return result;
+        }
+    }
+
+    public static SimpleGroup groupFromUser(FlatSchema user) {
+        SimpleGroup root = new SimpleGroup(schema);
+        root.append("col0", user.col0());
+        root.append("col1", user.col1());
+
+        if (user.getCol2() != null) {
+            root.append("col2", user.getCol2());
+        }
+
+        if (user.getCol3() != null) {
+            root.append("col3", user.getCol3());
+        }
+
+        root.append("col4", user.col4());
+        root.append("col5", user.col5());
+        root.append("col6", user.col6());
+        return root;
+    }
+
+    public static File writeToFile(List<FlatSchema> records) throws IOException {
+        File f = File.createTempFile("phonebook2", ".parquet");
+        f.deleteOnExit();
+        if (!f.delete()) {
+            throw new IOException("couldn't delete tmp file" + f);
+        }
+
+        writeToFile(f, records);
+
+        return f;
+    }
+
+    public static void writeToFile(File f, List<FlatSchema> records) throws IOException {
+        Configuration conf = new Configuration();
+        GroupWriteSupport.setSchema(schema, conf);
+
+        ParquetWriter<Group> writer = new ParquetWriter<Group>(new Path(f.getAbsolutePath()), conf, new GroupWriteSupport());
+        for (FlatSchema u : records) {
+            writer.write(groupFromUser(u));
+        }
+        writer.close();
+    }
+
+    public static List<Group> readFile(File f, Filter filter) throws IOException {
+        Configuration conf = new Configuration();
+        GroupWriteSupport.setSchema(schema, conf);
+
+        ParquetReader<Group> reader =
+                ParquetReader.builder(new GroupReadSupport(), new Path(f.getAbsolutePath()))
+                        .withConf(conf)
+                        .withFilter(filter)
+                        .build();
+
+        Group current;
+        List<Group> users = new ArrayList<Group>();
+
+        current = reader.read();
+        while (current != null) {
+            users.add(current);
+            current = reader.read();
+        }
+
+        return users;
+    }
+
+    public static void main(String[] args) throws IOException {
+        File f = new File(args[0]);
+        writeToFile(f, TestRecordLevelFilters.makeRecords());
+    }
+
+}

--- a/parquet-hadoop/src/test/java/parquet/filter2/recordlevel/TestRecordLevelFilters.java
+++ b/parquet-hadoop/src/test/java/parquet/filter2/recordlevel/TestRecordLevelFilters.java
@@ -14,9 +14,11 @@ import parquet.example.data.Group;
 import parquet.filter2.compat.FilterCompat;
 import parquet.filter2.predicate.FilterPredicate;
 import parquet.filter2.predicate.Operators.BinaryColumn;
+import parquet.filter2.predicate.Operators.IntColumn;
 import parquet.filter2.predicate.Operators.DoubleColumn;
 import parquet.filter2.predicate.Statistics;
 import parquet.filter2.predicate.UserDefinedPredicate;
+import parquet.filter2.recordlevel.FlatSchemaWriter.FlatSchema;
 import parquet.filter2.recordlevel.PhoneBookWriter.Location;
 import parquet.filter2.recordlevel.PhoneBookWriter.PhoneNumber;
 import parquet.filter2.recordlevel.PhoneBookWriter.User;
@@ -25,6 +27,7 @@ import parquet.io.api.Binary;
 import static org.junit.Assert.assertEquals;
 import static parquet.filter2.predicate.FilterApi.and;
 import static parquet.filter2.predicate.FilterApi.binaryColumn;
+import static parquet.filter2.predicate.FilterApi.intColumn;
 import static parquet.filter2.predicate.FilterApi.doubleColumn;
 import static parquet.filter2.predicate.FilterApi.eq;
 import static parquet.filter2.predicate.FilterApi.gt;
@@ -70,17 +73,41 @@ public class TestRecordLevelFilters {
     return users;
   }
 
+  public static List<FlatSchema> makeRecords() {
+    List<FlatSchema> records = new ArrayList<FlatSchema>();
+
+    records.add(new FlatSchema(17, 45, null, null, 89, 91.0, 78));
+
+    records.add(new FlatSchema(18, 87, "bob", "opera", 90, 12.0, 104));
+
+    records.add(new FlatSchema(19, 109, "test", "ie", 91, 45.7, 116));
+
+    records.add(new FlatSchema(20, 119, "test", "firefox", 92, 67.9, 119));
+
+    records.add(new FlatSchema(21, 127, "test", "chrome", 93, 89.2, 189));
+
+    return records;
+  }
+
   private static File phonebookFile;
+  private static File testBookFile;
   private static List<User> users;
+  private static List<FlatSchema> records;
 
   @BeforeClass
   public static void setup() throws IOException{
     users = makeUsers();
+    records = makeRecords();
     phonebookFile = PhoneBookWriter.writeToFile(users);
+    testBookFile = FlatSchemaWriter.writeToFile(records);
   }
 
   private static interface UserFilter {
     boolean keep(User u);
+  }
+
+  private static interface FlatSchemaFilter {
+    boolean keep(FlatSchema u);
   }
 
   private static List<Group> getExpected(UserFilter f) {
@@ -93,7 +120,27 @@ public class TestRecordLevelFilters {
     return expected;
   }
 
+  private static List<Group> getExpected(FlatSchemaFilter f) {
+    List<Group> expected = new ArrayList<Group>();
+    for (FlatSchema u : records) {
+      if (f.keep(u)) {
+        expected.add(FlatSchemaWriter.groupFromUser(u));
+      }
+    }
+    return expected;
+  }
+
   private static void assertFilter(List<Group> found, UserFilter f) {
+    List<Group> expected = getExpected(f);
+    assertEquals(expected.size(), found.size());
+    Iterator<Group> expectedIter = expected.iterator();
+    Iterator<Group> foundIter = found.iterator();
+    while(expectedIter.hasNext()) {
+      assertEquals(expectedIter.next().toString(), foundIter.next().toString());
+    }
+  }
+
+  private static void assertFilter(List<Group> found, FlatSchemaFilter f) {
     List<Group> expected = getExpected(f);
     assertEquals(expected.size(), found.size());
     Iterator<Group> expectedIter = expected.iterator();
@@ -199,6 +246,27 @@ public class TestRecordLevelFilters {
         }
 
         return (lon != null && lon > 150.0 && lat != null) || "alice".equals(name);
+      }
+    });
+  }
+
+  @Test
+  public void testComplexFlatRecords() throws Exception {
+    BinaryColumn col2 = binaryColumn("col2");
+    DoubleColumn col5 = doubleColumn("col5");
+    IntColumn col4 = intColumn("col4");
+
+    FilterPredicate pred = and(eq(col2, Binary.fromString("test")), or(eq(col5, 89.2), eq(col4, 92)));
+    List<Group> found = PhoneBookWriter.readFile(testBookFile, FilterCompat.get(pred));
+
+    assertFilter(found, new FlatSchemaFilter() {
+      @Override
+      public boolean keep(FlatSchema u) {
+        String col2 = u.getCol2();
+        Double col5 = u.col5();
+        long col4 = u.col4();
+
+        return (((col5 == 89.2)) || col4 == 92) && "test".equals(col2);
       }
     });
   }


### PR DESCRIPTION
The RecordReader implementation currently will read all the columns before applying the filter predicate and deciding whether to keep the row or discard it.
We can have a RecordReader which will only assemble the columns on which filters are applied (which are usually a few), then apply the filter and decide whether to keep the row or not , and then goes on to assemble the remaining columns or skip the remaining columns accordingly.
Also for applications like spark sql , the schema usually applied is a flat one with no repeating or nested columns. In such cases, its better to have a light-weight, faster RecordReader.
The performance improvement by this change is seen to be significant , and is better in case smaller number of rows are returned by filtering (which is usually the case) and there are many number of columns
This PR:
             1. Added OptFilterRecordReaderImplementation which skips reading columns for the rows rejected by the filter on which filter is never applied.
             2. Added a light-weight FlatSchemaRecordReaderImplementation with filtering, which only works with a flat schema (non repeated and non nested columns), which uses the above optimization as well. Usually for application like spark sql, the schema is flat and hence this reader results in much faster queries.