### PR TITLE
PARQUET-225: INT64 support for Delta Encoding

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java
@@ -21,6 +21,7 @@ package org.apache.parquet.column;
 import static org.apache.parquet.column.values.bitpacking.Packer.BIG_ENDIAN;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
 
@@ -163,8 +164,8 @@ public enum Encoding {
   DELTA_BINARY_PACKED {
     @Override
     public ValuesReader getValuesReader(ColumnDescriptor descriptor, ValuesType valuesType) {
-      if(descriptor.getType() != INT32) {
-        throw new ParquetDecodingException("Encoding DELTA_BINARY_PACKED is only supported for type INT32");
+      if(descriptor.getType() != INT32 && descriptor.getType() != INT64) {
+        throw new ParquetDecodingException("Encoding DELTA_BINARY_PACKED is only supported for type INT32 and INT64");
       }
       return new DeltaBinaryPackingValuesReader();
     }

--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -170,9 +170,9 @@ public class ParquetProperties {
       case FIXED_LEN_BYTE_ARRAY:
         return new DeltaByteArrayWriter(initialSizePerCol, pageSize,this.allocator);
       case INT32:
+      case INT64:
         return new DeltaBinaryPackingValuesWriter(initialSizePerCol, pageSize, this.allocator);
       case INT96:
-      case INT64:
       case DOUBLE:
       case FLOAT:
         return plainWriter(path, initialSizePerCol, pageSize);

--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -18,20 +18,21 @@
  */
 package org.apache.parquet.column;
 
-import org.apache.parquet.Preconditions;
-import org.apache.parquet.bytes.ByteBufferAllocator;
-import org.apache.parquet.bytes.HeapByteBufferAllocator;
-
 import static org.apache.parquet.bytes.BytesUtils.getWidthFromMaxInt;
 import static org.apache.parquet.column.Encoding.PLAIN;
 import static org.apache.parquet.column.Encoding.PLAIN_DICTIONARY;
 import static org.apache.parquet.column.Encoding.RLE_DICTIONARY;
+
+import org.apache.parquet.Preconditions;
+import org.apache.parquet.bytes.ByteBufferAllocator;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.column.impl.ColumnWriteStoreV1;
 import org.apache.parquet.column.impl.ColumnWriteStoreV2;
 import org.apache.parquet.column.page.PageWriteStore;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.boundedint.DevNullValuesWriter;
-import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
 import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter;
@@ -170,8 +171,9 @@ public class ParquetProperties {
       case FIXED_LEN_BYTE_ARRAY:
         return new DeltaByteArrayWriter(initialSizePerCol, pageSize,this.allocator);
       case INT32:
+        return new DeltaBinaryPackingValuesWriterForInteger(initialSizePerCol, pageSize, this.allocator);
       case INT64:
-        return new DeltaBinaryPackingValuesWriter(initialSizePerCol, pageSize, this.allocator);
+        return new DeltaBinaryPackingValuesWriterForLong(initialSizePerCol, pageSize, this.allocator);
       case INT96:
       case DOUBLE:
       case FLOAT:

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriter.java
@@ -50,73 +50,40 @@ import java.io.IOException;
  *
  * @author Tianshuo Deng
  */
-public class DeltaBinaryPackingValuesWriter extends ValuesWriter {
-  /**
-   * Is the current column of type int (INT32)
-   */
-  private boolean isInt;
-
-  /**
-   * max bitwidth for a mini block, it is used to allocate miniBlockByteBuffer which is
-   * reused between flushes.
-   */
-  public static final int MAX_BITWIDTH = 64;
+public abstract class DeltaBinaryPackingValuesWriter extends ValuesWriter {
 
   public static final int DEFAULT_NUM_BLOCK_VALUES = 128;
 
   public static final int DEFAULT_NUM_MINIBLOCKS = 4;
 
-  private final CapacityByteArrayOutputStream baos;
+  protected final CapacityByteArrayOutputStream baos;
 
   /**
    * stores blockSizeInValues, miniBlockNumInABlock and miniBlockSizeInValues
    */
-  private final DeltaBinaryPackingConfig config;
+  protected final DeltaBinaryPackingConfig config;
 
   /**
    * bit width for each mini block, reused between flushes
    */
-  private final int[] bitWidths;
+  protected final int[] bitWidths;
 
-  private int totalValueCount = 0;
+  protected int totalValueCount = 0;
 
   /**
    * a pointer to deltaBlockBuffer indicating the end of deltaBlockBuffer
    * the number of values in the deltaBlockBuffer that haven't flushed to baos
    * it will be reset after each flush
    */
-  private int deltaValuesToFlush = 0;
-
-  /**
-   * stores delta values starting from the 2nd value written(1st value is stored in header).
-   * It's reused between flushes
-   */
-  private long[] deltaBlockBuffer;
+  protected int deltaValuesToFlush = 0;
 
   /**
    * bytes buffer for a mini block, it is reused for each mini block.
    * Therefore the size of biggest miniblock with bitwith of MAX_BITWITH is allocated
    */
-  private byte[] miniBlockByteBuffer;
+  protected byte[] miniBlockByteBuffer;
 
-  /**
-   * firstValue is written to the header of the page
-   */
-  private long firstValue = 0;
-
-  /**
-   * cache previous written value for calculating delta
-   */
-  private long previousValue = 0;
-
-  /**
-   * min delta is written to the beginning of each block.
-   * it's zig-zag encoded. The deltas stored in each block is actually the difference to min delta,
-   * therefore are all positive
-   * it will be reset after each flush
-   */
-  private long minDeltaInCurrentBlock = Long.MAX_VALUE;
-
+// TODO: remove this.
   public DeltaBinaryPackingValuesWriter(int slabSize, int pageSize, ByteBufferAllocator allocator) {
     this(DEFAULT_NUM_BLOCK_VALUES, DEFAULT_NUM_MINIBLOCKS, slabSize, pageSize, allocator);
   }
@@ -124,8 +91,6 @@ public class DeltaBinaryPackingValuesWriter extends ValuesWriter {
   public DeltaBinaryPackingValuesWriter(int blockSizeInValues, int miniBlockNum, int slabSize, int pageSize, ByteBufferAllocator allocator) {
     this.config = new DeltaBinaryPackingConfig(blockSizeInValues, miniBlockNum);
     bitWidths = new int[config.miniBlockNumInABlock];
-    deltaBlockBuffer = new long[config.blockSizeInValues];
-    miniBlockByteBuffer = new byte[config.miniBlockSizeInValues * MAX_BITWIDTH];
     baos = new CapacityByteArrayOutputStream(slabSize, pageSize, allocator);
   }
 
@@ -134,89 +99,7 @@ public class DeltaBinaryPackingValuesWriter extends ValuesWriter {
     return baos.size();
   }
 
-  @Override
-  public void writeInteger(int v) {
-    /*
-     * isInt is needed. Just calling internalWrite might result in a different binary representation.
-     * Example: [Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MIN_VALUE, Integer.MAX_VALUE]
-     */
-    isInt = true;
-    internalWrite(v);
-  }
-
-  @Override
-  public void writeLong(long v) {
-    isInt = false;
-    internalWrite(v);
-  }
-
-  public void internalWrite(long v) {
-    totalValueCount++;
-
-    if (totalValueCount == 1) {
-      firstValue = v;
-      previousValue = firstValue;
-      return;
-    }
-
-    // Calculate delta. The possible overflow is accounted for. The algorithm is correct because
-    // Java long is working as a mudalar ring with base 2^64 and because of the plus and minus
-    // properties of a ring. http://en.wikipedia.org/wiki/Modular_arithmetic#Integers_modulo_n
-    long delta = v - previousValue;
-    previousValue = v;
-
-    deltaBlockBuffer[deltaValuesToFlush++] = delta;
-
-    if (delta < minDeltaInCurrentBlock) {
-      minDeltaInCurrentBlock = delta;
-    }
-
-    if (config.blockSizeInValues == deltaValuesToFlush) {
-      flushBlockBuffer();
-    }
-  }
-
-  private void flushBlockBuffer() {
-    //since we store the min delta, the deltas will be converted to be the difference to min delta and all positive
-    for (int i = 0; i < deltaValuesToFlush; i++) {
-      deltaBlockBuffer[i] = deltaBlockBuffer[i] - minDeltaInCurrentBlock;
-    }
-
-    if (isInt) {
-      minDeltaInCurrentBlock = (int) minDeltaInCurrentBlock;
-      for (int i = 0; i < deltaValuesToFlush; i++) {
-        deltaBlockBuffer[i] &= (1l << 32) - 1l;
-      }
-    }
-
-    writeMinDelta();
-    int miniBlocksToFlush = getMiniBlockCountToFlush(deltaValuesToFlush);
-
-    calculateBitWidthsForDeltaBlockBuffer(miniBlocksToFlush);
-    for (int i = 0; i < config.miniBlockNumInABlock; i++) {
-      writeBitWidthForMiniBlock(i);
-    }
-
-    for (int i = 0; i < miniBlocksToFlush; i++) {
-      //writing i th miniblock
-      int currentBitWidth = bitWidths[i];
-      BytePackerForLong packer = Packer.LITTLE_ENDIAN.newBytePackerForLong(currentBitWidth);
-      int miniBlockStart = i * config.miniBlockSizeInValues;
-      for (int j = miniBlockStart; j < (i + 1) * config.miniBlockSizeInValues; j += 8) {//8 values per pack
-        // mini block is atomic in terms of flushing
-        // This may write more values when reach to the end of data writing to last mini block,
-        // since it may not be aligend to miniblock,
-        // but doesnt matter. The reader uses total count to see if reached the end.
-        packer.pack8Values(deltaBlockBuffer, j, miniBlockByteBuffer, 0);
-        baos.write(miniBlockByteBuffer, 0, currentBitWidth);
-      }
-    }
-
-    minDeltaInCurrentBlock = Long.MAX_VALUE;
-    deltaValuesToFlush = 0;
-  }
-
-  private void writeBitWidthForMiniBlock(int i) {
+  protected void writeBitWidthForMiniBlock(int i) {
     try {
       BytesUtils.writeIntLittleEndianOnOneByte(baos, bitWidths[i]);
     } catch (IOException e) {
@@ -224,55 +107,8 @@ public class DeltaBinaryPackingValuesWriter extends ValuesWriter {
     }
   }
 
-  private void writeMinDelta() {
-    try {
-      BytesUtils.writeZigZagVarLong(minDeltaInCurrentBlock, baos);
-    } catch (IOException e) {
-      throw new ParquetEncodingException("can not write min delta for block", e);
-    }
-  }
-
-  /**
-   * iterate through values in each mini block and calculate the bitWidths of max values.
-   *
-   * @param miniBlocksToFlush
-   */
-  private void calculateBitWidthsForDeltaBlockBuffer(int miniBlocksToFlush) {
-    for (int miniBlockIndex = 0; miniBlockIndex < miniBlocksToFlush; miniBlockIndex++) {
-
-      long mask = 0;
-      int miniStart = miniBlockIndex * config.miniBlockSizeInValues;
-
-      //The end of current mini block could be the end of current block(deltaValuesToFlush) buffer when data is not aligned to mini block
-      int miniEnd = Math.min((miniBlockIndex + 1) * config.miniBlockSizeInValues, deltaValuesToFlush);
-
-      for (int i = miniStart; i < miniEnd; i++) {
-        mask |= deltaBlockBuffer[i];
-      }
-      bitWidths[miniBlockIndex] = 64 - Long.numberOfLeadingZeros(mask);
-    }
-  }
-
-  private int getMiniBlockCountToFlush(double numberCount) {
+  protected int getMiniBlockCountToFlush(double numberCount) {
     return (int) Math.ceil(numberCount / config.miniBlockSizeInValues);
-  }
-
-  /**
-   * getBytes will trigger flushing block buffer, DO NOT write after getBytes() is called without calling reset()
-   *
-   * @return
-   */
-  @Override
-  public BytesInput getBytes() {
-    //The Page Header should include: blockSizeInValues, numberOfMiniBlocks, totalValueCount
-    if (deltaValuesToFlush != 0) {
-      flushBlockBuffer();
-    }
-    return BytesInput.concat(
-            config.toBytesInput(),
-            BytesInput.fromUnsignedVarInt(totalValueCount),
-            BytesInput.fromZigZagVarLong(firstValue),
-            BytesInput.from(baos));
   }
 
   @Override
@@ -285,7 +121,6 @@ public class DeltaBinaryPackingValuesWriter extends ValuesWriter {
     this.totalValueCount = 0;
     this.baos.reset();
     this.deltaValuesToFlush = 0;
-    this.minDeltaInCurrentBlock = Long.MAX_VALUE;
   }
 
   @Override
@@ -293,7 +128,6 @@ public class DeltaBinaryPackingValuesWriter extends ValuesWriter {
     this.totalValueCount = 0;
     this.baos.close();
     this.deltaValuesToFlush = 0;
-    this.minDeltaInCurrentBlock = Integer.MAX_VALUE;
   }
 
   @Override

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForInteger.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForInteger.java
@@ -1,0 +1,200 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.delta;
+
+import java.io.IOException;
+
+import org.apache.parquet.bytes.ByteBufferAllocator;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.column.values.bitpacking.BytePacker;
+import org.apache.parquet.column.values.bitpacking.Packer;
+import org.apache.parquet.io.ParquetEncodingException;
+
+/**
+ * Write integers (INT32) with delta encoding and binary packing.
+ * 
+ * @author Vassil Lunchev
+ */
+public class DeltaBinaryPackingValuesWriterForInteger extends DeltaBinaryPackingValuesWriter {
+  /**
+   * max bitwidth for a mini block, it is used to allocate miniBlockByteBuffer which is
+   * reused between flushes.
+   */
+  public static final int MAX_BITWIDTH = 32;
+
+  /**
+   * stores delta values starting from the 2nd value written(1st value is stored in header).
+   * It's reused between flushes
+   */
+  private int[] deltaBlockBuffer;
+
+  /**
+   * firstValue is written to the header of the page
+   */
+  private int firstValue = 0;
+
+  /**
+   * cache previous written value for calculating delta
+   */
+  private int previousValue = 0;
+
+  /**
+   * min delta is written to the beginning of each block.
+   * it's zig-zag encoded. The deltas stored in each block is actually the difference to min delta,
+   * therefore are all positive
+   * it will be reset after each flush
+   */
+  private int minDeltaInCurrentBlock = Integer.MAX_VALUE;
+
+  public DeltaBinaryPackingValuesWriterForInteger(
+      int slabSize, int pageSize, ByteBufferAllocator allocator) {
+    this(DEFAULT_NUM_BLOCK_VALUES, DEFAULT_NUM_MINIBLOCKS, slabSize, pageSize, allocator);
+  }
+
+  public DeltaBinaryPackingValuesWriterForInteger(int blockSizeInValues, int miniBlockNum, 
+      int slabSize, int pageSize, ByteBufferAllocator allocator) {
+    super(blockSizeInValues, miniBlockNum, slabSize, pageSize, allocator);
+    deltaBlockBuffer = new int[config.blockSizeInValues];
+    miniBlockByteBuffer = new byte[config.miniBlockSizeInValues * MAX_BITWIDTH];
+  }
+
+  @Override
+  public void writeInteger(int v) {
+    internalWrite(v);
+  }
+
+  public void internalWrite(int v) {
+    totalValueCount++;
+
+    if (totalValueCount == 1) {
+      firstValue = v;
+      previousValue = firstValue;
+      return;
+    }
+
+    // Calculate delta. The possible overflow is accounted for. The algorithm is correct because
+    // Java int is working as a mudalar ring with base 2^32 and because of the plus and minus
+    // properties of a ring. http://en.wikipedia.org/wiki/Modular_arithmetic#Integers_modulo_n
+    int delta = v - previousValue;
+    previousValue = v;
+
+    deltaBlockBuffer[deltaValuesToFlush++] = delta;
+
+    if (delta < minDeltaInCurrentBlock) {
+      minDeltaInCurrentBlock = delta;
+    }
+
+    if (config.blockSizeInValues == deltaValuesToFlush) {
+      flushBlockBuffer();
+    }
+  }
+
+  private void flushBlockBuffer() {
+    // since we store the min delta, the deltas will be converted to be the difference to min delta
+    // and all positive
+    for (int i = 0; i < deltaValuesToFlush; i++) {
+      deltaBlockBuffer[i] = deltaBlockBuffer[i] - minDeltaInCurrentBlock;
+    }
+
+    writeMinDelta();
+    int miniBlocksToFlush = getMiniBlockCountToFlush(deltaValuesToFlush);
+
+    calculateBitWidthsForDeltaBlockBuffer(miniBlocksToFlush);
+    for (int i = 0; i < config.miniBlockNumInABlock; i++) {
+      writeBitWidthForMiniBlock(i);
+    }
+
+    for (int i = 0; i < miniBlocksToFlush; i++) {
+      //writing i th miniblock
+      int currentBitWidth = bitWidths[i];
+      BytePacker packer = Packer.LITTLE_ENDIAN.newBytePacker(currentBitWidth);
+      int miniBlockStart = i * config.miniBlockSizeInValues;
+      for (int j = miniBlockStart; j < (i + 1) * config.miniBlockSizeInValues; j += 8) {//8 values per pack
+        // mini block is atomic in terms of flushing
+        // This may write more values when reach to the end of data writing to last mini block,
+        // since it may not be aligend to miniblock,
+        // but doesnt matter. The reader uses total count to see if reached the end.
+        packer.pack8Values(deltaBlockBuffer, j, miniBlockByteBuffer, 0);
+        baos.write(miniBlockByteBuffer, 0, currentBitWidth);
+      }
+    }
+
+    minDeltaInCurrentBlock = Integer.MAX_VALUE;
+    deltaValuesToFlush = 0;
+  }
+
+  private void writeMinDelta() {
+    try {
+      BytesUtils.writeZigZagVarInt(minDeltaInCurrentBlock, baos);
+    } catch (IOException e) {
+      throw new ParquetEncodingException("can not write min delta for block", e);
+    }
+  }
+
+  /**
+   * iterate through values in each mini block and calculate the bitWidths of max values.
+   *
+   * @param miniBlocksToFlush
+   */
+  private void calculateBitWidthsForDeltaBlockBuffer(int miniBlocksToFlush) {
+    for (int miniBlockIndex = 0; miniBlockIndex < miniBlocksToFlush; miniBlockIndex++) {
+      int mask = 0;
+      int miniStart = miniBlockIndex * config.miniBlockSizeInValues;
+
+      //The end of current mini block could be the end of current block(deltaValuesToFlush) buffer when data is not aligned to mini block
+      int miniEnd = Math.min((miniBlockIndex + 1) * config.miniBlockSizeInValues, deltaValuesToFlush);
+
+      for (int i = miniStart; i < miniEnd; i++) {
+        mask |= deltaBlockBuffer[i];
+      }
+      bitWidths[miniBlockIndex] = 32 - Integer.numberOfLeadingZeros(mask);
+    }
+  }
+
+  /**
+   * getBytes will trigger flushing block buffer, DO NOT write after getBytes() is called without calling reset()
+   *
+   * @return
+   */
+  @Override
+  public BytesInput getBytes() {
+    //The Page Header should include: blockSizeInValues, numberOfMiniBlocks, totalValueCount
+    if (deltaValuesToFlush != 0) {
+      flushBlockBuffer();
+    }
+    return BytesInput.concat(
+            config.toBytesInput(),
+            BytesInput.fromUnsignedVarInt(totalValueCount),
+            BytesInput.fromZigZagVarInt(firstValue),
+            BytesInput.from(baos));
+  }
+
+  @Override
+  public void reset() {
+    super.reset();
+    this.minDeltaInCurrentBlock = Integer.MAX_VALUE;
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    this.minDeltaInCurrentBlock = Integer.MAX_VALUE;
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForLong.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForLong.java
@@ -1,0 +1,200 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.delta;
+
+import java.io.IOException;
+
+import org.apache.parquet.bytes.ByteBufferAllocator;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.column.values.bitpacking.BytePackerForLong;
+import org.apache.parquet.column.values.bitpacking.Packer;
+import org.apache.parquet.io.ParquetEncodingException;
+
+/**
+ * Write longs (INT64) with delta encoding and binary packing.
+ * 
+ * @author Vassil Lunchev
+ */
+public class DeltaBinaryPackingValuesWriterForLong extends DeltaBinaryPackingValuesWriter {
+  /**
+   * max bitwidth for a mini block, it is used to allocate miniBlockByteBuffer which is
+   * reused between flushes.
+   */
+  public static final int MAX_BITWIDTH = 64;
+
+  /**
+   * stores delta values starting from the 2nd value written(1st value is stored in header).
+   * It's reused between flushes
+   */
+  private long[] deltaBlockBuffer;
+
+  /**
+   * firstValue is written to the header of the page
+   */
+  private long firstValue = 0;
+
+  /**
+   * cache previous written value for calculating delta
+   */
+  private long previousValue = 0;
+
+  /**
+   * min delta is written to the beginning of each block.
+   * it's zig-zag encoded. The deltas stored in each block is actually the difference to min delta,
+   * therefore are all positive
+   * it will be reset after each flush
+   */
+  private long minDeltaInCurrentBlock = Long.MAX_VALUE;
+
+  public DeltaBinaryPackingValuesWriterForLong(
+      int slabSize, int pageSize, ByteBufferAllocator allocator) {
+    this(DEFAULT_NUM_BLOCK_VALUES, DEFAULT_NUM_MINIBLOCKS, slabSize, pageSize, allocator);
+  }
+
+  public DeltaBinaryPackingValuesWriterForLong(int blockSizeInValues, int miniBlockNum, 
+      int slabSize, int pageSize, ByteBufferAllocator allocator) {
+    super(blockSizeInValues, miniBlockNum, slabSize, pageSize, allocator);
+    deltaBlockBuffer = new long[config.blockSizeInValues];
+    miniBlockByteBuffer = new byte[config.miniBlockSizeInValues * MAX_BITWIDTH];
+  }
+
+  @Override
+  public void writeLong(long v) {
+    internalWrite(v);
+  }
+
+  private void internalWrite(long v) {
+    totalValueCount++;
+
+    if (totalValueCount == 1) {
+      firstValue = v;
+      previousValue = firstValue;
+      return;
+    }
+
+    // Calculate delta. The possible overflow is accounted for. The algorithm is correct because
+    // Java long is working as a mudalar ring with base 2^64 and because of the plus and minus
+    // properties of a ring. http://en.wikipedia.org/wiki/Modular_arithmetic#Integers_modulo_n
+    long delta = v - previousValue;
+    previousValue = v;
+
+    deltaBlockBuffer[deltaValuesToFlush++] = delta;
+
+    if (delta < minDeltaInCurrentBlock) {
+      minDeltaInCurrentBlock = delta;
+    }
+
+    if (config.blockSizeInValues == deltaValuesToFlush) {
+      flushBlockBuffer();
+    }
+  }
+
+  private void flushBlockBuffer() {
+    // since we store the min delta, the deltas will be converted to be the difference to min delta
+    // and all positive
+    for (int i = 0; i < deltaValuesToFlush; i++) {
+      deltaBlockBuffer[i] = deltaBlockBuffer[i] - minDeltaInCurrentBlock;
+    }
+
+    writeMinDelta();
+    int miniBlocksToFlush = getMiniBlockCountToFlush(deltaValuesToFlush);
+
+    calculateBitWidthsForDeltaBlockBuffer(miniBlocksToFlush);
+    for (int i = 0; i < config.miniBlockNumInABlock; i++) {
+      writeBitWidthForMiniBlock(i);
+    }
+
+    for (int i = 0; i < miniBlocksToFlush; i++) {
+      //writing i th miniblock
+      int currentBitWidth = bitWidths[i];
+      BytePackerForLong packer = Packer.LITTLE_ENDIAN.newBytePackerForLong(currentBitWidth);
+      int miniBlockStart = i * config.miniBlockSizeInValues;
+      for (int j = miniBlockStart; j < (i + 1) * config.miniBlockSizeInValues; j += 8) {//8 values per pack
+        // mini block is atomic in terms of flushing
+        // This may write more values when reach to the end of data writing to last mini block,
+        // since it may not be aligend to miniblock,
+        // but doesnt matter. The reader uses total count to see if reached the end.
+        packer.pack8Values(deltaBlockBuffer, j, miniBlockByteBuffer, 0);
+        baos.write(miniBlockByteBuffer, 0, currentBitWidth);
+      }
+    }
+
+    minDeltaInCurrentBlock = Long.MAX_VALUE;
+    deltaValuesToFlush = 0;
+  }
+
+  private void writeMinDelta() {
+    try {
+      BytesUtils.writeZigZagVarLong(minDeltaInCurrentBlock, baos);
+    } catch (IOException e) {
+      throw new ParquetEncodingException("can not write min delta for block", e);
+    }
+  }
+
+  /**
+   * iterate through values in each mini block and calculate the bitWidths of max values.
+   *
+   * @param miniBlocksToFlush
+   */
+  private void calculateBitWidthsForDeltaBlockBuffer(int miniBlocksToFlush) {
+    for (int miniBlockIndex = 0; miniBlockIndex < miniBlocksToFlush; miniBlockIndex++) {
+      long mask = 0;
+      int miniStart = miniBlockIndex * config.miniBlockSizeInValues;
+
+      //The end of current mini block could be the end of current block(deltaValuesToFlush) buffer when data is not aligned to mini block
+      int miniEnd = Math.min((miniBlockIndex + 1) * config.miniBlockSizeInValues, deltaValuesToFlush);
+
+      for (int i = miniStart; i < miniEnd; i++) {
+        mask |= deltaBlockBuffer[i];
+      }
+      bitWidths[miniBlockIndex] = 64 - Long.numberOfLeadingZeros(mask);
+    }
+  }
+
+  /**
+   * getBytes will trigger flushing block buffer, DO NOT write after getBytes() is called without calling reset()
+   *
+   * @return
+   */
+  @Override
+  public BytesInput getBytes() {
+    //The Page Header should include: blockSizeInValues, numberOfMiniBlocks, totalValueCount
+    if (deltaValuesToFlush != 0) {
+      flushBlockBuffer();
+    }
+    return BytesInput.concat(
+            config.toBytesInput(),
+            BytesInput.fromUnsignedVarInt(totalValueCount),
+            BytesInput.fromZigZagVarLong(firstValue),
+            BytesInput.from(baos));
+  }
+
+  @Override
+  public void reset() {
+    super.reset();
+    this.minDeltaInCurrentBlock = Long.MAX_VALUE;
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    this.minDeltaInCurrentBlock = Long.MAX_VALUE;
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltalengthbytearray/DeltaLengthByteArrayValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltalengthbytearray/DeltaLengthByteArrayValuesWriter.java
@@ -28,6 +28,7 @@ import org.apache.parquet.bytes.LittleEndianDataOutputStream;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
 import org.apache.parquet.io.ParquetEncodingException;
 import org.apache.parquet.io.api.Binary;
 
@@ -52,7 +53,7 @@ public class DeltaLengthByteArrayValuesWriter extends ValuesWriter {
   public DeltaLengthByteArrayValuesWriter(int initialSize, int pageSize, ByteBufferAllocator allocator) {
     arrayOut = new CapacityByteArrayOutputStream(initialSize, pageSize, allocator);
     out = new LittleEndianDataOutputStream(arrayOut);
-    lengthWriter = new DeltaBinaryPackingValuesWriter(
+    lengthWriter = new DeltaBinaryPackingValuesWriterForInteger(
         DeltaBinaryPackingValuesWriter.DEFAULT_NUM_BLOCK_VALUES,
         DeltaBinaryPackingValuesWriter.DEFAULT_NUM_MINIBLOCKS,
         initialSize, pageSize, allocator);

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
@@ -23,6 +23,7 @@ import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
 import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
 import org.apache.parquet.io.api.Binary;
 
@@ -43,7 +44,8 @@ public class DeltaByteArrayWriter extends ValuesWriter{
   private byte[] previous;
 
   public DeltaByteArrayWriter(int initialCapacity, int pageSize, ByteBufferAllocator allocator) {
-    this.prefixLengthWriter = new DeltaBinaryPackingValuesWriter(128, 4, initialCapacity, pageSize, allocator);
+    this.prefixLengthWriter = 
+        new DeltaBinaryPackingValuesWriterForInteger(128, 4, initialCapacity, pageSize, allocator);
     this.suffixWriter = new DeltaLengthByteArrayValuesWriter(initialCapacity, pageSize, allocator);
     this.previous = new byte[0];
   }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForIntegerTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForIntegerTest.java
@@ -1,0 +1,266 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.delta;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.parquet.bytes.DirectByteBufferAllocator;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.io.ParquetDecodingException;
+
+public class DeltaBinaryPackingValuesWriterForIntegerTest {
+  DeltaBinaryPackingValuesReader reader;
+  private int blockSize;
+  private int miniBlockNum;
+  private ValuesWriter writer;
+  private Random random;
+
+  @Before
+  public void setUp() {
+    blockSize = 128;
+    miniBlockNum = 4;
+    writer = new DeltaBinaryPackingValuesWriterForInteger(
+        blockSize, miniBlockNum, 100, 200, new DirectByteBufferAllocator());
+    random = new Random(0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void miniBlockSizeShouldBeMultipleOf8() {
+    new DeltaBinaryPackingValuesWriterForInteger(
+        1281, 4, 100, 100, new DirectByteBufferAllocator());
+  }
+
+  /* When data size is multiple of Block*/
+  @Test
+  public void shouldWriteWhenDataIsAlignedWithBlock() throws IOException {
+    int[] data = new int[5 * blockSize];
+    for (int i = 0; i < blockSize * 5; i++) {
+      data[i] = random.nextInt();
+    }
+    shouldWriteAndRead(data);
+  }
+
+  @Test
+  public void shouldWriteAndReadWhenBlockIsNotFullyWritten() throws IOException {
+    int[] data = new int[blockSize - 3];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = random.nextInt();
+    }
+    shouldWriteAndRead(data);
+  }
+
+  @Test
+  public void shouldWriteAndReadWhenAMiniBlockIsNotFullyWritten() throws IOException {
+    int miniBlockSize = blockSize / miniBlockNum;
+    int[] data = new int[miniBlockSize - 3];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = random.nextInt();
+    }
+    shouldWriteAndRead(data);
+  }
+
+  @Test
+  public void shouldWriteNegativeDeltas() throws IOException {
+    int[] data = new int[blockSize];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = 10 - (i * 32 - random.nextInt(6));
+    }
+    shouldWriteAndRead(data);
+  }
+
+  @Test
+  public void shouldWriteAndReadWhenDeltasAreSame() throws IOException {
+    int[] data = new int[2 * blockSize];
+    for (int i = 0; i < blockSize; i++) {
+      data[i] = i * 32;
+    }
+    shouldWriteAndRead(data);
+  }
+
+  @Test
+  public void shouldWriteAndReadWhenValuesAreSame() throws IOException {
+    int[] data = new int[2 * blockSize];
+    for (int i = 0; i < blockSize; i++) {
+      data[i] = 3;
+    }
+    shouldWriteAndRead(data);
+  }
+
+  @Test
+  public void shouldWriteWhenDeltaIs0ForEachBlock() throws IOException {
+    int[] data = new int[5 * blockSize + 1];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = (i - 1) / blockSize;
+    }
+    shouldWriteAndRead(data);
+  }
+
+  @Test
+  public void shouldReadWriteWhenDataIsNotAlignedWithBlock() throws IOException {
+    int[] data = new int[5 * blockSize + 3];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = random.nextInt(20) - 10;
+    }
+    shouldWriteAndRead(data);
+  }
+
+  @Test
+  public void shouldReadMaxMinValue() throws IOException {
+    int[] data = new int[10];
+    for (int i = 0; i < data.length; i++) {
+      if (i % 2 == 0) {
+        data[i] = Integer.MIN_VALUE;
+      } else {
+        data[i] = Integer.MAX_VALUE;
+      }
+    }
+    shouldWriteAndRead(data);
+  }
+
+  @Test
+  public void shouldReturnCorrectOffsetAfterInitialization() throws IOException {
+    int[] data = new int[2 * blockSize + 3];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = i * 32;
+    }
+    writeData(data);
+
+    reader = new DeltaBinaryPackingValuesReader();
+    BytesInput bytes = writer.getBytes();
+    byte[] valueContent = bytes.toByteArray();
+    byte[] pageContent = new byte[valueContent.length * 10];
+    int contentOffsetInPage = 33;
+    System.arraycopy(valueContent, 0, pageContent, contentOffsetInPage, valueContent.length);
+
+    //offset should be correct
+    reader.initFromPage(100, ByteBuffer.wrap(pageContent), contentOffsetInPage);
+    int offset= reader.getNextOffset();
+    assertEquals(valueContent.length + contentOffsetInPage, offset);
+
+    //should be able to read data correclty
+    for (int i : data) {
+      assertEquals(i, reader.readInteger());
+    }
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenReadMoreThanWritten() throws IOException {
+    int[] data = new int[5 * blockSize + 1];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = i * 32;
+    }
+    shouldWriteAndRead(data);
+    try {
+      reader.readInteger();
+    } catch (ParquetDecodingException e) {
+      assertEquals("no more value to read, total value count is " + data.length, e.getMessage());
+    }
+
+  }
+
+  @Test
+  public void shouldSkip() throws IOException {
+    int[] data = new int[5 * blockSize + 1];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = i * 32;
+    }
+    writeData(data);
+    reader = new DeltaBinaryPackingValuesReader();
+    reader.initFromPage(100, writer.getBytes().toByteBuffer(), 0);
+    for (int i = 0; i < data.length; i++) {
+      if (i % 3 == 0) {
+        reader.skip();
+      } else {
+        assertEquals(i * 32, reader.readInteger());
+      }
+    }
+  }
+
+  @Test
+  public void shouldReset() throws IOException {
+    shouldReadWriteWhenDataIsNotAlignedWithBlock();
+    int[] data = new int[5 * blockSize];
+    for (int i = 0; i < blockSize * 5; i++) {
+      data[i] = i * 2;
+    }
+    writer.reset();
+    shouldWriteAndRead(data);
+  }
+
+  @Test
+  public void randomDataTest() throws IOException {
+    int maxSize = 1000;
+    int[] data = new int[maxSize];
+
+    for (int round = 0; round < 100000; round++) {
+
+
+      int size = random.nextInt(maxSize);
+
+      for (int i = 0; i < size; i++) {
+        data[i] = random.nextInt();
+      }
+      shouldReadAndWrite(data, size);
+      writer.reset();
+    }
+  }
+
+  private void shouldWriteAndRead(int[] data) throws IOException {
+    shouldReadAndWrite(data, data.length);
+  }
+
+  private void shouldReadAndWrite(int[] data, int length) throws IOException {
+    writeData(data, length);
+    reader = new DeltaBinaryPackingValuesReader();
+    byte[] page = writer.getBytes().toByteArray();
+    int miniBlockSize = blockSize / miniBlockNum;
+
+    double miniBlockFlushed = Math.ceil(((double) length - 1) / miniBlockSize);
+    double blockFlushed = Math.ceil(((double) length - 1) / blockSize);
+    double estimatedSize = 4 * 5 //blockHeader
+        + 4 * miniBlockFlushed * miniBlockSize //data(aligned to miniBlock)
+        + blockFlushed * miniBlockNum //bitWidth of mini blocks
+        + (5.0 * blockFlushed);//min delta for each block
+    assertTrue(estimatedSize >= page.length);
+    reader.initFromPage(100, ByteBuffer.wrap(page), 0);
+
+    for (int i = 0; i < length; i++) {
+      assertEquals(data[i], reader.readInteger());
+    }
+  }
+
+  private void writeData(int[] data) {
+    writeData(data, data.length);
+  }
+
+  private void writeData(int[] data, int length) {
+    for (int i = 0; i < length; i++) {
+      writer.writeInteger(data[i]);
+    }
+  }
+}

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/BenchmarkIntegerOutputSize.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/BenchmarkIntegerOutputSize.java
@@ -18,11 +18,13 @@
  */
 package org.apache.parquet.column.values.delta.benchmark;
 
-import org.junit.Test;
+import java.util.Random;
+
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
-import java.util.Random;
+import org.junit.Test;
 
 public class BenchmarkIntegerOutputSize {
   public static int blockSize=128;
@@ -78,8 +80,10 @@ public class BenchmarkIntegerOutputSize {
   }
 
   public void testRandomIntegers(IntFunc func,int bitWidth) {
-    DeltaBinaryPackingValuesWriter delta=new DeltaBinaryPackingValuesWriter(blockSize,miniBlockNum, 100, 20000, new DirectByteBufferAllocator());
-    RunLengthBitPackingHybridValuesWriter rle= new RunLengthBitPackingHybridValuesWriter(bitWidth, 100, 20000, new DirectByteBufferAllocator());
+    DeltaBinaryPackingValuesWriter delta = new DeltaBinaryPackingValuesWriterForInteger(
+        blockSize,miniBlockNum, 100, 20000, new DirectByteBufferAllocator());
+    RunLengthBitPackingHybridValuesWriter rle = new RunLengthBitPackingHybridValuesWriter(
+        bitWidth, 100, 20000, new DirectByteBufferAllocator());
     for (int i = 0; i < dataSize; i++) {
       int v = func.getIntValue();
       delta.writeInteger(v);

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/BenchmarkReadingRandomIntegers.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/BenchmarkReadingRandomIntegers.java
@@ -18,24 +18,25 @@
  */
 package org.apache.parquet.column.values.delta.benchmark;
 
-import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
-import com.carrotsearch.junitbenchmarks.BenchmarkRule;
-import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
-import com.carrotsearch.junitbenchmarks.annotation.BenchmarkMethodChart;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
-import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesReader;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Random;
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
+import com.carrotsearch.junitbenchmarks.annotation.BenchmarkMethodChart;
 
 @AxisRange(min = 0, max = 1)
 @BenchmarkMethodChart(filePrefix = "benchmark-encoding-reading-random")
@@ -56,8 +57,10 @@ public class BenchmarkReadingRandomIntegers {
       data[i] = random.nextInt(100) - 200;
     }
 
-    ValuesWriter delta = new DeltaBinaryPackingValuesWriter(blockSize, miniBlockNum, 100, 20000, new DirectByteBufferAllocator());
-    ValuesWriter rle = new RunLengthBitPackingHybridValuesWriter(32, 100, 20000, new DirectByteBufferAllocator());
+    ValuesWriter delta = new DeltaBinaryPackingValuesWriterForInteger(
+        blockSize, miniBlockNum, 100, 20000, new DirectByteBufferAllocator());
+    ValuesWriter rle = new RunLengthBitPackingHybridValuesWriter(
+        32, 100, 20000, new DirectByteBufferAllocator());
 
     for (int i = 0; i < data.length; i++) {
       delta.writeInteger(data[i]);

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/RandomWritingBenchmarkTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/RandomWritingBenchmarkTest.java
@@ -18,18 +18,21 @@
  */
 package org.apache.parquet.column.values.delta.benchmark;
 
+import java.util.Random;
+
+import org.apache.parquet.bytes.DirectByteBufferAllocator;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
+import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
 import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
 import com.carrotsearch.junitbenchmarks.annotation.BenchmarkMethodChart;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.apache.parquet.bytes.DirectByteBufferAllocator;
-import org.apache.parquet.column.values.ValuesWriter;
-import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
-import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
-import java.util.Random;
 
 @AxisRange(min = 0, max = 1)
 @BenchmarkMethodChart(filePrefix = "benchmark-encoding-writing-random")
@@ -51,7 +54,8 @@ public class RandomWritingBenchmarkTest extends BenchMarkTest{
   @BenchmarkOptions(benchmarkRounds = 10, warmupRounds = 2)
   @Test
   public void writeDeltaPackingTest(){
-    DeltaBinaryPackingValuesWriter writer = new DeltaBinaryPackingValuesWriter(blockSize, miniBlockNum, 100, 20000, new DirectByteBufferAllocator());
+    DeltaBinaryPackingValuesWriter writer = new DeltaBinaryPackingValuesWriterForInteger(
+        blockSize, miniBlockNum, 100, 20000, new DirectByteBufferAllocator());
     runWriteTest(writer);
   }
 
@@ -65,7 +69,8 @@ public class RandomWritingBenchmarkTest extends BenchMarkTest{
   @BenchmarkOptions(benchmarkRounds = 10, warmupRounds = 2)
   @Test
   public void writeDeltaPackingTest2(){
-    DeltaBinaryPackingValuesWriter writer = new DeltaBinaryPackingValuesWriter(blockSize, miniBlockNum, 100, 20000, new DirectByteBufferAllocator());
+    DeltaBinaryPackingValuesWriter writer = new DeltaBinaryPackingValuesWriterForInteger(
+        blockSize, miniBlockNum, 100, 20000, new DirectByteBufferAllocator());
     runWriteTest(writer);
   }
 }

--- a/parquet-encoding/src/main/java/org/apache/parquet/bytes/BytesInput.java
+++ b/parquet-encoding/src/main/java/org/apache/parquet/bytes/BytesInput.java
@@ -125,6 +125,23 @@ abstract public class BytesInput {
   }
 
   /**
+   * @param longValue the long to write
+   * @return a BytesInput that will write var long
+   */
+  public static BytesInput fromUnsignedVarLong(long longValue) {
+    return new UnsignedVarLongBytesInput(longValue);
+  }
+
+  /**
+   *
+   * @param longValue the long to write
+   */
+  public static BytesInput fromZigZagVarLong(long longValue) {
+    long zigZag = (longValue << 1) ^ (longValue >> 63);
+    return new UnsignedVarLongBytesInput(zigZag);
+  }
+
+  /**
    * @param arrayOut
    * @return a BytesInput that will write the content of the buffer
    */
@@ -320,7 +337,27 @@ abstract public class BytesInput {
 
     @Override
     public long size() {
-      int s = 5 - ((Integer.numberOfLeadingZeros(intValue) + 3) / 7);
+      int s = (38 - Integer.numberOfLeadingZeros(intValue)) / 7;
+      return s == 0 ? 1 : s;
+    }
+  }
+
+  private static class UnsignedVarLongBytesInput extends BytesInput {
+
+    private final long longValue;
+
+    public UnsignedVarLongBytesInput(long longValue) {
+      this.longValue = longValue;
+    }
+
+    @Override
+    public void writeAllTo(OutputStream out) throws IOException {
+      BytesUtils.writeUnsignedVarLong(longValue, out);
+    }
+
+    @Override
+    public long size() {
+      int s = (70 - Long.numberOfLeadingZeros(longValue)) / 7;
       return s == 0 ? 1 : s;
     }
   }

--- a/parquet-encoding/src/main/java/org/apache/parquet/column/values/bitpacking/BytePackerForLong.java
+++ b/parquet-encoding/src/main/java/org/apache/parquet/column/values/bitpacking/BytePackerForLong.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.parquet.column.values.bitpacking;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Packs and unpacks INT64 into bytes
+ *
+ * packing unpacking treats: - n values at a time (with n % 8 == 0) - bitWidth * (n/8) bytes at a
+ * time.
+ *
+ * @author Vassil Lunchev
+ *
+ */
+public abstract class BytePackerForLong {
+
+  private final int bitWidth;
+
+  BytePackerForLong(int bitWidth) {
+    this.bitWidth = bitWidth;
+  }
+
+  /**
+   * @return the width in bits used for encoding, also how many bytes are packed/unpacked at a time
+   *         by pack8Values/unpack8Values
+   */
+  public final int getBitWidth() {
+    return bitWidth;
+  }
+
+  /**
+   * pack 8 values from input at inPos into bitWidth bytes in output at outPos. nextPosition: inPos
+   * += 8; outPos += getBitWidth()
+   * 
+   * @param input the input values
+   * @param inPos where to read from in input
+   * @param output the output bytes
+   * @param outPos where to write to in output
+   */
+  public abstract void pack8Values(final long[] input, final int inPos, final byte[] output,
+      final int outPos);
+
+  /**
+   * pack 32 values from input at inPos into bitWidth * 4 bytes in output at outPos. nextPosition:
+   * inPos += 32; outPos += getBitWidth() * 4
+   * 
+   * @param input the input values
+   * @param inPos where to read from in input
+   * @param output the output bytes
+   * @param outPos where to write to in output
+   */
+  public abstract void pack32Values(long[] input, int inPos, byte[] output, int outPos);
+
+  /**
+   * unpack bitWidth bytes from input at inPos into 8 values in output at outPos. nextPosition:
+   * inPos += getBitWidth(); outPos += 8
+   * 
+   * @param input the input bytes
+   * @param inPos where to read from in input
+   * @param output the output values
+   * @param outPos where to write to in output
+   */
+  public abstract void unpack8Values(final ByteBuffer input, final int inPos, final long[] output,
+      final int outPos);
+
+  /**
+   * unpack bitWidth * 4 bytes from input at inPos into 32 values in output at outPos. nextPosition:
+   * inPos += getBitWidth() * 4; outPos += 32
+   * 
+   * @param input the input bytes
+   * @param inPos where to read from in input
+   * @param output the output values
+   * @param outPos where to write to in output
+   */
+  public abstract void unpack32Values(ByteBuffer input, int inPos, long[] output, int outPos);
+
+  /**
+   * unpack bitWidth bytes from input at inPos into 8 values in output at outPos. nextPosition:
+   * inPos += getBitWidth(); outPos += 8
+   * 
+   * @param input the input bytes
+   * @param inPos where to read from in input
+   * @param output the output values
+   * @param outPos where to write to in output
+   */
+  public abstract void unpack8Values(final byte[] input, final int inPos, final long[] output,
+      final int outPos);
+
+  /**
+   * unpack bitWidth * 4 bytes from input at inPos into 32 values in output at outPos. nextPosition:
+   * inPos += getBitWidth() * 4; outPos += 32
+   * 
+   * @param input the input bytes
+   * @param inPos where to read from in input
+   * @param output the output values
+   * @param outPos where to write to in output
+   */
+  public abstract void unpack32Values(byte[] input, int inPos, long[] output, int outPos);
+}

--- a/parquet-encoding/src/main/java/org/apache/parquet/column/values/bitpacking/BytePackerForLongFactory.java
+++ b/parquet-encoding/src/main/java/org/apache/parquet/column/values/bitpacking/BytePackerForLongFactory.java
@@ -1,0 +1,25 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.bitpacking;
+
+public interface BytePackerForLongFactory {
+
+  BytePackerForLong newBytePackerForLong(int width);
+
+}

--- a/parquet-encoding/src/main/java/org/apache/parquet/column/values/bitpacking/Packer.java
+++ b/parquet-encoding/src/main/java/org/apache/parquet/column/values/bitpacking/Packer.java
@@ -39,6 +39,10 @@ public enum Packer {
     public BytePacker newBytePacker(int width) {
       return beBytePackerFactory.newBytePacker(width);
     }
+    @Override
+    public BytePackerForLong newBytePackerForLong(int width) {
+      return beBytePackerForLongFactory.newBytePackerForLong(width);
+    }
   },
 
   /**
@@ -54,6 +58,10 @@ public enum Packer {
     public BytePacker newBytePacker(int width) {
       return leBytePackerFactory.newBytePacker(width);
     }
+    @Override
+    public BytePackerForLong newBytePackerForLong(int width) {
+      return leBytePackerForLongFactory.newBytePackerForLong(width);
+    }
   };
 
   private static IntPackerFactory getIntPackerFactory(String name) {
@@ -62,6 +70,10 @@ public enum Packer {
 
   private static BytePackerFactory getBytePackerFactory(String name) {
     return (BytePackerFactory)getStaticField("org.apache.parquet.column.values.bitpacking." + name, "factory");
+  }
+
+  private static BytePackerForLongFactory getBytePackerForLongFactory(String name) {
+    return (BytePackerForLongFactory)getStaticField("org.apache.parquet.column.values.bitpacking." + name, "factory");
   }
 
   private static Object getStaticField(String className, String fieldName) {
@@ -80,10 +92,12 @@ public enum Packer {
     }
   }
 
-  static BytePackerFactory beBytePackerFactory = getBytePackerFactory("ByteBitPackingBE");
   static IntPackerFactory beIntPackerFactory = getIntPackerFactory("LemireBitPackingBE");
-  static BytePackerFactory leBytePackerFactory = getBytePackerFactory("ByteBitPackingLE");
   static IntPackerFactory leIntPackerFactory = getIntPackerFactory("LemireBitPackingLE");
+  static BytePackerFactory beBytePackerFactory = getBytePackerFactory("ByteBitPackingBE");
+  static BytePackerFactory leBytePackerFactory = getBytePackerFactory("ByteBitPackingLE");
+  static BytePackerForLongFactory beBytePackerForLongFactory = getBytePackerForLongFactory("ByteBitPackingForLongBE");
+  static BytePackerForLongFactory leBytePackerForLongFactory = getBytePackerForLongFactory("ByteBitPackingForLongLE");
 
   /**
    * @param width the width in bits of the packed values
@@ -96,4 +110,10 @@ public enum Packer {
    * @return a byte based packer
    */
   public abstract BytePacker newBytePacker(int width);
+
+  /**
+   * @param width the width in bits of the packed values
+   * @return a byte based packer for INT64
+   */
+  public abstract BytePackerForLong newBytePackerForLong(int width);
 }

--- a/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestBitPacking.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestBitPacking.java
@@ -196,6 +196,20 @@ public class TestBitPacking {
     return sb.toString();
   }
 
+  public static String toString(long[] vals) {
+    StringBuilder sb = new StringBuilder();
+    boolean first = true;
+    for (long i : vals) {
+      if (first) {
+        first = false;
+      } else {
+        sb.append(" ");
+      }
+      sb.append(i);
+    }
+    return sb.toString();
+  }
+
   public static String toString(byte[] bytes) {
     StringBuilder sb = new StringBuilder();
     boolean first = true;

--- a/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking.java
@@ -46,6 +46,24 @@ public class TestByteBitPacking {
       Assert.assertArrayEquals("width "+i, values, unpacked);
     }
   }
+  
+  @Test
+  public void testPackUnPackLong() {
+    LOG.debug("");
+    LOG.debug("testPackUnPackLong");
+    for (int i = 1; i < 64; i++) {
+      LOG.debug("Width: " + i);
+      long[] unpacked32 = new long[32];
+      long[] unpacked8 = new long[32];
+      long[] values = generateValuesLong(i);
+      packUnpack32(Packer.BIG_ENDIAN.newBytePackerForLong(i), values, unpacked32);
+      LOG.debug("Output 32: " + TestBitPacking.toString(unpacked32));
+      Assert.assertArrayEquals("width "+i, values, unpacked32);
+      packUnpack8(Packer.BIG_ENDIAN.newBytePackerForLong(i), values, unpacked8);
+      LOG.debug("Output 8: " + TestBitPacking.toString(unpacked8));
+      Assert.assertArrayEquals("width "+i, values, unpacked8);
+    }
+  }
 
   private void packUnpack(BytePacker packer, int[] values, int[] unpacked) {
     byte[] packed = new byte[packer.getBitWidth() * 4];
@@ -54,10 +72,38 @@ public class TestByteBitPacking {
     packer.unpack32Values(ByteBuffer.wrap(packed), 0, unpacked, 0);
   }
 
+  private void packUnpack32(BytePackerForLong packer, long[] values, long[] unpacked) {
+    byte[] packed = new byte[packer.getBitWidth() * 4];
+    packer.pack32Values(values, 0, packed, 0);
+    LOG.debug("packed: " + TestBitPacking.toString(packed));
+    packer.unpack32Values(packed, 0, unpacked, 0);
+  }
+
+  private void packUnpack8(BytePackerForLong packer, long[] values, long[] unpacked) {
+    byte[] packed = new byte[packer.getBitWidth() * 4];
+    for (int i = 0; i < 4; i++) {
+      packer.pack8Values(values,  8 * i, packed, packer.getBitWidth() * i);
+    }
+    LOG.debug("packed: " + TestBitPacking.toString(packed));
+    for (int i = 0; i < 4; i++) {
+      packer.unpack8Values(packed, packer.getBitWidth() * i, unpacked, 8 * i);
+    }
+  }
+
   private int[] generateValues(int bitWidth) {
     int[] values = new int[32];
     for (int j = 0; j < values.length; j++) {
       values[j] = (int)(Math.random() * 100000) % (int)Math.pow(2, bitWidth);
+    }
+    LOG.debug("Input:  " + TestBitPacking.toString(values));
+    return values;
+  }
+
+  private long[] generateValuesLong(int bitWidth) {
+    long[] values = new long[32];
+    for (int j = 0; j < values.length; j++) {
+      values[j] = ((long)(Math.random() * (1l<<32)) * (long)(Math.random() * (1l<<32))) &
+          ((1l << bitWidth) - 1l);
     }
     LOG.debug("Input:  " + TestBitPacking.toString(values));
     return values;

--- a/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking.java
@@ -22,10 +22,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Random;
 
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.apache.parquet.Log;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingReader;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingWriter;
@@ -101,9 +101,9 @@ public class TestByteBitPacking {
 
   private long[] generateValuesLong(int bitWidth) {
     long[] values = new long[32];
+    Random random = new Random(0);
     for (int j = 0; j < values.length; j++) {
-      values[j] = ((long)(Math.random() * (1l<<32)) * (long)(Math.random() * (1l<<32))) &
-          ((1l << bitWidth) - 1l);
+      values[j] = random.nextLong() & ((1l << bitWidth) - 1l);
     }
     LOG.debug("Input:  " + TestBitPacking.toString(values));
     return values;

--- a/parquet-generator/src/main/java/org/apache/parquet/encoding/bitpacking/ByteBasedBitPackingGenerator.java
+++ b/parquet-generator/src/main/java/org/apache/parquet/encoding/bitpacking/ByteBasedBitPackingGenerator.java
@@ -27,23 +27,40 @@ import java.io.IOException;
  * This class generates bit packers that pack the most significant bit first.
  * The result of the generation is checked in. To regenerate the code run this class and check in the result.
  *
- * TODO: remove the unnecessary masks for perf
- *
  * @author Julien Le Dem
  *
  */
 public class ByteBasedBitPackingGenerator {
 
-  private static final String CLASS_NAME_PREFIX = "ByteBitPacking";
-  private static final int PACKER_COUNT = 32;
+  private static final String CLASS_NAME_PREFIX_FOR_INT = "ByteBitPacking";
+  private static final String CLASS_NAME_PREFIX_FOR_LONG = "ByteBitPackingForLong";
+  private static final String VARIABLE_TYPE_FOR_INT = "int";
+  private static final String VARIABLE_TYPE_FOR_LONG = "long";
+  private static final int MAX_BITS_FOR_INT = 32;
+  private static final int MAX_BITS_FOR_LONG = 64;
 
   public static void main(String[] args) throws Exception {
     String basePath = args[0];
-    generateScheme(CLASS_NAME_PREFIX + "BE", true, basePath);
-    generateScheme(CLASS_NAME_PREFIX + "LE", false, basePath);
+    // Int for Big Endian
+    generateScheme(false, true, basePath);
+
+    // Int for Little Endian
+    generateScheme(false, false, basePath);
+
+    // Long for Big Endian
+    generateScheme(true, true, basePath);
+
+    // Long for Little Endian
+    generateScheme(true, false, basePath);
   }
 
-  private static void generateScheme(String className, boolean msbFirst, String basePath) throws IOException {
+  private static void generateScheme(boolean isLong, boolean msbFirst, 
+      String basePath) throws IOException {
+    String baseClassName = isLong ? CLASS_NAME_PREFIX_FOR_LONG : CLASS_NAME_PREFIX_FOR_INT;
+    String className = msbFirst ? (baseClassName + "BE") : (baseClassName + "LE");
+    int maxBits = isLong ? MAX_BITS_FOR_LONG : MAX_BITS_FOR_INT;
+    String nameSuffix = isLong ? "ForLong" : "";
+    
     final File file = new File(basePath + "/org/apache/parquet/column/values/bitpacking/" + className + ".java").getAbsoluteFile();
     if (!file.getParentFile().exists()) {
       file.getParentFile().mkdirs();
@@ -65,48 +82,58 @@ public class ByteBasedBitPackingGenerator {
     fw.append(" */\n");
     fw.append("public abstract class " + className + " {\n");
     fw.append("\n");
-    fw.append("  private static final BytePacker[] packers = new BytePacker[33];\n");
+    fw.append("  private static final BytePacker" + nameSuffix + "[] packers = new BytePacker" + nameSuffix + "[" + (maxBits + 1) + "];\n");
     fw.append("  static {\n");
-    for (int i = 0; i <= PACKER_COUNT; i++) {
+    for (int i = 0; i <= maxBits; i++) {
       fw.append("    packers[" + i + "] = new Packer" + i + "();\n");
     }
     fw.append("  }\n");
     fw.append("\n");
-    fw.append("  public static final BytePackerFactory factory = new BytePackerFactory() {\n");
-    fw.append("    public BytePacker newBytePacker(int bitWidth) {\n");
+    fw.append("  public static final BytePacker" + nameSuffix + "Factory factory = new BytePacker" + nameSuffix + "Factory() {\n");
+    fw.append("    public BytePacker" + nameSuffix + " newBytePacker" + nameSuffix + "(int bitWidth) {\n");
     fw.append("      return packers[bitWidth];\n");
     fw.append("    }\n");
     fw.append("  };\n");
     fw.append("\n");
-    for (int i = 0; i <= PACKER_COUNT; i++) {
-      generateClass(fw, i, msbFirst);
+    for (int i = 0; i <= maxBits; i++) {
+      generateClass(fw, i, isLong, msbFirst);
       fw.append("\n");
     }
     fw.append("}\n");
     fw.close();
   }
 
-  private static void generateClass(FileWriter fw, int bitWidth, boolean msbFirst) throws IOException {
-    fw.append("  private static final class Packer" + bitWidth + " extends BytePacker {\n");
+  private static void generateClass(FileWriter fw, int bitWidth, boolean isLong, boolean msbFirst) throws IOException {
+    String nameSuffix = isLong ? "ForLong" : "";
+    fw.append("  private static final class Packer" + bitWidth + " extends BytePacker" + nameSuffix + " {\n");
     fw.append("\n");
     fw.append("    private Packer" + bitWidth + "() {\n");
     fw.append("      super("+bitWidth+");\n");
     fw.append("    }\n");
     fw.append("\n");
     // Packing
-    generatePack(fw, bitWidth, 1, msbFirst);
-    generatePack(fw, bitWidth, 4, msbFirst);
+    generatePack(fw, bitWidth, 1, isLong, msbFirst);
+    generatePack(fw, bitWidth, 4, isLong, msbFirst);
 
     // Unpacking
-    generateUnpack(fw, bitWidth, 1, msbFirst, true);
-    generateUnpack(fw, bitWidth, 1, msbFirst, false);
-    generateUnpack(fw, bitWidth, 4, msbFirst, true);
-    generateUnpack(fw, bitWidth, 4, msbFirst, false);
+    generateUnpack(fw, bitWidth, 1, isLong, msbFirst, true);
+    generateUnpack(fw, bitWidth, 1, isLong, msbFirst, false);
+    generateUnpack(fw, bitWidth, 4, isLong, msbFirst, true);
+    generateUnpack(fw, bitWidth, 4, isLong, msbFirst, false);
 
     fw.append("  }\n");
   }
-
-  private static int getShift(FileWriter fw, int bitWidth, boolean msbFirst,
+  
+  private static class ShiftMask {
+    ShiftMask(int shift, long mask) {
+      this.shift = shift;
+      this.mask = mask;
+    }
+    public int shift;
+    public long mask;
+  }
+  
+  private static ShiftMask getShift(FileWriter fw, int bitWidth, boolean isLong, boolean msbFirst,
       int byteIndex, int valueIndex) throws IOException {
     // relative positions of the start and end of the value to the start and end of the byte
     int valueStartBitIndex = (valueIndex * bitWidth) - (8 * (byteIndex));
@@ -120,6 +147,7 @@ public class ByteBasedBitPackingGenerator {
     int byteEndBitWanted;
 
     int shift;
+    int widthWanted;
 
     if (msbFirst) {
       valueStartBitWanted = valueStartBitIndex < 0 ? bitWidth - 1 + valueStartBitIndex : bitWidth - 1;
@@ -127,13 +155,17 @@ public class ByteBasedBitPackingGenerator {
       byteStartBitWanted = valueStartBitIndex < 0 ? 8 : 7 - valueStartBitIndex;
       byteEndBitWanted = valueEndBitIndex > 0 ? 0 : -valueEndBitIndex;
       shift = valueEndBitWanted - byteEndBitWanted;
+      widthWanted = Math.min(7, byteStartBitWanted) - Math.min(7, byteEndBitWanted) + 1;
     } else {
       valueStartBitWanted = bitWidth - 1 - (valueEndBitIndex > 0 ? valueEndBitIndex : 0);
       valueEndBitWanted = bitWidth - 1 - (valueStartBitIndex < 0 ? bitWidth - 1 + valueStartBitIndex : bitWidth - 1);
       byteStartBitWanted = 7 - (valueEndBitIndex > 0 ? 0 : -valueEndBitIndex);
       byteEndBitWanted = 7 - (valueStartBitIndex < 0 ? 8 : 7 - valueStartBitIndex);
       shift = valueStartBitWanted - byteStartBitWanted;
+      widthWanted = Math.max(0, byteStartBitWanted) - Math.max(0, byteEndBitWanted) + 1;
     }
+    
+    int maskWidth = widthWanted + Math.max(0, shift);
 
     visualizeAlignment(
         fw, bitWidth, valueEndBitIndex,
@@ -141,7 +173,7 @@ public class ByteBasedBitPackingGenerator {
         byteStartBitWanted, byteEndBitWanted,
         shift
         );
-    return shift;
+    return new ShiftMask(shift, genMask(maskWidth, isLong));
   }
 
   private static void visualizeAlignment(FileWriter fw, int bitWidth,
@@ -177,9 +209,11 @@ public class ByteBasedBitPackingGenerator {
     fw.append("           ");
   }
 
-  private static void generatePack(FileWriter fw, int bitWidth, int batch, boolean msbFirst) throws IOException {
-    int mask = genMask(bitWidth);
-    fw.append("    public final void pack" + (batch * 8) + "Values(final int[] in, final int inPos, final byte[] out, final int outPos) {\n");
+  private static void generatePack(FileWriter fw, int bitWidth, int batch, boolean isLong, boolean msbFirst) throws IOException {
+    long mask = genMask(bitWidth, isLong);
+    String maskSuffix = isLong ? "L" : "";
+    String variableType = isLong ? VARIABLE_TYPE_FOR_LONG : VARIABLE_TYPE_FOR_INT;
+    fw.append("    public final void pack" + (batch * 8) + "Values(final " + variableType + "[] in, final int inPos, final byte[] out, final int outPos) {\n");
     for (int byteIndex = 0; byteIndex < bitWidth * batch; ++byteIndex) {
       fw.append("      out[" + align(byteIndex, 2) + " + outPos] = (byte)((\n");
       int startIndex = (byteIndex * 8) / bitWidth;
@@ -191,32 +225,31 @@ public class ByteBasedBitPackingGenerator {
         } else {
           fw.append("\n        | ");
         }
-        int shift = getShift(fw, bitWidth, msbFirst, byteIndex, valueIndex);
+        ShiftMask shiftMask = getShift(fw, bitWidth, isLong, msbFirst, byteIndex, valueIndex);
 
         String shiftString = ""; // used when shift == 0
-        if (shift > 0) {
-          shiftString = " >>> " + shift;
-        } else if (shift < 0) {
-          shiftString = " <<  " + ( - shift);
+        if (shiftMask.shift > 0) {
+          shiftString = " >>> " + shiftMask.shift;
+        } else if (shiftMask.shift < 0) {
+          shiftString = " <<  " + ( - shiftMask.shift);
         }
-        fw.append("((in[" + align(valueIndex, 2) + " + inPos] & " + mask + ")" + shiftString + ")");
+        fw.append("((in[" + align(valueIndex, 2) + " + inPos] & " + mask + maskSuffix + ")" + shiftString + ")");
       }
       fw.append(") & 255);\n");
     }
     fw.append("    }\n");
   }
 
-  private static void generateUnpack(FileWriter fw, int bitWidth, int batch, boolean msbFirst, boolean useByteArray)
+  private static void generateUnpack(FileWriter fw, int bitWidth, int batch, boolean isLong, boolean msbFirst, boolean useByteArray)
       throws IOException {
-    final String bufferDataType;
-    if (useByteArray) {
-      bufferDataType = "byte[]";
-    } else {
-      bufferDataType = "ByteBuffer";
-    }
-    fw.append("    public final void unpack" + (batch * 8) + "Values(final " + bufferDataType + " in, final int inPos, final int[] out, final int outPos) {\n");
+    final String variableType = isLong ? VARIABLE_TYPE_FOR_LONG : VARIABLE_TYPE_FOR_INT;
+    final String bufferDataType = useByteArray ? "byte[]" : "ByteBuffer";
+    
+    fw.append("    public final void unpack" + (batch * 8) + "Values(final " + bufferDataType + " in, "
+        + "final int inPos, final " + variableType + "[] out, final int outPos) {\n");
+
     if (bitWidth > 0) {
-      int mask = genMask(bitWidth);
+      String maskSuffix = isLong ? "L" : "";
       for (int valueIndex = 0; valueIndex < (batch * 8); ++valueIndex) {
         fw.append("      out[" + align(valueIndex, 2) + " + outPos] =\n");
 
@@ -229,14 +262,16 @@ public class ByteBasedBitPackingGenerator {
           } else {
             fw.append("\n        | ");
           }
-          int shift = getShift(fw, bitWidth, msbFirst, byteIndex, valueIndex);
+          
+          ShiftMask shiftMask = getShift(fw, bitWidth, isLong, msbFirst, byteIndex, valueIndex);
 
           String shiftString = ""; // when shift == 0
-          if (shift < 0) {
-            shiftString = ">>>  " + (-shift);
-          } else if (shift > 0){
-            shiftString = "<<  " + shift;
+          if (shiftMask.shift < 0) {
+            shiftString = ">>  " + (-shiftMask.shift);
+          } else if (shiftMask.shift > 0){
+            shiftString = "<<  " + shiftMask.shift;
           }
+
           final String byteAccess;
           if (useByteArray) {
             byteAccess = "in[" + align(byteIndex, 2) + " + inPos]";
@@ -244,7 +279,10 @@ public class ByteBasedBitPackingGenerator {
             // use ByteBuffer#get(index) method
             byteAccess = "in.get(" + align(byteIndex, 2) + " + inPos)";
           }
-          fw.append(" (((((int)" + byteAccess + ") & 255) " + shiftString + ") & " + mask + ")");
+
+          // Shift the wanted bits to the least significant position and mask them knowing how many bits to get.
+          fw.append(" ((((" + variableType + ")" + byteAccess + ") " + shiftString +
+              ") & " + shiftMask.mask + maskSuffix + ")");
         }
         fw.append(";\n");
       }
@@ -252,8 +290,14 @@ public class ByteBasedBitPackingGenerator {
     fw.append("    }\n");
   }
 
-  private static int genMask(int bitWidth) {
-    int mask = 0;
+  private static long genMask(int bitWidth, boolean isLong) {
+    int maxBitWidth = isLong ? MAX_BITS_FOR_LONG : MAX_BITS_FOR_INT;
+    if (bitWidth >= maxBitWidth) {
+      // -1 is always ones (11111...1111). It covers all it can possibly can.
+      return -1;
+    }
+    
+    long mask = 0;
     for (int i = 0; i < bitWidth; i++) {
       mask <<= 1;
       mask |= 1;


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/PARQUET-225

As of now, parquet doesn't support delta encoding for INT64. However it is planned in the format:
https://github.com/Parquet/parquet-format/blob/master/Encodings.md

The benefits of this feature are huge. For timestamps it achieves twice better compression than SNAPPY on plain encoding, and the reading is faster. This feature is actually advertised on the home page of Parquet, even though it is not yet implemented:
http://parquet.incubator.apache.org/
http://image.slidesharecdn.com/hadoopsummit-140630160016-phpapp01/95/efficient-data-storage-for-analytics-with-apache-parquet-20-30-638.jpg?cb=1404162126

This pull request adds full support for INT64. It keeps INT32 binary unchanged, even though it reads it with the INT64 implementation. That might be slower on 32 bit processors, but I don't not consider it a problem.

Regarding testing, all test made for INT32 are ran against the new INT64 implementation and also 2 new unit tests are added specifically for INT64.