### PR TITLE
PARQUET-279 : Check empty struct in compatibility checker

### DIFF
--- a/parquet-common/src/main/java/org/apache/parquet/Strings.java
+++ b/parquet-common/src/main/java/org/apache/parquet/Strings.java
@@ -40,7 +40,19 @@ public final class Strings {
    * @return a single joined string
    */
   public static String join(Iterable<String> s, String on) {
-    Iterator<String> iter = s.iterator();
+    return join(s.iterator(), on);
+  }
+
+  /**
+   * Join an Iterator of Strings into a single string with a delimiter.
+   * For example, join(Arrays.asList("foo","","bar","x"), "|") would return
+   * "foo||bar|x"
+   *
+   * @param iter an iterator of strings
+   * @param on the delimiter
+   * @return a single joined string
+   */
+  public static String join(Iterator<String> iter, String on) {
     StringBuilder sb = new StringBuilder();
     while (iter.hasNext()) {
       sb.append(iter.next());

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/BufferedProtocolReadToWrite.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/BufferedProtocolReadToWrite.java
@@ -414,7 +414,7 @@ public class BufferedProtocolReadToWrite implements ProtocolPipe {
       case UNION:
         // this is a union with an unrecognized member -- this is fatal for this record
         // in the write path, because it will be unreadable in the read path.
-        // throwing here means we will either skip this record entirely, or fail completely.
+        // throwing here means we will either skip this record entirely, or incompatible completely.
         throw new DecodingSchemaMismatchException("Unrecognized union member with id: "
             + field.id + " for struct:\n" + type);
       case UNKNOWN:

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/BufferedProtocolReadToWrite.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/BufferedProtocolReadToWrite.java
@@ -414,7 +414,7 @@ public class BufferedProtocolReadToWrite implements ProtocolPipe {
       case UNION:
         // this is a union with an unrecognized member -- this is fatal for this record
         // in the write path, because it will be unreadable in the read path.
-        // throwing here means we will either skip this record entirely, or incompatible completely.
+        // throwing here means we will either skip this record entirely, or fail completely.
         throw new DecodingSchemaMismatchException("Unrecognized union member with id: "
             + field.id + " for struct:\n" + type);
       case UNKNOWN:

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConverter.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConverter.java
@@ -124,11 +124,11 @@ public class ThriftSchemaConverter {
         break;
       case SET:
         final Field setElemField = field.getSetElemField();
-        type = new ThriftType.SetType(toThriftField(name, setElemField, requirement));
+        type = new ThriftType.SetType(toThriftField(setElemField.getName(), setElemField, requirement));
         break;
       case LIST:
         final Field listElemField = field.getListElemField();
-        type = new ThriftType.ListType(toThriftField(name, listElemField, requirement));
+        type = new ThriftType.ListType(toThriftField(listElemField.getName(), listElemField, requirement));
         break;
       case ENUM:
         Collection<TEnum> enumValues = field.getEnumValues();

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityChecker.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityChecker.java
@@ -213,7 +213,7 @@ class CompatibleCheckerVisitor implements ThriftType.TypeVisitor<Void, Void> {
     short oldMaxId = 0;
 
     if (newStruct.getChildren().size() == 0) {
-      report.emptyStruct("new struct has no child: " + path);
+      report.emptyStruct("new struct is an empty struct: " + path);
     }
 
     for (ThriftField oldField : currentOldType.getChildren()) {

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityChecker.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityChecker.java
@@ -107,7 +107,7 @@ class State {
   }
 }
 
-class CompatibleCheckerVisitor implements ThriftType.TypeVisitor<Void, State> {
+class CompatibleCheckerVisitor implements ThriftType.StateVisitor<Void, State> {
 
   CompatibilityReport report = new CompatibilityReport();
 

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityChecker.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityChecker.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -33,6 +33,7 @@ import org.apache.parquet.thrift.struct.ThriftType.I16Type;
 import org.apache.parquet.thrift.struct.ThriftType.I32Type;
 import org.apache.parquet.thrift.struct.ThriftType.I64Type;
 import org.apache.parquet.thrift.struct.ThriftType.StringType;
+import org.apache.parquet.Strings;
 
 /**
  * A checker for thrift struct to enforce its backward compatibility, returns compatibility report based on following rules:
@@ -81,12 +82,8 @@ class CompatibilityReport {
   }
 
   public String prettyMessages() {
-    StringBuffer message = new StringBuffer();
-    for(String m: messages) {
-      message.append(m);
-      message.append("\n");
-    }
-    return message.toString();
+
+    return Strings.join(messages, "\n");
   }
 
   @Override
@@ -117,13 +114,7 @@ class CompatibleCheckerVisitor implements ThriftType.TypeVisitor<Void, Void> {
 
     @Override
     public String toString() {
-      StringBuffer buffer = new StringBuffer("/");
-      Iterator<String> it = path.descendingIterator();
-      while(it.hasNext()) {
-        buffer.append(it.next());
-        buffer.append('/');
-      }
-      return buffer.toString();
+     return Strings.join(path.descendingIterator(), "/");
     }
   }
 
@@ -212,8 +203,8 @@ class CompatibleCheckerVisitor implements ThriftType.TypeVisitor<Void, Void> {
     ThriftType.StructType currentOldType = ((ThriftType.StructType) oldType);
     short oldMaxId = 0;
 
-    if (newStruct.getChildren().size() == 0) {
-      report.emptyStruct("new struct is an empty struct: " + path);
+    if (newStruct.getChildren().isEmpty()) {
+      report.emptyStruct("encountered an empty struct: " + path);
     }
 
     for (ThriftField oldField : currentOldType.getChildren()) {

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityChecker.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityChecker.java
@@ -48,7 +48,7 @@ import org.apache.parquet.Strings;
 public class CompatibilityChecker {
 
   public CompatibilityReport checkCompatibility(ThriftType.StructType oldStruct, ThriftType.StructType newStruct) {
-    CompatibleCheckerVisitor visitor = new CompatibleCheckerVisitor(oldStruct);
+    CompatibleCheckerVisitor visitor = new CompatibleCheckerVisitor();
     newStruct.accept(visitor, new State(oldStruct,new FieldsPath()));
     return visitor.getReport();
   }
@@ -110,9 +110,6 @@ class State {
 class CompatibleCheckerVisitor implements ThriftType.TypeVisitor<Void, State> {
 
   CompatibilityReport report = new CompatibilityReport();
-
-  CompatibleCheckerVisitor(ThriftType.StructType oldType) {
-  }
 
   public CompatibilityReport getReport() {
     return report;

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityRunner.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityRunner.java
@@ -74,7 +74,7 @@ public class CompatibilityRunner {
       System.exit(1);
     }
 
-    if (!report.hasEmptyStruct()) {
+    if (report.hasEmptyStruct()) {
       System.err.println("schema contains empty struct");
       System.err.println(report.getMessages());
       System.exit(1);

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityRunner.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityRunner.java
@@ -73,6 +73,13 @@ public class CompatibilityRunner {
       System.err.println(report.getMessages());
       System.exit(1);
     }
+
+    if (!report.hasEmptyStruct()) {
+      System.err.println("schema contains empty struct");
+      System.err.println(report.getMessages());
+      System.exit(1);
+    }
+
     System.out.println("[success] schema is compatible");
 
   }

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityRunner.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityRunner.java
@@ -36,7 +36,7 @@ import java.util.LinkedList;
  *
  * java CompatibilityRunner compare-json {old_json_path} {new_json_path}
  * The above command will succeed when the new schema is compatible with the old schema.
- * It will fail when they are not compatible. For compatibility rules: {@link CompatibilityChecker}
+ * It will incompatible when they are not compatible. For compatibility rules: {@link CompatibilityChecker}
  *
  * @author Tianshuo Deng
  */

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityRunner.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityRunner.java
@@ -36,7 +36,7 @@ import java.util.LinkedList;
  *
  * java CompatibilityRunner compare-json {old_json_path} {new_json_path}
  * The above command will succeed when the new schema is compatible with the old schema.
- * It will incompatible when they are not compatible. For compatibility rules: {@link CompatibilityChecker}
+ * It will fail when they are not compatible. For compatibility rules: {@link CompatibilityChecker}
  *
  * @author Tianshuo Deng
  */

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/CompatibilityCheckerTest.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/CompatibilityCheckerTest.java
@@ -111,7 +111,8 @@ public class CompatibilityCheckerTest {
   @Test
   public void testEmptyStruct() {
     CompatibilityReport report = getCompatibilityReport(NestedEmptyStruct.class, NestedEmptyStruct.class);
-    System.out.println(report.getMessages());
+    assertTrue(report.prettyMessages().contains("new struct is an empty struct: /required_empty/"));
+    assertTrue(report.prettyMessages().contains("new struct is an empty struct: /optional_empty/"));
     assertTrue(report.hasEmptyStruct());
   }
 
@@ -127,7 +128,6 @@ public class CompatibilityCheckerTest {
 
   private void verifyCompatible(Class oldClass, Class newClass, boolean expectCompatible) {
     CompatibilityReport report = getCompatibilityReport(oldClass, newClass);
-    System.out.println(report);
     assertEquals(expectCompatible, report.isCompatible());
   }
 }

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/CompatibilityCheckerTest.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/CompatibilityCheckerTest.java
@@ -111,8 +111,7 @@ public class CompatibilityCheckerTest {
   @Test
   public void testEmptyStruct() {
     CompatibilityReport report = getCompatibilityReport(NestedEmptyStruct.class, NestedEmptyStruct.class);
-    assertTrue(report.prettyMessages().contains("new struct is an empty struct: /required_empty/"));
-    assertTrue(report.prettyMessages().contains("new struct is an empty struct: /optional_empty/"));
+    assertEquals("encountered an empty struct: required_empty\nencountered an empty struct: optional_empty",report.prettyMessages());
     assertTrue(report.hasEmptyStruct());
   }
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/CompatibilityCheckerTest.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/CompatibilityCheckerTest.java
@@ -23,6 +23,7 @@ import org.apache.parquet.thrift.ThriftSchemaConverter;
 import org.apache.parquet.thrift.test.compat.*;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CompatibilityCheckerTest {
 
@@ -107,14 +108,26 @@ public class CompatibilityCheckerTest {
     verifyCompatible(ListStructV1.class, ListStructV2.class, true);
   }
 
+  @Test
+  public void testEmptyStruct() {
+    CompatibilityReport report = getCompatibilityReport(NestedEmptyStruct.class, NestedEmptyStruct.class);
+    System.out.println(report.getMessages());
+    assertTrue(report.hasEmptyStruct());
+  }
+
   private ThriftType.StructType struct(Class thriftClass) {
     return new ThriftSchemaConverter().toStructType(thriftClass);
   }
 
-  private void verifyCompatible(Class oldClass, Class newClass, boolean expectCompatible) {
+  private CompatibilityReport getCompatibilityReport(Class oldClass, Class newClass) {
     CompatibilityChecker checker = new CompatibilityChecker();
     CompatibilityReport report = checker.checkCompatibility(struct(oldClass), struct(newClass));
-    System.out.println(report.messages);
+    return report;
+  }
+
+  private void verifyCompatible(Class oldClass, Class newClass, boolean expectCompatible) {
+    CompatibilityReport report = getCompatibilityReport(oldClass, newClass);
+    System.out.println(report);
     assertEquals(expectCompatible, report.isCompatible());
   }
 }

--- a/parquet-thrift/src/test/thrift/compat.thrift
+++ b/parquet-thrift/src/test/thrift/compat.thrift
@@ -253,3 +253,12 @@ struct ListOfUnions {
   1: optional list<UnionOfStructs> optListUnion
   2: required list<UnionOfStructs> reqListUnion
 }
+
+struct EmptyStruct {
+
+}
+
+struct NestedEmptyStruct {
+  1: required EmptyStruct required_empty
+  2: optional EmptyStruct optional_empty
+}


### PR DESCRIPTION
Add the empty struct check in the CompatibilityChecker util.
Parquet currently does not support empty struct/group without leaves
