### PR TITLE
PARQUET-269: Restore scrooge-maven-plugin to version 3.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file

--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -185,7 +185,7 @@
         <plugin>
             <groupId>com.twitter</groupId>
             <artifactId>scrooge-maven-plugin</artifactId>
-            <version>3.16.3</version>
+            <version>3.17.0</version>
             <configuration>
                 <outputDirectory>${project.build.directory}/generated-test-sources/scrooge</outputDirectory>
                 <thriftNamespaceMappings>

--- a/parquet-scrooge/src/test/java/org/apache/parquet/scrooge/ScroogeStructConverterTest.java
+++ b/parquet-scrooge/src/test/java/org/apache/parquet/scrooge/ScroogeStructConverterTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.parquet.scrooge;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.parquet.scrooge.test.AddressWithStreetWithDefaultRequirement;
@@ -55,7 +54,6 @@ public class ScroogeStructConverterTest {
   }
 
   @Test
-  @Ignore
   public void testUnion() throws Exception {
     ThriftType.StructType expected = new ThriftSchemaConverter().toStructType(org.apache.parquet.thrift.test.TestUnion.class);
     ThriftType.StructType scroogeUnion = new ScroogeStructConverter().convert(TestUnion.class);
@@ -110,7 +108,6 @@ public class ScroogeStructConverterTest {
  * if the getter returns option, then it's optional, otherwise it's required
  */
   @Test
-  @Ignore
   public void testDefaultFields() throws Exception{
     ThriftType.StructType scroogePerson = new ScroogeStructConverter().convert(AddressWithStreetWithDefaultRequirement.class);
     ThriftType.StructType expected = new ThriftSchemaConverter().toStructType(org.apache.parquet.thrift.test.AddressWithStreetWithDefaultRequirement.class);


### PR DESCRIPTION
Scrooge has re-published scrooge-maven-plugin 3.17.0, so we should be able to use it again.
Lets see if travis is able to pick up the changes.