### PR TITLE
PARQUET-248: Add ParquetWriter.Builder.

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
@@ -145,67 +145,12 @@ public class AvroParquetWriter<T> extends ParquetWriter<T> {
         new AvroSchemaConverter(conf).convert(avroSchema), avroSchema, model);
   }
 
-  public static class Builder<T> {
-    private final Path file;
-    private Configuration conf = new Configuration();
-    private CompressionCodecName codecName = DEFAULT_COMPRESSION_CODEC_NAME;
-    private int blockSize = DEFAULT_BLOCK_SIZE;
-    private int pageSize = DEFAULT_PAGE_SIZE;
-    private boolean enableDictionary = DEFAULT_IS_DICTIONARY_ENABLED;
-    private boolean enableValidation = DEFAULT_IS_VALIDATING_ENABLED;
-    private WriterVersion writerVersion = DEFAULT_WRITER_VERSION;
-
-    // avro-specific
+  public static class Builder<T> extends ParquetWriter.Builder<T, Builder<T>> {
     private Schema schema = null;
     private GenericData model = SpecificData.get();
 
     private Builder(Path file) {
-      this.file = file;
-    }
-
-    public Builder<T> withConf(Configuration conf) {
-      this.conf = conf;
-      return this;
-    }
-
-    public Builder<T> withCompressionCodec(CompressionCodecName codecName) {
-      this.codecName = codecName;
-      return this;
-    }
-
-    public Builder<T> withBlockSize(int blockSize) {
-      this.blockSize = blockSize;
-      return this;
-    }
-
-    public Builder<T> withPageSize(int pageSize) {
-      this.pageSize = pageSize;
-      return this;
-    }
-
-    public Builder<T> enableDictionaryEncoding() {
-      this.enableDictionary = true;
-      return this;
-    }
-
-    public Builder<T> withDictionaryEncoding(boolean enableDictionary) {
-      this.enableDictionary = enableDictionary;
-      return this;
-    }
-
-    public Builder<T> enableValidation() {
-      this.enableValidation = true;
-      return this;
-    }
-
-    public Builder<T> withValidation(boolean enableValidation) {
-      this.enableValidation = enableValidation;
-      return this;
-    }
-
-    public Builder<T> withWriterVersion(WriterVersion version) {
-      this.writerVersion = version;
-      return this;
+      super(file);
     }
 
     public Builder<T> withSchema(Schema schema) {
@@ -218,14 +163,14 @@ public class AvroParquetWriter<T> extends ParquetWriter<T> {
       return this;
     }
 
-    private WriteSupport<T> getWriteSupport() {
-      return AvroParquetWriter.<T>writeSupport(conf, schema, model);
+    @Override
+    protected Builder<T> self() {
+      return this;
     }
 
-    public ParquetWriter<T> build() throws IOException {
-      return new AvroParquetWriter<T>(file, getWriteSupport(), codecName,
-          blockSize, pageSize, enableDictionary, enableValidation,
-          writerVersion, conf);
+    @Override
+    protected WriteSupport<T> getWriteSupport(Configuration conf) {
+      return AvroParquetWriter.writeSupport(conf, schema, model);
     }
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -273,4 +273,162 @@ public class ParquetWriter<T> implements Closeable {
       throw new IOException(e);
     }
   }
+
+  /**
+   * An abstract builder class for ParquetWriter instances.
+   *
+   * Object models should extend this builder to provide writer configuration
+   * options.
+   *
+   * @param <T> The type of objects written by the constructed ParquetWriter.
+   * @param <SELF> The type of this builder that is returned by builder methods
+   */
+  public abstract static class Builder<T, SELF extends Builder<T, SELF>> {
+    private final Path file;
+    private Configuration conf = new Configuration();
+    private CompressionCodecName codecName = DEFAULT_COMPRESSION_CODEC_NAME;
+    private int blockSize = DEFAULT_BLOCK_SIZE;
+    private int pageSize = DEFAULT_PAGE_SIZE;
+    private int dictionaryPageSize = DEFAULT_PAGE_SIZE;
+    private boolean enableDictionary = DEFAULT_IS_DICTIONARY_ENABLED;
+    private boolean enableValidation = DEFAULT_IS_VALIDATING_ENABLED;
+    private WriterVersion writerVersion = DEFAULT_WRITER_VERSION;
+
+    protected Builder(Path file) {
+      this.file = file;
+    }
+
+    /**
+     * @return this as the correct subclass of ParquetWriter.Builder.
+     */
+    protected abstract SELF self();
+
+    /**
+     * @return an appropriate WriteSupport for the object model.
+     */
+    protected abstract WriteSupport<T> getWriteSupport(Configuration conf);
+
+    /**
+     * Set the {@link Configuration} used by the constructed writer.
+     *
+     * @param conf a {@code Configuration}
+     * @return this builder for method chaining.
+     */
+    public SELF withConf(Configuration conf) {
+      this.conf = conf;
+      return self();
+    }
+
+    /**
+     * Set the {@link CompressionCodecName compression codec} used by the
+     * constructed writer.
+     *
+     * @param codecName a {@code CompressionCodecName}
+     * @return this builder for method chaining.
+     */
+    public SELF withCompressionCodec(CompressionCodecName codecName) {
+      this.codecName = codecName;
+      return self();
+    }
+
+    /**
+     * Set the Parquet format row group size used by the constructed writer.
+     *
+     * @param rowGroupSize an integer size in bytes
+     * @return this builder for method chaining.
+     */
+    public SELF withRowGroupSize(int rowGroupSize) {
+      this.blockSize = rowGroupSize;
+      return self();
+    }
+
+    /**
+     * Set the Parquet format page size used by the constructed writer.
+     *
+     * @param pageSize an integer size in bytes
+     * @return this builder for method chaining.
+     */
+    public SELF withPageSize(int pageSize) {
+      this.pageSize = pageSize;
+      return self();
+    }
+
+    /**
+     * Set the Parquet format dictionary page size used by the constructed
+     * writer.
+     *
+     * @param dictionaryPageSize an integer size in bytes
+     * @return this builder for method chaining.
+     */
+    public SELF withDictionaryPageSize(int dictionaryPageSize) {
+      this.dictionaryPageSize = dictionaryPageSize;
+      return self();
+    }
+
+    /**
+     * Enables dictionary encoding for the constructed writer.
+     *
+     * @return this builder for method chaining.
+     */
+    public SELF enableDictionaryEncoding() {
+      this.enableDictionary = true;
+      return self();
+    }
+
+    /**
+     * Enable or disable dictionary encoding for the constructed writer.
+     *
+     * @param enableDictionary whether dictionary encoding should be enabled
+     * @return this builder for method chaining.
+     */
+    public SELF withDictionaryEncoding(boolean enableDictionary) {
+      this.enableDictionary = enableDictionary;
+      return self();
+    }
+
+    /**
+     * Enables validation for the constructed writer.
+     *
+     * @return this builder for method chaining.
+     */
+    public SELF enableValidation() {
+      this.enableValidation = true;
+      return self();
+    }
+
+    /**
+     * Enable or disable validation for the constructed writer.
+     *
+     * @param enableValidation whether validation should be enabled
+     * @return this builder for method chaining.
+     */
+    public SELF withValidation(boolean enableValidation) {
+      this.enableValidation = enableValidation;
+      return self();
+    }
+
+    /**
+     * Set the {@link WriterVersion format version} used by the constructed
+     * writer.
+     *
+     * @param version a {@code WriterVersion}
+     * @return this builder for method chaining.
+     */
+    public SELF withWriterVersion(WriterVersion version) {
+      this.writerVersion = version;
+      return self();
+    }
+
+    /**
+     * Build a {@link ParquetWriter} with the accumulated configuration.
+     *
+     * @return a configured {@code ParquetWriter} instance.
+     * @throws IOException
+     */
+    public ParquetWriter<T> build() throws IOException {
+      return new ParquetWriter<T>(file, getWriteSupport(conf), codecName,
+          blockSize, pageSize, dictionaryPageSize, enableDictionary,
+          enableValidation, writerVersion, conf);
+    }
+  }
 }


### PR DESCRIPTION
This refactors the builder recently added to parquet-avro so that it can
be used by all object models. The Builder class is abstract and
implementations should extend it.

This changes the API slightly from AvroParquetWriter, renaming
withBlockSize to withRowGroupSize. The Avro builder has not been
released so this isn't a breaking change.