### PR TITLE
PARQUET-171: Support Avro schema resolution across Parquet-Avro files

### DIFF
--- a/parquet-avro/src/main/java/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroReadSupport.java
@@ -34,7 +34,6 @@ import parquet.io.api.RecordMaterializer;
 import parquet.schema.MessageType;
 
 import static org.apache.avro.SchemaCompatibility.*;
-import static parquet.avro.AvroReadSupport.*;
 
 /**
  * Avro implementation of {@link ReadSupport} for Avro {@link IndexedRecord}s which cover both Avro Specific and

--- a/parquet-avro/src/main/java/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroReadSupport.java
@@ -51,7 +51,7 @@ public class AvroReadSupport<T extends IndexedRecord> extends ReadSupport<T> {
 
   static final String AVRO_SCHEMA_METADATA_KEY = "avro.schema";
 
-  private static final String AVRO_READ_SCHEMA_METADATA_KEY = "avro.read.schema";
+  static final String AVRO_READ_SCHEMA_METADATA_KEY = "avro.read.schema";
 
   public static String AVRO_DATA_SUPPLIER = "parquet.avro.data.supplier";
 
@@ -179,11 +179,7 @@ public class AvroReadSupport<T extends IndexedRecord> extends ReadSupport<T> {
       return mergeKeyValueMetadata(context, readerSchema);
     // otherwise, do not attempt to perform schema resolution/evolution
     } else {
-      Map<String, String> metadata = context.getMergedKeyValueMetaData();
-      if (readerSchemaString != null) {
-        metadata.put(AVRO_READ_SCHEMA_METADATA_KEY, readerSchemaString);
-      }
-      return metadata;
+      return context.getMergedKeyValueMetaData();
     }
   }
 
@@ -192,8 +188,11 @@ public class AvroReadSupport<T extends IndexedRecord> extends ReadSupport<T> {
     MessageType fileSchema = context.getFileSchema();
     MessageType schema = fileSchema;
     Map<String, String> metadata = getMergedKeyValueMetadata(context);
-    // replace Parquet schema with one created from an Avro projection, iff one is supplied
     Configuration configuration = context.getConfiguration();
+    String readerSchemaString = configuration.get(AVRO_READ_SCHEMA);
+    if (readerSchemaString != null) {
+      metadata.put(AVRO_READ_SCHEMA_METADATA_KEY, readerSchemaString);
+    }
     String requestedProjectionString = configuration.get(AVRO_REQUESTED_PROJECTION);
     if (requestedProjectionString != null) {
       Schema avroRequestedProjection = new Schema.Parser().parse(requestedProjectionString);

--- a/parquet-avro/src/main/java/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroReadSupport.java
@@ -40,10 +40,6 @@ import static parquet.avro.AvroReadSupport.*;
  * Avro implementation of {@link ReadSupport} for Avro {@link IndexedRecord}s which cover both Avro Specific and
  * Generic. Users should use {@link AvroParquetReader} or {@link AvroParquetInputFormat} rather than using
  * this class directly.
- * <p>{@code AvroReadSupport} that will perform schema evolution, if possible.</p>
- * <p>It is required to set the {@link AvroReadSupport#AVRO_READ_SCHEMA} in the context {@link Configuration}.</p>
- * <p>Avro schemas found in input files will be checked for compatibility against the {@code AVRO_READ_SCHEMA}.</p>
- * <p>A {@code RuntimeException} will be thrown if schemas are not compatible.</p>
  */
 public class AvroReadSupport<T extends IndexedRecord> extends ReadSupport<T> {
 
@@ -78,10 +74,17 @@ public class AvroReadSupport<T extends IndexedRecord> extends ReadSupport<T> {
     configuration.set(AVRO_DATA_SUPPLIER, clazz.toString());
   }
 
+  /**
+   * Enable the resolution of Avro schemas in the metadata against the {@link #AVRO_READ_SCHEMA}.
+   */
   public static void enableAvroSchemaCompatibilityCheck(Configuration configuration) {
     configuration.setBoolean(AVRO_SCHEMA_COMPATIBILITY_CHECK, true);
   }
 
+  /**
+   * Disable the resolution of Avro schemas in the metadata against the {@link #AVRO_READ_SCHEMA}.
+   * Avro schema compatibility checks are disabled by default.
+   */
   public static void disableAvroSchemaCompatibilityCheck(Configuration configuration) {
     configuration.setBoolean(AVRO_SCHEMA_COMPATIBILITY_CHECK, false);
   }
@@ -115,7 +118,7 @@ public class AvroReadSupport<T extends IndexedRecord> extends ReadSupport<T> {
    * Attempt to merge the Avro schemas listed under the {@code AVRO_SCHEMA_METADATA_KEY} by checking
    * if each schema is compatible with the requested "reader" schema.
    *
-   * <p>Avro schemas in the metadata may differ across our Parquet files, but they may be compatible in terms of Avro schema evolution.</p>
+   * <p>Avro schemas in the metadata may differ, but they may be compatible in terms of Avro schema evolution.</p>
    * <p>For other keys in the metadata, follow the conventions of {@link InitContext#getMergedKeyValueMetaData}.</p>
    *
    * @param context init context that contains unmerged key-value metadata
@@ -159,8 +162,9 @@ public class AvroReadSupport<T extends IndexedRecord> extends ReadSupport<T> {
   }
 
   /**
-   * To initialize, {@link #AVRO_READ_SCHEMA} must be defined in the context configuration.
-   * @see ReadSupport#init(InitContext)
+   * If an {@link #AVRO_READ_SCHEMA} is provided and the {@link #AVRO_SCHEMA_COMPATIBILITY_CHECK}
+   * flag has been set, all Avro schemas found in the metadata will be checked for compatibility
+   * against the {@code AVRO_READ_SCHEMA}.
    */
   @Override
   public ReadContext init(InitContext context) {

--- a/parquet-avro/src/main/java/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/parquet/avro/AvroReadSupport.java
@@ -18,27 +18,43 @@
  */
 package parquet.avro;
 
+import java.util.Iterator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.ReflectionUtils;
+import parquet.hadoop.api.InitContext;
 import parquet.hadoop.api.ReadSupport;
 import parquet.io.api.RecordMaterializer;
 import parquet.schema.MessageType;
+
+import static org.apache.avro.SchemaCompatibility.*;
+import static parquet.avro.AvroReadSupport.*;
 
 /**
  * Avro implementation of {@link ReadSupport} for Avro {@link IndexedRecord}s which cover both Avro Specific and
  * Generic. Users should use {@link AvroParquetReader} or {@link AvroParquetInputFormat} rather than using
  * this class directly.
+ * <p>{@code AvroReadSupport} that will perform schema evolution, if possible.</p>
+ * <p>It is required to set the {@link AvroReadSupport#AVRO_READ_SCHEMA} in the context {@link Configuration}.</p>
+ * <p>Avro schemas found in input files will be checked for compatibility against the {@code AVRO_READ_SCHEMA}.</p>
+ * <p>A {@code RuntimeException} will be thrown if schemas are not compatible.</p>
  */
 public class AvroReadSupport<T extends IndexedRecord> extends ReadSupport<T> {
 
   public static String AVRO_REQUESTED_PROJECTION = "parquet.avro.projection";
-  private static final String AVRO_READ_SCHEMA = "parquet.avro.read.schema";
 
-  static final String AVRO_SCHEMA_METADATA_KEY = "avro.schema";
+  public static final String AVRO_READ_SCHEMA = "parquet.avro.read.schema";
+
+  public static final String AVRO_SCHEMA_COMPATIBILITY_CHECK = "parquet.avro.schema.compatibility";
+
+  public static final String AVRO_SCHEMA_METADATA_KEY = "avro.schema";
+
   private static final String AVRO_READ_SCHEMA_METADATA_KEY = "avro.read.schema";
 
   public static String AVRO_DATA_SUPPLIER = "parquet.avro.data.supplier";
@@ -60,6 +76,107 @@ public class AvroReadSupport<T extends IndexedRecord> extends ReadSupport<T> {
   public static void setAvroDataSupplier(Configuration configuration,
       Class<? extends AvroDataSupplier> clazz) {
     configuration.set(AVRO_DATA_SUPPLIER, clazz.toString());
+  }
+
+  public static void enableAvroSchemaCompatibilityCheck(Configuration configuration) {
+    configuration.setBoolean(AVRO_SCHEMA_COMPATIBILITY_CHECK, true);
+  }
+
+  public static void disableAvroSchemaCompatibilityCheck(Configuration configuration) {
+    configuration.setBoolean(AVRO_SCHEMA_COMPATIBILITY_CHECK, false);
+  }
+
+  /**
+   * Are the two given Avro schemas compatible according to Avro schema resolution guidelines?
+   * @param readerSchema the "destination" or updated schema
+   * @param writerSchema the "source" or original schema
+   */
+  static boolean isSchemaCompatible(Schema readerSchema, Schema writerSchema) {
+    SchemaCompatibilityType result = checkReaderWriterCompatibility(readerSchema, writerSchema).getType();
+    return result == SchemaCompatibilityType.COMPATIBLE;
+  }
+
+  /**
+   * Are all given Avro schemas compatible with a single updated schema, according to Avro schema resolution guidelines?
+   * @param readerSchema the "destination" or updated schema
+   * @param writerSchemas a set of "source" or original schemas
+   */
+  static boolean areSchemasCompatible(Schema readerSchema, Set<Schema> writerSchemas) {
+    boolean acc = true;
+    Iterator<Schema> schemaIterator = writerSchemas.iterator();
+    while (acc && schemaIterator.hasNext()) {
+      Schema writerSchema = schemaIterator.next();
+      acc = acc && isSchemaCompatible(readerSchema, writerSchema);
+    }
+    return acc;
+  }
+
+  /**
+   * Attempt to merge the Avro schemas listed under the {@code AVRO_SCHEMA_METADATA_KEY} by checking
+   * if each schema is compatible with the requested "reader" schema.
+   *
+   * <p>Avro schemas in the metadata may differ across our Parquet files, but they may be compatible in terms of Avro schema evolution.</p>
+   * <p>For other keys in the metadata, follow the conventions of {@link InitContext#getMergedKeyValueMetaData}.</p>
+   *
+   * @param context init context that contains unmerged key-value metadata
+   * @param readerSchema the reader Avro schema that will be used for validating schema compatibility
+   * @return the merged key-value metadata
+   * @see AvroReadSupport
+   * @see InitContext
+   */
+  static Map<String, String> mergeKeyValueMetadata(InitContext context, Schema readerSchema) {
+    Map<String, Set<String>> unmergedKeyValueMetadata = context.getKeyValueMetadata();
+    Map<String, String> mergedKeyValueMetadata = new HashMap<String, String>();
+    Iterator<Map.Entry<String, Set<String>>> entryIterator = unmergedKeyValueMetadata.entrySet().iterator();
+
+    while (entryIterator.hasNext()) {
+      Map.Entry<String, Set<String>> entry = entryIterator.next();
+      String key = entry.getKey();
+      if (key.equals(AVRO_SCHEMA_METADATA_KEY)) {
+        // check compatibility of avro schemas in metadata
+        Set<String> writerSchemaStrings = entry.getValue();
+        Set<Schema> writerSchemas = new HashSet<Schema>();
+        /* It is necessary to instantiate a Schema.Parser for each schema
+         * because we are parsing for the same type with different, "evolved" definitions!
+         */
+        for (String s : writerSchemaStrings) {
+          Schema.Parser parser = new Schema.Parser();
+          Schema writerSchema = parser.parse(s);
+          writerSchemas.add(writerSchema);
+        }
+        if (!areSchemasCompatible(readerSchema, writerSchemas))
+          throw new RuntimeException("could not merge metadata: key " + AVRO_SCHEMA_METADATA_KEY + " contains incompatible schemas");
+        // if all writer schemas are compatible with the reader, reassign metadata schema to the reader schema
+        mergedKeyValueMetadata.put(AVRO_SCHEMA_METADATA_KEY, readerSchema.toString());
+      } else if (entry.getValue().size() > 1) {
+        throw new RuntimeException("could not merge metadata: key " + key  + " has conflicting values");
+      } else {
+        String value = entry.getValue().iterator().next();
+        mergedKeyValueMetadata.put(key, value);
+      }
+    }
+    return mergedKeyValueMetadata;
+  }
+
+  /**
+   * To initialize, {@link #AVRO_READ_SCHEMA} must be defined in the context configuration.
+   * @see ReadSupport#init(InitContext)
+   */
+  @Override
+  public ReadContext init(InitContext context) {
+    Configuration configuration = context.getConfiguration();
+    String readerSchemaString = configuration.get(AVRO_READ_SCHEMA);
+    boolean checkSchemaCompatibility = configuration.getBoolean(AVRO_SCHEMA_COMPATIBILITY_CHECK, false);
+    // attempt to resolve/evolve writer schemas to the reader schema
+    // iff a reader schema is provided and the compatibility check flag is flipped
+    if (readerSchemaString != null && checkSchemaCompatibility) {
+      Schema.Parser parser = new Schema.Parser();
+      Schema readerSchema = parser.parse(readerSchemaString);
+      return init(configuration, mergeKeyValueMetadata(context, readerSchema), context.getFileSchema());
+    // otherwise, do not attempt to perform schema resolution/evolution
+    } else {
+      return init(configuration, context.getMergedKeyValueMetaData(), context.getFileSchema());
+    }
   }
 
   @Override

--- a/parquet-avro/src/test/java/parquet/avro/TestAvroReadSupport.java
+++ b/parquet-avro/src/test/java/parquet/avro/TestAvroReadSupport.java
@@ -1,0 +1,198 @@
+package parquet.avro;
+
+import java.util.*;
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import parquet.hadoop.api.InitContext;
+import parquet.schema.MessageType;
+import parquet.schema.MessageTypeParser;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static parquet.avro.AvroReadSupport.*;
+
+public class TestAvroReadSupport {
+
+  /* Avro Schemas */
+
+  /* equivalent to message Foo { required binary field_1 (UTF8); } */
+  static final String RECORD_WITH_REQUIRED_STRING = "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"field_1\",\"type\":{\"type\":\"string\"}}]}";
+
+  /* equivalent to message Foo { optional binary field_1 (UTF8); } */
+  static final String RECORD_WITH_OPTIONAL_STRING = "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"field_1\",\"type\":[\"null\",{\"type\":\"string\"}],\"default\":null}]}";
+
+  /* equivalent to message Foo { required int64 field_1; } */
+  static final String RECORD_WITH_REQUIRED_LONG = "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"field_1\",\"type\":{\"type\":\"long\"}}]}";
+
+  /* equivalent to message Foo { optional binary field_1 (UTF8); required binary field_2 (UTF8) = "foo"; } */
+  static final String RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS = "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"field_1\",\"type\":[\"null\",{\"type\":\"string\"}],\"default\":null},{\"name\":\"field_2\",\"type\":{\"type\":\"string\"},\"default\":\"foo\"}]}";
+
+  /* Parquet Schemas */
+
+  static final String MESSAGE_WITH_REQUIRED_STRING = "message Foo { required binary field_1 (UTF8); }";
+
+  static final String MESSAGE_WITH_REQUIRED_AND_OPTIONAL_STRINGS = "message Foo { optional binary field_1 (UTF8); required binary field_2 (UTF8); }";
+
+  /* Changing a field from required to optional is valid */
+  @Test
+  public void testValidSchemaCompatibility() throws Exception {
+    Schema readerSchema = new Schema.Parser().parse(RECORD_WITH_OPTIONAL_STRING);
+    Schema writerSchema = new Schema.Parser().parse(RECORD_WITH_REQUIRED_STRING);
+    boolean result = isSchemaCompatible(readerSchema, writerSchema);
+    assertTrue(result);
+  }
+
+  /* Changing a field from string to long */
+  @Test
+  public void testInvalidSchemaCompatibility() throws Exception {
+    Schema readerSchema = new Schema.Parser().parse(RECORD_WITH_REQUIRED_LONG);
+    Schema writerSchema = new Schema.Parser().parse(RECORD_WITH_REQUIRED_STRING);
+    boolean result = isSchemaCompatible(readerSchema, writerSchema);
+    assertFalse(result);
+  }
+
+  /* Changing a field from required to optional and adding an additional field */
+  @Test
+  public void testValidAggregateSchemaCompatibility() throws Exception {
+    String[] writerSchemaStrings = {
+      RECORD_WITH_REQUIRED_STRING,
+      RECORD_WITH_OPTIONAL_STRING,
+      RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS
+    };
+    Set<Schema> writerSchemas = new HashSet<Schema>();
+    for (String s : writerSchemaStrings) {
+      Schema writerSchema = new Schema.Parser().parse(s);
+      writerSchemas.add(writerSchema);
+    }
+    Schema readerSchema = new Schema.Parser().parse(RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS);
+    boolean result = areSchemasCompatible(readerSchema, writerSchemas);
+    assertTrue(result);
+  }
+
+  /* Changing a field from required to optional, changing a field type from string to long, and adding an additional field */
+  @Test
+  public void testInvalidAggregateSchemaCompatibility() throws Exception {
+    String[] writerSchemaStrings = {
+      RECORD_WITH_REQUIRED_STRING,
+      RECORD_WITH_OPTIONAL_STRING,
+      RECORD_WITH_REQUIRED_LONG,
+      RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS
+    };
+    Set<Schema> writerSchemas = new HashSet<Schema>();
+    for (String s : writerSchemaStrings) {
+      Schema writerSchema = new Schema.Parser().parse(s);
+      writerSchemas.add(writerSchema);
+    }
+    Schema readerSchema = new Schema.Parser().parse(RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS);
+    boolean result = areSchemasCompatible(readerSchema, writerSchemas);
+    assertFalse(result);
+  }
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
+  /* Reader schema supplied */
+  @Test
+  public void doesNotThrowRuntimeExceptionIfAvroReadSchemaSet() {
+    InitContext context = initContext(RECORD_WITH_REQUIRED_STRING, null, MESSAGE_WITH_REQUIRED_STRING);
+    AvroReadSupport readSupport = new AvroReadSupport();
+    readSupport.init(context);
+  }
+
+  /* No reader schema supplied */
+  @Test
+  public void doesNotThrowsRuntimeExceptionIfAvroReadSchemaUnset() {
+    InitContext context = initContext(null, null, MESSAGE_WITH_REQUIRED_STRING);
+    AvroReadSupport readSupport = new AvroReadSupport();
+    readSupport.init(context);
+  }
+
+  /* No reader schema supplied, but one writer schema found */
+  @Test
+  public void doesNotThrowRuntimeExceptionIfAvroReadSchemaUnsetAndWriterSchemaPresent() {
+    Set<String> writerSchemaStrings = new HashSet<String>();
+    writerSchemaStrings.add(RECORD_WITH_REQUIRED_STRING);
+    InitContext context = initContext(null, writerSchemaStrings, MESSAGE_WITH_REQUIRED_STRING);
+    AvroReadSupport readSupport = new AvroReadSupport();
+    readSupport.init(context);
+  }
+
+  /* No reader schema supplied, but multiple writer schemas found */
+  @Test
+  public void throwsRuntimeExceptionIfAvroReadSchemaUnsetAndWriterSchemasPresent() {
+    Set<String> writerSchemaStrings = new HashSet<String>();
+    writerSchemaStrings.add(RECORD_WITH_REQUIRED_STRING);
+    writerSchemaStrings.add(RECORD_WITH_OPTIONAL_STRING);
+    InitContext context = initContext(null, writerSchemaStrings, MESSAGE_WITH_REQUIRED_STRING);
+    AvroReadSupport readSupport = new AvroReadSupport();
+    exception.expect(RuntimeException.class);
+    exception.expectMessage("could not merge metadata: key " + AVRO_SCHEMA_METADATA_KEY + " has conflicting values");
+    readSupport.init(context);
+  }
+
+  /* Changing a field from required to optional, changing a field type from string to long, and adding an additional field */
+  @Test
+  public void throwsRuntimeExceptionIfSchemasAreNotCompatible() {
+    String readerSchemaString = RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS;
+    Set<String> writerSchemaStrings = new HashSet<String>();
+    writerSchemaStrings.add(RECORD_WITH_REQUIRED_STRING);
+    writerSchemaStrings.add(RECORD_WITH_OPTIONAL_STRING);
+    writerSchemaStrings.add(RECORD_WITH_REQUIRED_LONG);
+    writerSchemaStrings.add(RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS);
+    String parquetSchemaString = MESSAGE_WITH_REQUIRED_AND_OPTIONAL_STRINGS;
+    InitContext context = initContext(readerSchemaString, writerSchemaStrings, parquetSchemaString);
+    AvroReadSupport readSupport = new AvroReadSupport();
+    exception.expect(RuntimeException.class);
+    exception.expectMessage("could not merge metadata: key " + AVRO_SCHEMA_METADATA_KEY + " contains incompatible schemas");
+    readSupport.init(context);
+  }
+
+  /* Changing a field from required to optional and adding an additional field */
+  @Test
+  public void doesNotThrowRuntimeExceptionIfSchemasAreCompatible() {
+    String readerSchemaString = RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS;
+    Set<String> writerSchemaStrings = new HashSet<String>();
+    writerSchemaStrings.add(RECORD_WITH_REQUIRED_STRING);
+    writerSchemaStrings.add(RECORD_WITH_OPTIONAL_STRING);
+    writerSchemaStrings.add(RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS);
+    String parquetSchemaString = MESSAGE_WITH_REQUIRED_AND_OPTIONAL_STRINGS;
+    InitContext context = initContext(readerSchemaString, writerSchemaStrings, parquetSchemaString);
+    AvroReadSupport readSupport = new AvroReadSupport();
+    readSupport.init(context);
+  }
+
+  /* Although only compatible schemas provided, do not check for compatibility if flag unset */
+  @Test
+  public void throwRuntimeExceptionIfSchemasAreCompatibleButCheckDisabled() {
+    String readerSchemaString = RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS;
+    Set<String> writerSchemaStrings = new HashSet<String>();
+    writerSchemaStrings.add(RECORD_WITH_REQUIRED_STRING);
+    writerSchemaStrings.add(RECORD_WITH_OPTIONAL_STRING);
+    writerSchemaStrings.add(RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS);
+    String parquetSchemaString = MESSAGE_WITH_REQUIRED_AND_OPTIONAL_STRINGS;
+    InitContext context = initContext(readerSchemaString, writerSchemaStrings, parquetSchemaString);
+    AvroReadSupport.disableAvroSchemaCompatibilityCheck(context.getConfiguration());
+    AvroReadSupport readSupport = new AvroReadSupport();
+    exception.expect(RuntimeException.class);
+    exception.expectMessage("could not merge metadata: key " + AVRO_SCHEMA_METADATA_KEY + " has conflicting values");
+    readSupport.init(context);
+  }
+
+  /* Helper function to build an instance of InitContext given Avro and Parquet schemas
+   * NOTE: Invoking this method will enable Avro schema compatibility checking!
+   */
+  static InitContext initContext(String readerSchemaString, Set<String> writerSchemaStrings, String parquetSchemaString) {
+    Configuration configuration = new Configuration(false);
+    configuration.setBoolean(AVRO_SCHEMA_COMPATIBILITY_CHECK, true);
+    if (readerSchemaString != null)
+      configuration.set(AVRO_READ_SCHEMA, readerSchemaString);
+    Map<String, Set<String>> metadata = new HashMap<String, Set<String>>();
+    if (writerSchemaStrings != null)
+      metadata.put(AVRO_SCHEMA_METADATA_KEY, writerSchemaStrings);
+    MessageType messageType = MessageTypeParser.parseMessageType(parquetSchemaString);
+    return new InitContext(configuration, metadata, messageType);
+  }
+}

--- a/parquet-avro/src/test/java/parquet/avro/TestAvroReadSupport.java
+++ b/parquet-avro/src/test/java/parquet/avro/TestAvroReadSupport.java
@@ -19,22 +19,67 @@ public class TestAvroReadSupport {
   /* Avro Schemas */
 
   /* equivalent to message Foo { required binary field_1 (UTF8); } */
-  static final String RECORD_WITH_REQUIRED_STRING = "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"field_1\",\"type\":{\"type\":\"string\"}}]}";
+  static final String RECORD_WITH_REQUIRED_STRING =
+    "{\"type\":\"record\"," +
+    " \"name\":\"Foo\"," +
+    " \"fields\":[" +
+    "    {\"name\":\"field_1\"," +
+    "     \"type\":{\"type\":\"string\"}" +
+    "    }" +
+    "  ]" +
+    "}";
 
   /* equivalent to message Foo { optional binary field_1 (UTF8); } */
-  static final String RECORD_WITH_OPTIONAL_STRING = "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"field_1\",\"type\":[\"null\",{\"type\":\"string\"}],\"default\":null}]}";
+  static final String RECORD_WITH_OPTIONAL_STRING =
+    "{\"type\":\"record\"," +
+    " \"name\":\"Foo\"," +
+    " \"fields\":[" +
+    "    {\"name\":\"field_1\"," +
+    "     \"type\":[\"null\",{\"type\":\"string\"}]," +
+    "     \"default\":null" +
+    "    }" +
+    "  ]" +
+    "}";
 
   /* equivalent to message Foo { required int64 field_1; } */
-  static final String RECORD_WITH_REQUIRED_LONG = "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"field_1\",\"type\":{\"type\":\"long\"}}]}";
+  static final String RECORD_WITH_REQUIRED_LONG =
+    "{\"type\":\"record\"," +
+    " \"name\":\"Foo\"," +
+    " \"fields\":[" +
+    "    {\"name\":\"field_1\"," +
+    "     \"type\":{\"type\":\"long\"}" +
+    "    }" +
+    "  ]" +
+    "}";
 
   /* equivalent to message Foo { optional binary field_1 (UTF8); required binary field_2 (UTF8) = "foo"; } */
-  static final String RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS = "{\"type\":\"record\",\"name\":\"Foo\",\"fields\":[{\"name\":\"field_1\",\"type\":[\"null\",{\"type\":\"string\"}],\"default\":null},{\"name\":\"field_2\",\"type\":{\"type\":\"string\"},\"default\":\"foo\"}]}";
+  static final String RECORD_WITH_REQUIRED_AND_OPTIONAL_STRINGS = 
+    "{\"type\":\"record\"," +
+    " \"name\":\"Foo\"," +
+    " \"fields\":[" +
+    "    {\"name\":\"field_1\"," +
+    "     \"type\":[\"null\",{\"type\":\"string\"}]," +
+    "     \"default\":null" +
+    "    }," +
+    "    {\"name\":\"field_2\"," +
+    "     \"type\":{\"type\":\"string\"}," +
+    "     \"default\":\"foo\"" +
+    "    }" +
+    "  ]" +
+    "}";
 
   /* Parquet Schemas */
 
-  static final String MESSAGE_WITH_REQUIRED_STRING = "message Foo { required binary field_1 (UTF8); }";
+  static final String MESSAGE_WITH_REQUIRED_STRING =
+    "message Foo {" +
+    "  required binary field_1 (UTF8);" +
+    "}";
 
-  static final String MESSAGE_WITH_REQUIRED_AND_OPTIONAL_STRINGS = "message Foo { optional binary field_1 (UTF8); required binary field_2 (UTF8); }";
+  static final String MESSAGE_WITH_REQUIRED_AND_OPTIONAL_STRINGS =
+    "message Foo {" +
+    "  optional binary field_1 (UTF8);" +
+    "  required binary field_2 (UTF8);" +
+    "}";
 
   /* Changing a field from required to optional is valid */
   @Test

--- a/parquet-avro/src/test/java/parquet/avro/TestReadWrite.java
+++ b/parquet-avro/src/test/java/parquet/avro/TestReadWrite.java
@@ -35,7 +35,9 @@ import org.apache.avro.util.Utf8;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.codehaus.jackson.node.NullNode;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import parquet.hadoop.ParquetWriter;
 import parquet.hadoop.api.WriteSupport;
 import parquet.io.api.Binary;
@@ -398,6 +400,58 @@ public class TestReadWrite {
     assertEquals(ImmutableMap.of("a", 1, "b", 2), nextRecord.get("mymap"));
     assertEquals(genericFixed, nextRecord.get("myfixed"));
 
+  }
+
+  @Rule
+  public TemporaryFolder dir = new TemporaryFolder();
+
+  /** FIXME test fails!
+   * potentially different underlying behavior than ParquetAvroInputFormat/ParquetInputFormat
+   * is it attempting to merge the parquet schemas as oppossed to just merging the avro ones?
+   * i would think:
+   *  read parquet file 1, extract avro record with schema 1 and migrate to schema 2
+   *  read parquet file 2, extract avro record with schema 2
+   * but potentially parquet schemas in all files are merged and the same logic is used
+   * for to extract all records, which isn't necessarily sound schema evolution...
+   */
+  @Test
+  public void testSchemaCompatibility() throws Exception {
+    // write to a file with schema 1
+    Schema schema1 = new Schema.Parser().parse(Resources.getResource("foo1.avsc").openStream());
+    File file1 = dir.newFile("foo1.avro.parquet");
+    Path path1 = new Path(file1.getPath());
+    file1.delete();
+    AvroParquetWriter<GenericRecord> writer1 = new AvroParquetWriter<GenericRecord>(path1, schema1);
+    GenericData.Record record1 = new GenericRecordBuilder(schema1)
+        .set("field_1", new Utf8("a"))
+      .build();
+    writer1.write(record1);
+    writer1.close();
+
+    // write to a different file with schema 2
+    Schema schema2 = new Schema.Parser().parse(Resources.getResource("foo2.avsc").openStream());
+    File file2 = dir.newFile("foo2.avro.parquet");
+    Path path2 = new Path(file2.getPath());
+    file2.delete();
+    AvroParquetWriter<GenericRecord> writer2 = new AvroParquetWriter<GenericRecord>(path2, schema2);
+    GenericData.Record record2 = new GenericRecordBuilder(schema2)
+        .set("field_1", new Utf8("b"))
+        .build();
+    writer2.write(record2);
+    writer2.close();
+
+    // read from both files, testing schema compatibility between schema1 and schema2
+    Path parent = new Path(dir.getRoot().getPath());
+    Configuration configuration = new Configuration(false);
+    AvroReadSupport.setAvroReadSchema(configuration, schema2);
+    AvroReadSupport.enableAvroSchemaCompatibilityCheck(configuration);
+    AvroParquetReader<GenericRecord> reader = new AvroParquetReader<GenericRecord>(configuration, parent);
+    GenericRecord nextRecord1 = reader.read();
+    assertNotNull(nextRecord1);
+    assertEquals(nextRecord1.get("field_1"), "a");
+    GenericRecord nextRecord2 = reader.read();
+    assertNotNull(nextRecord2);
+    assertEquals(nextRecord2.get("field_1"), "b");
   }
 
 }

--- a/parquet-avro/src/test/resources/foo1.avsc
+++ b/parquet-avro/src/test/resources/foo1.avsc
@@ -1,0 +1,9 @@
+{ "type": "record"
+, "name": "Foo"
+, "fields":
+  [
+    { "name": "field_1"
+    , "type": { "type": "string" }
+    }
+  ]
+}

--- a/parquet-avro/src/test/resources/foo2.avsc
+++ b/parquet-avro/src/test/resources/foo2.avsc
@@ -1,0 +1,10 @@
+{ "type": "record"
+, "name": "Foo"
+, "fields":
+  [
+    { "name": "field_1"
+    , "type": [ "null",  { "type": "string" } ]
+    , "default": null
+    }
+  ]
+}


### PR DESCRIPTION
This pull request provides a derived version of `AvroReadSupport` that supports Avro schema resolution.

Currently, `AvroReadSupport` will throw a runtime exception if there exist Parquet-Avro files with different Avro schemas.

This is a problem our organization has encountered when running MapReduce jobs over a large range of Parquet-Avro files as Avro schemas may change over time.

Differing Avro schemas may be "compatible" -- a feature of Avro's schema resolution/evolution -- and if schemas in a given input set are compatible, they can be resolved to a single Avro schema.

The provided solution extends `AvroReadSupport` (for backwards compatibility) and uses the utilities provided by the Apache Avro library for checking if all Avro schemas present in the Parquet-Avro data files are compatible with the given "reader" schema.

See https://issues.apache.org/jira/browse/PARQUET-171 for a full description of the problem and solution.

/cc @rdblue  