### PR TITLE
PARQUET-220: do not log unnecessary warnings on initializing ParquetReco...

### DIFF
--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetRecordReader.java
@@ -38,10 +38,8 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.mapreduce.TaskInputOutputContext;
 
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
-import parquet.Log;
 import parquet.filter.UnboundRecordFilter;
 import parquet.filter2.compat.FilterCompat;
 import parquet.filter2.compat.FilterCompat.Filter;
@@ -63,7 +61,6 @@ import parquet.schema.MessageType;
  */
 public class ParquetRecordReader<T> extends RecordReader<Void, T> {
 
-  private static final Log LOG = Log.getLog(ParquetRecordReader.class);
   private final InternalParquetRecordReader<T> internalReader;
 
   /**
@@ -130,12 +127,7 @@ public class ParquetRecordReader<T> extends RecordReader<Void, T> {
   @Override
   public void initialize(InputSplit inputSplit, TaskAttemptContext context)
       throws IOException, InterruptedException {
-    if (context instanceof TaskInputOutputContext<?, ?, ?, ?>) {
-      BenchmarkCounter.initCounterFromContext((TaskInputOutputContext<?, ?, ?, ?>) context);
-    } else {
-      LOG.error("Can not initialize counter due to context is not a instance of TaskInputOutputContext, but is "
-              + context.getClass().getCanonicalName());
-    }
+    BenchmarkCounter.initCounterFromContext(context);
 
     initializeInternalReader(toParquetSplit(inputSplit), ContextUtil.getConfiguration(context));
   }

--- a/parquet-hadoop/src/main/java/parquet/hadoop/util/counters/BenchmarkCounter.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/util/counters/BenchmarkCounter.java
@@ -20,7 +20,9 @@ package parquet.hadoop.util.counters;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.TaskInputOutputContext;
+
 import parquet.hadoop.util.counters.mapred.MapRedCounterLoader;
 import parquet.hadoop.util.counters.mapreduce.MapReduceCounterLoader;
 
@@ -44,11 +46,23 @@ public class BenchmarkCounter {
   private static CounterLoader counterLoader;
 
   /**
+   * This method is for backward compatibility.
+   *
+   * @deprecated
+   *          will be removed in 2.0.0; use
+   *          {@link #initCounterFromContext(TaskAttemptContext)} instead.
+   */
+  @Deprecated
+  public static void initCounterFromContext(TaskInputOutputContext<?, ?, ?, ?> context) {
+    initCounterFromContext((TaskAttemptContext) context);
+  }
+
+  /**
    * Init counters in hadoop's mapreduce API, support both 1.x and 2.x
    *
    * @param context
    */
-  public static void initCounterFromContext(TaskInputOutputContext<?, ?, ?, ?> context) {
+  public static void initCounterFromContext(TaskAttemptContext context) {
     counterLoader = new MapReduceCounterLoader(context);
     loadCounters();
   }

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,7 @@
                      <exclude>parquet/org/**</exclude>
                      <exclude>parquet/column/**</exclude>
                      <exclude>parquet/hadoop/ParquetInputSplit</exclude>
+                     <exclude>parquet/hadoop/util/ContextUtil</exclude>
                    </excludes>
                  </requireBackwardCompatibility>
                </rules>


### PR DESCRIPTION
...rdReader

Refactored to replace TaskInputOutputContext with TaskAttemptContext.

The warning is now logged only in case if TaskAttemptContext interface doesn't
support counters (e.g. in Hadoop 1.x)