### PR TITLE
PARQUET-263: Release changes from parquet-1.7.0 branch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@
 
 # Parquet #
 
+### Version 1.7.0 ###
+
+*   [PARQUET-23](https://issues.apache.org/jira/browse/PARQUET-23) - Rename to org.apache.
+
 ### Version 1.6.0 ###
 
 ####  Bug

--- a/dev/prepare-release.sh
+++ b/dev/prepare-release.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <version>"
+  exit
+fi
+
+version=$1
+
+tag=apache-parquet-$version
+
+mvn release:clean
+mvn release:prepare -Dtag=$tag -DreleaseVersion=$version
+
+echo "Finish staging binary artifacts by running: sh dev/perform-release.sh"

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -68,7 +68,7 @@ svn co --depth=empty https://dist.apache.org/repos/dist/dev/parquet tmp
 mkdir -p tmp/$tagrc
 cp ${tarball}* tmp/$tagrc
 svn add tmp/$tagrc
-echo "svn ci -m 'Apache Parquet MR $version RC${rc}' tmp/$tagrc"
+svn ci -m 'Apache Parquet MR $version RC${rc}' tmp/$tagrc
 
 # clean up
 rm -rf tmp

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>14</version>
+    <version>16</version>
   </parent>
 
   <groupId>org.apache.parquet</groupId>
@@ -55,32 +55,6 @@
       <email>julien@twitter.com</email>
     </developer>
   </developers>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype OSS</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <name>Nexus Release Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
-  <repositories>
-    <repository>
-      <id>sonatype-nexus-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-     </repository>
-  </repositories>
 
   <!-- this is needed for maven-thrift-plugin, would like to remove this.
    see: https://issues.apache.org/jira/browse/THRIFT-1536  -->
@@ -211,6 +185,16 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <!-- Disable the source artifact from ASF parent -->
+          <artifactId>maven-assembly-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>source-release-assembly</id>
+              <phase>none</phase>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>1.3.1</version>
           <dependencies>
@@ -248,16 +232,6 @@
            </execution>
            -->
          </executions>
-        </plugin>
-        <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-release-plugin</artifactId>
-         <version>2.1</version>
-         <configuration>
-          <mavenExecutorId>forked-path</mavenExecutorId>
-          <useReleaseProfile>false</useReleaseProfile>
-          <arguments>-Psonatype-oss-release</arguments>
-         </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -473,53 +447,6 @@
                   <goal>site</goal>
                 </goals>
                 <phase>site-deploy</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>sonatype-oss-release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>2.1.2</version>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.7</version>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.1</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
These are the additional changes needed to build the 1.7.0 RC. No functional changes to the library, just configuration in the POM, release scripts, and the addition to the changelog.