### PR TITLE
PARQUET-261: Extend classloader fix to rest of codebase.

### DIFF
--- a/parquet-common/src/main/java/org/apache/parquet/ClassLoading.java
+++ b/parquet-common/src/main/java/org/apache/parquet/ClassLoading.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet;
+
+public class ClassLoading {
+
+  // Static version of Hadoop Configuration's getClassByName
+  public static Class getClassByName(String className) throws ClassNotFoundException {
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    Class foundClass = Class.forName(className, true, classLoader);
+    return foundClass;
+  }
+}

--- a/parquet-encoding/src/main/java/org/apache/parquet/column/values/bitpacking/Packer.java
+++ b/parquet-encoding/src/main/java/org/apache/parquet/column/values/bitpacking/Packer.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,6 +17,8 @@
  * under the License.
  */
 package org.apache.parquet.column.values.bitpacking;
+
+import org.apache.parquet.ClassLoading;
 
 /**
  * Factory for packing implementations
@@ -66,7 +68,7 @@ public enum Packer {
 
   private static Object getStaticField(String className, String fieldName) {
     try {
-      return Class.forName(className).getField(fieldName).get(null);
+      return ClassLoading.getClassByName(className).getField(fieldName).get(null);
     } catch (IllegalArgumentException e) {
       throw new RuntimeException(e);
     } catch (IllegalAccessException e) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CodecPool;
 import org.apache.hadoop.io.compress.CompressionCodec;
@@ -34,6 +33,7 @@ import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
 import org.apache.hadoop.util.ReflectionUtils;
 
+import org.apache.parquet.ClassLoading;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
@@ -153,7 +153,7 @@ class CodecFactory {
     }
 
     try {
-      Class<?> codecClass = Class.forName(codecClassName);
+      Class<?> codecClass = ClassLoading.getClassByName(codecClassName);
       codec = (CompressionCodec)ReflectionUtils.newInstance(codecClass, configuration);
       codecByName.put(codecClassName, codec);
       return codec;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/CompressionCodecName.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/CompressionCodecName.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.hadoop.metadata;
 
+import org.apache.parquet.ClassLoading;
 import org.apache.parquet.format.CompressionCodec;
 import org.apache.parquet.hadoop.codec.CompressionCodecNotSupportedException;
 
@@ -76,7 +77,7 @@ public enum CompressionCodecName {
       return null;
     }
     try {
-      return Class.forName(codecClassName);
+      return ClassLoading.getClassByName(codecClassName);
     } catch (ClassNotFoundException e) {
       return null;
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/ContextUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/ContextUtil.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -36,6 +36,8 @@ import org.apache.hadoop.mapreduce.StatusReporter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.TaskInputOutputContext;
+
+import org.apache.parquet.ClassLoading;
 
 /*
  * This is based on ContextFactory.java from hadoop-2.0.x sources.
@@ -68,7 +70,7 @@ public class ContextUtil {
     boolean v21 = true;
     final String PACKAGE = "org.apache.hadoop.mapreduce";
     try {
-      Class.forName(PACKAGE + ".task.JobContextImpl");
+      ClassLoading.getClassByName(PACKAGE + ".task.JobContextImpl");
     } catch (ClassNotFoundException cnfe) {
       v21 = false;
     }
@@ -83,29 +85,29 @@ public class ContextUtil {
     try {
       if (v21) {
         jobContextCls =
-            Class.forName(PACKAGE+".task.JobContextImpl");
+            ClassLoading.getClassByName(PACKAGE+".task.JobContextImpl");
         taskContextCls =
-            Class.forName(PACKAGE+".task.TaskAttemptContextImpl");
+            ClassLoading.getClassByName(PACKAGE+".task.TaskAttemptContextImpl");
         taskIOContextCls =
-            Class.forName(PACKAGE+".task.TaskInputOutputContextImpl");
-        mapContextCls = Class.forName(PACKAGE + ".task.MapContextImpl");
-        mapCls = Class.forName(PACKAGE + ".lib.map.WrappedMapper");
+            ClassLoading.getClassByName(PACKAGE+".task.TaskInputOutputContextImpl");
+        mapContextCls = ClassLoading.getClassByName(PACKAGE + ".task.MapContextImpl");
+        mapCls = ClassLoading.getClassByName(PACKAGE + ".lib.map.WrappedMapper");
         innerMapContextCls =
-            Class.forName(PACKAGE+".lib.map.WrappedMapper$Context");
-        genericCounterCls = Class.forName(PACKAGE+".counters.GenericCounter");
+            ClassLoading.getClassByName(PACKAGE+".lib.map.WrappedMapper$Context");
+        genericCounterCls = ClassLoading.getClassByName(PACKAGE+".counters.GenericCounter");
       } else {
         jobContextCls =
-            Class.forName(PACKAGE+".JobContext");
+            ClassLoading.getClassByName(PACKAGE+".JobContext");
         taskContextCls =
-            Class.forName(PACKAGE+".TaskAttemptContext");
+            ClassLoading.getClassByName(PACKAGE+".TaskAttemptContext");
         taskIOContextCls =
-            Class.forName(PACKAGE+".TaskInputOutputContext");
-        mapContextCls = Class.forName(PACKAGE + ".MapContext");
-        mapCls = Class.forName(PACKAGE + ".Mapper");
+            ClassLoading.getClassByName(PACKAGE+".TaskInputOutputContext");
+        mapContextCls = ClassLoading.getClassByName(PACKAGE + ".MapContext");
+        mapCls = ClassLoading.getClassByName(PACKAGE + ".Mapper");
         innerMapContextCls =
-            Class.forName(PACKAGE+".Mapper$Context");
+            ClassLoading.getClassByName(PACKAGE+".Mapper$Context");
         genericCounterCls =
-            Class.forName("org.apache.hadoop.mapred.Counters$Counter");
+            ClassLoading.getClassByName("org.apache.hadoop.mapred.Counters$Counter");
       }
     } catch (ClassNotFoundException e) {
       throw new IllegalArgumentException("Can't find class", e);
@@ -142,10 +144,10 @@ public class ContextUtil {
         WRAPPED_CONTEXT_FIELD.setAccessible(true);
         Method get_counter_method;
         try {
-          get_counter_method = Class.forName(PACKAGE + ".TaskAttemptContext").getMethod("getCounter", String.class,
+          get_counter_method = ClassLoading.getClassByName(PACKAGE + ".TaskAttemptContext").getMethod("getCounter", String.class,
                   String.class);
         } catch (Exception e) {
-          get_counter_method = Class.forName(PACKAGE + ".TaskInputOutputContext").getMethod("getCounter",
+          get_counter_method = ClassLoading.getClassByName(PACKAGE + ".TaskInputOutputContext").getMethod("getCounter",
                   String.class, String.class);
         }
         GET_COUNTER_METHOD=get_counter_method;
@@ -170,9 +172,9 @@ public class ContextUtil {
       WRITER_FIELD.setAccessible(true);
       OUTER_MAP_FIELD = innerMapContextCls.getDeclaredField("this$0");
       OUTER_MAP_FIELD.setAccessible(true);
-      GET_CONFIGURATION_METHOD = Class.forName(PACKAGE+".JobContext")
+      GET_CONFIGURATION_METHOD = ClassLoading.getClassByName(PACKAGE+".JobContext")
           .getMethod("getConfiguration");
-      INCREMENT_COUNTER_METHOD = Class.forName(PACKAGE+".Counter")
+      INCREMENT_COUNTER_METHOD = ClassLoading.getClassByName(PACKAGE+".Counter")
               .getMethod("increment", Long.TYPE);
     } catch (SecurityException e) {
       throw new IllegalArgumentException("Can't run constructor ", e);

--- a/parquet-scrooge/src/main/java/org/apache/parquet/scrooge/ScroogeRecordConverter.java
+++ b/parquet-scrooge/src/main/java/org/apache/parquet/scrooge/ScroogeRecordConverter.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,6 +24,7 @@ import org.apache.thrift.protocol.TProtocol;
 import com.twitter.scrooge.ThriftStruct;
 import com.twitter.scrooge.ThriftStructCodec;
 
+import org.apache.parquet.ClassLoading;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.thrift.ThriftReader;
 import org.apache.parquet.thrift.ThriftRecordConverter;
@@ -46,7 +47,7 @@ public class ScroogeRecordConverter<T extends ThriftStruct> extends ThriftRecord
   private static ThriftStructCodec<?> getCodec(Class<?> klass) {
     Class<?> companionClass;
     try {
-      companionClass = Class.forName(klass.getName() + "$");
+      companionClass = ClassLoading.getClassByName(klass.getName() + "$");
       Object companionObject = companionClass.getField("MODULE$").get(null);
       return (ThriftStructCodec<?>) companionObject;
     } catch (Exception t) {

--- a/parquet-scrooge/src/main/java/org/apache/parquet/scrooge/ScroogeStructConverter.java
+++ b/parquet-scrooge/src/main/java/org/apache/parquet/scrooge/ScroogeStructConverter.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -20,6 +20,7 @@ package org.apache.parquet.scrooge;
 
 import com.twitter.scrooge.ThriftStructCodec;
 import com.twitter.scrooge.ThriftStructFieldInfo;
+import org.apache.parquet.ClassLoading;
 import org.apache.parquet.thrift.struct.ThriftField;
 import org.apache.parquet.thrift.struct.ThriftType;
 import org.apache.parquet.thrift.struct.ThriftType.StructType.StructOrUnionType;
@@ -58,7 +59,7 @@ public class ScroogeStructConverter {
 
   private Class getCompanionClass(Class klass) {
     try {
-     return Class.forName(klass.getName() + "$");
+     return ClassLoading.getClassByName(klass.getName() + "$");
     } catch (ClassNotFoundException e) {
       throw new ScroogeSchemaConversionException("Can not find companion object for scrooge class " + klass, e);
     }
@@ -287,7 +288,7 @@ public class ScroogeStructConverter {
    */
   private List getEnumList(String enumName) throws ClassNotFoundException, IllegalAccessException, NoSuchFieldException, NoSuchMethodException, InvocationTargetException {
     enumName += "$";//In scala generated code, the actual class is ended with $
-    Class companionObjectClass = Class.forName(enumName);
+    Class companionObjectClass = ClassLoading.getClassByName(enumName);
     Object cObject = companionObjectClass.getField("MODULE$").get(null);
     Method listMethod = companionObjectClass.getMethod("list", new Class[]{});
     Object result = listMethod.invoke(cObject, null);

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/AbstractThriftWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/AbstractThriftWriteSupport.java
@@ -22,6 +22,7 @@ import org.apache.thrift.TBase;
 
 import com.twitter.elephantbird.pig.util.ThriftToPig;
 
+import org.apache.parquet.ClassLoading;
 import org.apache.parquet.Log;
 import org.apache.parquet.hadoop.BadConfigurationException;
 import org.apache.parquet.hadoop.api.WriteSupport;
@@ -52,7 +53,7 @@ public abstract class AbstractThriftWriteSupport<T> extends WriteSupport<T> {
 
     try {
       @SuppressWarnings("unchecked")
-      Class thriftClass = Class.forName(thriftClassName);
+      Class thriftClass = configuration.getClassByName(thriftClassName);
       return thriftClass;
     } catch (ClassNotFoundException e) {
       throw new BadConfigurationException("the class "+thriftClassName+" in job conf at " + PARQUET_THRIFT_CLASS + " could not be found", e);
@@ -99,7 +100,7 @@ public abstract class AbstractThriftWriteSupport<T> extends WriteSupport<T> {
 
   protected boolean isPigLoaded() {
     try {
-      Class.forName("org.apache.pig.impl.logicalLayer.schema.Schema");
+      ClassLoading.getClassByName("org.apache.pig.impl.logicalLayer.schema.Schema");
       return true;
     } catch (ClassNotFoundException e) {
       LOG.info("Pig is not loaded, pig metadata will not be written");

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -58,7 +58,7 @@ public class ThriftBytesWriteSupport extends WriteSupport<BytesWritable> {
     }
     try {
       @SuppressWarnings("unchecked")
-      Class<TProtocolFactory> tProtocolFactoryClass = (Class<TProtocolFactory>)Class.forName(tProtocolClassName + "$Factory");
+      Class<TProtocolFactory> tProtocolFactoryClass = (Class<TProtocolFactory>)conf.getClassByName(tProtocolClassName + "$Factory");
       return tProtocolFactoryClass;
     } catch (ClassNotFoundException e) {
       throw new BadConfigurationException("the Factory for class " + tProtocolClassName + " in job conf at " + PARQUET_PROTOCOL_CLASS + " could not be found", e);

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftReadSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftReadSupport.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -134,7 +134,7 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
       }
       className = names.iterator().next();
     }
-    thriftClass = (Class<T>)Class.forName(className);
+    thriftClass = (Class<T>)conf.getClassByName(className);
   }
 
   @SuppressWarnings("unchecked")
@@ -150,7 +150,7 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
       }
       thriftClass = (Class<T>)metaData.getThriftClass();
     } else {
-      thriftClass = (Class<T>)Class.forName(className);
+      thriftClass = (Class<T>)conf.getClassByName(className);
     }
   }
 
@@ -164,7 +164,7 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
 
       String converterClassName = configuration.get(RECORD_CONVERTER_CLASS_KEY, RECORD_CONVERTER_DEFAULT);
       @SuppressWarnings("unchecked")
-      Class<ThriftRecordConverter<T>> converterClass = (Class<ThriftRecordConverter<T>>) Class.forName(converterClassName);
+      Class<ThriftRecordConverter<T>> converterClass = (Class<ThriftRecordConverter<T>>) configuration.getClassByName(converterClassName);
       Constructor<ThriftRecordConverter<T>> constructor =
           converterClass.getConstructor(Class.class, MessageType.class, StructType.class);
       ThriftRecordConverter<T> converter = constructor.newInstance(thriftClass, readContext.getRequestedSchema(), thriftMetaData.getDescriptor());

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftMetaData.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftMetaData.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,6 +19,7 @@
 package org.apache.parquet.thrift;
 import java.util.*;
 
+import org.apache.parquet.ClassLoading;
 import org.apache.parquet.Log;
 import org.apache.parquet.hadoop.BadConfigurationException;
 import org.apache.parquet.thrift.struct.ThriftType;
@@ -68,7 +69,7 @@ public class ThriftMetaData {
    */
   public static Class<?> getThriftClass(String thriftClassName) {
     try {
-      Class<?> thriftClass = Class.forName(thriftClassName);
+      Class<?> thriftClass = ClassLoading.getClassByName(thriftClassName);
       return thriftClass;
     } catch (ClassNotFoundException e) {
       throw new BadConfigurationException("Could not instantiate thrift class " + thriftClassName, e);

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityRunner.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityRunner.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,6 +21,7 @@ package org.apache.parquet.thrift.struct;
 
 import org.apache.thrift.TBase;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.apache.parquet.ClassLoading;
 import org.apache.parquet.thrift.ThriftSchemaConverter;
 
 import java.io.File;
@@ -88,7 +89,7 @@ public class CompatibilityRunner {
     String className = arguments.pollFirst();
     String storedPath = arguments.pollFirst();
     File storeDir = new File(storedPath);
-    ThriftType.StructType structType = new ThriftSchemaConverter().toStructType((Class<? extends TBase<?, ?>>) Class.forName(className));
+    ThriftType.StructType structType = new ThriftSchemaConverter().toStructType((Class<? extends TBase<?, ?>>) ClassLoading.getClassByName(className));
     ObjectMapper mapper = new ObjectMapper();
 
     String fileName = catName + ".json";


### PR DESCRIPTION
This applies the fix from https://github.com/Parquet/parquet-mr/pull/289 to the rest of the codebase.

Anywhere a Hadoop Configuration object is available, the utility method .getClassByName is used. Otherwise, a new utility class ClassLoading is used.