### PR TITLE
PARQUET-176 : whitespace for other os

### DIFF
--- a/parquet-column/src/main/java/parquet/schema/MessageTypeParser.java
+++ b/parquet-column/src/main/java/parquet/schema/MessageTypeParser.java
@@ -40,7 +40,7 @@ public class MessageTypeParser {
     private StringBuffer currentLine = new StringBuffer();
 
     public Tokenizer(String schemaString, String string) {
-      st = new StringTokenizer(schemaString, " ,;{}()\n\t=", true);
+      st = new StringTokenizer(schemaString, " ,;{}()\n\t\r=", true);
     }
 
     public String nextToken() {
@@ -60,7 +60,7 @@ public class MessageTypeParser {
     }
 
     private boolean isWhitespace(String t) {
-      return t.equals(" ") || t.equals("\t") || t.equals("\n");
+      return t.equals(" ") || t.equals("\t") || t.equals("\n") || t.equals("\r");
     }
 
     public String getLocationString() {
@@ -80,7 +80,7 @@ public class MessageTypeParser {
   }
 
   private static MessageType parse(String schemaString) {
-    Tokenizer st = new Tokenizer(schemaString, " ;{}()\n\t");
+    Tokenizer st = new Tokenizer(schemaString, " ;{}()\n\t\r");
     Types.MessageTypeBuilder builder = Types.buildMessage();
 
     String t = st.nextToken();


### PR DESCRIPTION
PARQUET-176 Parquet fails to parse schema contains '\r'