### PR TITLE
PARQUET-262: Restore semver checks.

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
@@ -43,7 +43,8 @@ public class AvroReadSupport<T> extends ReadSupport<T> {
   static final String OLD_AVRO_SCHEMA_METADATA_KEY = "avro.schema";
   private static final String AVRO_READ_SCHEMA_METADATA_KEY = "avro.read.schema";
 
-  public static final String AVRO_DATA_SUPPLIER = "parquet.avro.data.supplier";
+  // TODO: for 2.0.0, make this final (breaking change)
+  public static String AVRO_DATA_SUPPLIER = "parquet.avro.data.supplier";
 
   public static final String AVRO_COMPATIBILITY = "parquet.avro.compatible";
   public static final boolean AVRO_DEFAULT_COMPATIBILITY = true;

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
@@ -67,6 +67,14 @@ public class ThriftSchemaConvertVisitor implements ThriftType.TypeVisitor {
     this.fieldProjectionFilter = Preconditions.checkNotNull(fieldProjectionFilter, "fieldProjectionFilter");
   }
 
+  /**
+   * @deprecated this will be removed in 2.0.0.
+   */
+  @Deprecated
+  public FieldProjectionFilter getFieldProjectionFilter() {
+    return fieldProjectionFilter;
+  }
+
   @Override
   public void visit(ThriftType.MapType mapType) {
     final ThriftField mapKeyField = mapType.getKey();

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <cascading.version>2.5.3</cascading.version>
     <parquet.format.version>2.3.0-incubating</parquet.format.version>
     <log4j.version>1.2.17</log4j.version>
-    <previous.version>1.5.0</previous.version>
+    <previous.version>1.7.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <scala.version>2.10.4</scala.version>
     <!-- scala.binary.version is used for projects that fetch dependencies that are in scala -->
@@ -222,7 +222,6 @@
             </dependency>
          </dependencies>
          <executions>
-           <!--
            <execution>
              <id>check</id>
              <phase>verify</phase>
@@ -235,19 +234,19 @@
                    <dumpDetails>true</dumpDetails>
                    <previousVersion>${previous.version}</previousVersion>
                    <excludes>
-                     <exclude>parquet/hadoop/thrift/**</exclude>
-                     <exclude>parquet/thrift/projection/**</exclude>
-                     <exclude>parquet/thrift/ThriftSchemaConverter</exclude>
-                     <exclude>parquet/filter2/**</exclude>
-                     <exclude>parquet/org/**</exclude>
-                     <exclude>parquet/column/**</exclude>
-                     <exclude>parquet/hadoop/ParquetInputSplit</exclude>
+                     <exclude>org/apache/parquet/hadoop/thrift/**</exclude>
+                     <exclude>org/apache/parquet/thrift/projection/**</exclude>
+                     <exclude>org/apache/parquet/thrift/ThriftSchemaConverter</exclude>
+                     <exclude>org/apache/parquet/filter2/**</exclude>
+                     <exclude>org/apache/parquet/column/**</exclude>
+                     <exclude>org/apache/parquet/hadoop/ParquetInputSplit</exclude>
+                     <exclude>shaded/**</exclude> <!-- shaded by parquet -->
+                     <exclude>parquet/**</exclude> <!-- shaded by parquet-format -->
                    </excludes>
                  </requireBackwardCompatibility>
                </rules>
              </configuration>
            </execution>
-           -->
          </executions>
         </plugin>
         <plugin>


### PR DESCRIPTION
Because 1.6.0 to 1.7.0 was a breaking rename, semver was turned off
until the 1.7.0 artifacts were released. Now that they are available,
the check needs to be restored.

There were already 2 breaking changes that are fixed by this commit:
* A field in AvroReadSupport was made final
* An accessor method in ThriftSchemaConvertVisitor was removed