### PR TITLE
PARQUET-278 : enforce non empty group on MessageType level

### DIFF
--- a/dev/merge_parquet_pr.py
+++ b/dev/merge_parquet_pr.py
@@ -79,7 +79,6 @@ def fail(msg):
 
 
 def run_cmd(cmd):
-    print cmd
     if isinstance(cmd, list):
         return subprocess.check_output(cmd)
     else:

--- a/dev/merge_parquet_pr.py
+++ b/dev/merge_parquet_pr.py
@@ -79,6 +79,7 @@ def fail(msg):
 
 
 def run_cmd(cmd):
+    print cmd
     if isinstance(cmd, list):
         return subprocess.check_output(cmd)
     else:

--- a/parquet-column/src/main/java/org/apache/parquet/schema/GroupType.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/GroupType.java
@@ -88,7 +88,7 @@ public class GroupType extends Type {
    */
   GroupType(Repetition repetition, String name, OriginalType originalType, List<Type> fields, ID id) {
     super(name, repetition, originalType, id);
-    if (fields.size() == 0) {
+    if (fields.isEmpty()) {
       throw new InvalidSchemaException("A group type can not be empty. Parquet does not support empty group without leaves. Empty group: " + name);
     }
     this.fields = fields;

--- a/parquet-column/src/main/java/org/apache/parquet/schema/GroupType.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/GroupType.java
@@ -88,6 +88,9 @@ public class GroupType extends Type {
    */
   GroupType(Repetition repetition, String name, OriginalType originalType, List<Type> fields, ID id) {
     super(name, repetition, originalType, id);
+    if (fields.size() == 0) {
+      throw new InvalidSchemaException("A group type can not be empty. Parquet does not support empty group without leaves. Empty group: " + name);
+    }
     this.fields = fields;
     this.indexByName = new HashMap<String, Integer>();
     for (int i = 0; i < fields.size(); i++) {

--- a/parquet-column/src/main/java/org/apache/parquet/schema/InvalidSchemaException.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/InvalidSchemaException.java
@@ -20,30 +20,12 @@ package org.apache.parquet.schema;
 
 import org.apache.parquet.ParquetRuntimeException;
 
-/**
- * thrown when we are trying to read together files with incompatible schemas.
- *
- * @author Julien Le Dem
- *
- */
-public class IncompatibleSchemaModificationException extends ParquetRuntimeException {
-  private static final long serialVersionUID = 1L;
-
-  public IncompatibleSchemaModificationException() {
-    super();
-  }
-
-  public IncompatibleSchemaModificationException(String message,
-      Throwable cause) {
+public class InvalidSchemaException extends ParquetRuntimeException {
+  public InvalidSchemaException(String message, Throwable cause) {
     super(message, cause);
   }
 
-  public IncompatibleSchemaModificationException(String message) {
+  public InvalidSchemaException(String message) {
     super(message);
   }
-
-  public IncompatibleSchemaModificationException(Throwable cause) {
-    super(cause);
-  }
-
 }

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestMessageType.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestMessageType.java
@@ -145,4 +145,18 @@ public class TestMessageType {
     assertEquals(schema, schema2);
     assertEquals(schema.toString(), schema2.toString());
   }
+
+  @Test
+  public void testEmptyGroup() {
+    try {
+      MessageType t5 = new MessageType("root1",
+          new GroupType(REQUIRED, "g1"),
+          new GroupType(REQUIRED, "g2",
+              new PrimitiveType(OPTIONAL, BINARY, "b")));
+    } catch (InvalidSchemaException e) {
+      assertEquals("A group type can not be empty. Parquet does not support empty group without leaves. Empty group: g1", e.getMessage());
+    }
+  }
+
+
 }

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestMessageType.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestMessageType.java
@@ -156,6 +156,7 @@ public class TestMessageType {
     } catch (InvalidSchemaException e) {
       assertEquals("A group type can not be empty. Parquet does not support empty group without leaves. Empty group: g1", e.getMessage());
     }
+    fail("should throw InvalidSchemaException when GroupType contains no child");
   }
 
 

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestMessageType.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestMessageType.java
@@ -153,11 +153,10 @@ public class TestMessageType {
           new GroupType(REQUIRED, "g1"),
           new GroupType(REQUIRED, "g2",
               new PrimitiveType(OPTIONAL, BINARY, "b")));
+      fail("should throw InvalidSchemaException when GroupType contains no child");
     } catch (InvalidSchemaException e) {
       assertEquals("A group type can not be empty. Parquet does not support empty group without leaves. Empty group: g1", e.getMessage());
     }
-    fail("should throw InvalidSchemaException when GroupType contains no child");
   }
-
 
 }

--- a/parquet-pig/src/test/java/org/apache/parquet/pig/TestPigSchemaConverter.java
+++ b/parquet-pig/src/test/java/org/apache/parquet/pig/TestPigSchemaConverter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.pig;
 
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.*;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.junit.Assert.assertEquals;
 import static org.apache.parquet.pig.PigSchemaConverter.pigSchemaToString;
 import static org.apache.parquet.pig.TupleReadSupport.getPigSchemaFromMultipleFiles;
@@ -28,6 +30,9 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Type;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
 import org.apache.pig.impl.util.Utils;
 import org.junit.Test;
@@ -221,7 +226,7 @@ public class TestPigSchemaConverter {
     map.put("pig.schema", new LinkedHashSet<String>(Arrays.asList(
         "a:int, b:int, c:int, d:int, e:int, f:int",
         "aa:int, aaa:int, b:int, c:int, ee:int")));
-    Schema result = getPigSchemaFromMultipleFiles(new MessageType("empty"), map);
+    Schema result = getPigSchemaFromMultipleFiles(new MessageType("file_schema", new PrimitiveType(OPTIONAL, INT32,"a")), map);
     assertEquals("a: int,b: int,c: int,d: int,e: int,f: int,aa: int,aaa: int,ee: int", pigSchemaToString(result));
   }
 

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConverter.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConverter.java
@@ -59,8 +59,8 @@ public class ThriftSchemaConverter {
   public MessageType convert(StructType thriftClass) {
     ThriftSchemaConvertVisitor visitor = new ThriftSchemaConvertVisitor(fieldProjectionFilter);
     thriftClass.accept(visitor);
-    MessageType convertedMessageType = visitor.getConvertedMessageType();
     fieldProjectionFilter.assertNoUnmatchedPatterns();
+    MessageType convertedMessageType = visitor.getConvertedMessageType();
     return convertedMessageType;
   }
 


### PR DESCRIPTION
As columnar format, parquet currently does not support empty struct/group without leaves. We should throw when constructing an empty GroupType to give a clear message.