### PR TITLE
PARQUET-286: Update String support to match upstream Avro.

### DIFF
--- a/parquet-avro/pom.xml
+++ b/parquet-avro/pom.xml
@@ -84,6 +84,14 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/test/avro</directory>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -97,7 +105,15 @@
         <artifactId>avro-maven-plugin</artifactId>
         <version>${avro.version}</version>
         <executions>
+          <execution>
+            <id>compile-avsc</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>schema</goal>
+            </goals>
+          </execution>
             <execution>
+                <id>compile-idl</id>
                 <phase>generate-test-sources</phase>
                 <goals>
                     <goal>idl-protocol</goal>

--- a/parquet-avro/src/test/avro/stringBehavior.avsc
+++ b/parquet-avro/src/test/avro/stringBehavior.avsc
@@ -1,0 +1,35 @@
+{
+  "name" : "StringBehaviorTest",
+  "namespace": "org.apache.parquet.avro",
+  "type" : "record",
+  "fields" : [ {
+    "name" : "default_class",
+    "type" : "string"
+  }, {
+    "name" : "string_class",
+    "type" : {"type": "string", "avro.java.string": "String"}
+  }, {
+    "name" : "stringable_class",
+    "type" : {"type": "string", "java-class": "java.math.BigDecimal"}
+  }, {
+    "name" : "default_map",
+    "type" : {
+      "type" : "map",
+      "values" : "int"
+    }
+  }, {
+    "name" : "string_map",
+    "type" : {
+      "type" : "map",
+      "values" : "int",
+      "avro.java.string": "String"
+    }
+  }, {
+    "name" : "stringable_map",
+    "type" : {
+      "type" : "map",
+      "values" : "int",
+      "java-key-class": "java.math.BigDecimal"
+    }
+  } ]
+}

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestBackwardCompatibility.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestBackwardCompatibility.java
@@ -21,6 +21,7 @@ package org.apache.parquet.avro;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
@@ -60,7 +61,7 @@ public class TestBackwardCompatibility {
     GenericRecord r;
     while ((r = reader.read()) != null) {
       Assert.assertTrue("Should read value into a String",
-          r.get("text") instanceof String);
+          r.get("text") instanceof Utf8);
     }
   }
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWrite.java
@@ -19,6 +19,7 @@
 package org.apache.parquet.avro;
 
 import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
@@ -149,10 +150,10 @@ public class TestReadWrite {
         .build();
 
     // Write a record with a null value
-    Map<String, Integer> map = new HashMap<String, Integer>();
-    map.put("thirty-four", 34);
-    map.put("eleventy-one", null);
-    map.put("one-hundred", 100);
+    Map<CharSequence, Integer> map = new HashMap<CharSequence, Integer>();
+    map.put(str("thirty-four"), 34);
+    map.put(str("eleventy-one"), null);
+    map.put(str("one-hundred"), 100);
 
     GenericData.Record record = new GenericRecordBuilder(schema)
         .set("mymap", map).build();
@@ -221,7 +222,7 @@ public class TestReadWrite {
     GenericRecord nextRecord = reader.read();
 
     assertNotNull(nextRecord);
-    assertEquals(ImmutableMap.of("a", 1, "b", 2), nextRecord.get("mymap"));
+    assertEquals(ImmutableMap.of(str("a"), 1, str("b"), 2), nextRecord.get("mymap"));
   }
 
   @Test
@@ -298,14 +299,14 @@ public class TestReadWrite {
     assertEquals(3.1f, nextRecord.get("myfloat"));
     assertEquals(4.1, nextRecord.get("mydouble"));
     assertEquals(ByteBuffer.wrap("hello".getBytes(Charsets.UTF_8)), nextRecord.get("mybytes"));
-    assertEquals("hello", nextRecord.get("mystring"));
+    assertEquals(str("hello"), nextRecord.get("mystring"));
     assertEquals(expectedEnumSymbol, nextRecord.get("myenum"));
     assertEquals(nestedRecord, nextRecord.get("mynestedrecord"));
     assertEquals(integerArray, nextRecord.get("myarray"));
     assertEquals(emptyArray, nextRecord.get("myemptyarray"));
     assertEquals(integerArray, nextRecord.get("myoptionalarray"));
     assertEquals(genericIntegerArrayWithNulls, nextRecord.get("myarrayofoptional"));
-    assertEquals(ImmutableMap.of("a", 1, "b", 2), nextRecord.get("mymap"));
+    assertEquals(ImmutableMap.of(str("a"), 1, str("b"), 2), nextRecord.get("mymap"));
     assertEquals(emptyMap, nextRecord.get("myemptymap"));
     assertEquals(genericFixed, nextRecord.get("myfixed"));
   }
@@ -517,16 +518,22 @@ public class TestReadWrite {
     assertEquals(3.1f, nextRecord.get("myfloat"));
     assertEquals(4.1, nextRecord.get("mydouble"));
     assertEquals(ByteBuffer.wrap("hello".getBytes(Charsets.UTF_8)), nextRecord.get("mybytes"));
-    assertEquals("hello", nextRecord.get("mystring"));
-    assertEquals("a", nextRecord.get("myenum"));
+    assertEquals(str("hello"), nextRecord.get("mystring"));
+    assertEquals(str("a"), nextRecord.get("myenum")); // enum symbols are unknown
     assertEquals(nestedRecord, nextRecord.get("mynestedrecord"));
     assertEquals(integerArray, nextRecord.get("myarray"));
     assertEquals(integerArray, nextRecord.get("myoptionalarray"));
     assertEquals(ingeterArrayWithNulls, nextRecord.get("myarrayofoptional"));
     assertEquals(genericRecordArray, nextRecord.get("myrecordarray"));
-    assertEquals(ImmutableMap.of("a", 1, "b", 2), nextRecord.get("mymap"));
+    assertEquals(ImmutableMap.of(str("a"), 1, str("b"), 2), nextRecord.get("mymap"));
     assertEquals(genericFixed, nextRecord.get("myfixed"));
 
   }
 
+  /**
+   * Return a String or Utf8 depending on whether compatibility is on
+   */
+  public CharSequence str(String value) {
+    return compat ? value : new Utf8(value);
+  }
 }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWriteOldListBehavior.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWriteOldListBehavior.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
-public class TestReadWriteOldBehavior {
+public class TestReadWriteOldListBehavior {
 
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
@@ -71,7 +71,7 @@ public class TestReadWriteOldBehavior {
   private final boolean compat;
   private final Configuration testConf = new Configuration(false);
 
-  public TestReadWriteOldBehavior(boolean compat) {
+  public TestReadWriteOldListBehavior(boolean compat) {
     this.compat = compat;
     this.testConf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, compat);
   }
@@ -144,10 +144,10 @@ public class TestReadWriteOldBehavior {
         new AvroParquetWriter<GenericRecord>(file, schema);
 
     // Write a record with a null value
-    Map<String, Integer> map = new HashMap<String, Integer>();
-    map.put("thirty-four", 34);
-    map.put("eleventy-one", null);
-    map.put("one-hundred", 100);
+    Map<CharSequence, Integer> map = new HashMap<CharSequence, Integer>();
+    map.put(str("thirty-four"), 34);
+    map.put(str("eleventy-one"), null);
+    map.put(str("one-hundred"), 100);
 
     GenericData.Record record = new GenericRecordBuilder(schema)
         .set("mymap", map).build();
@@ -210,7 +210,7 @@ public class TestReadWriteOldBehavior {
     GenericRecord nextRecord = reader.read();
 
     assertNotNull(nextRecord);
-    assertEquals(ImmutableMap.of("a", 1, "b", 2), nextRecord.get("mymap"));
+    assertEquals(ImmutableMap.of(str("a"), 1, str("b"), 2), nextRecord.get("mymap"));
   }
 
   @Test
@@ -277,14 +277,14 @@ public class TestReadWriteOldBehavior {
     assertEquals(3.1f, nextRecord.get("myfloat"));
     assertEquals(4.1, nextRecord.get("mydouble"));
     assertEquals(ByteBuffer.wrap("hello".getBytes(Charsets.UTF_8)), nextRecord.get("mybytes"));
-    assertEquals("hello", nextRecord.get("mystring"));
+    assertEquals(str("hello"), nextRecord.get("mystring"));
     assertEquals(expectedEnumSymbol, nextRecord.get("myenum"));
     assertEquals(nestedRecord, nextRecord.get("mynestedrecord"));
     assertEquals(integerArray, nextRecord.get("myarray"));
     assertEquals(emptyArray, nextRecord.get("myemptyarray"));
     assertEquals(integerArray, nextRecord.get("myoptionalarray"));
     assertEquals(integerArray, nextRecord.get("myarrayofoptional"));
-    assertEquals(ImmutableMap.of("a", 1, "b", 2), nextRecord.get("mymap"));
+    assertEquals(ImmutableMap.of(str("a"), 1, str("b"), 2), nextRecord.get("mymap"));
     assertEquals(emptyMap, nextRecord.get("myemptymap"));
     assertEquals(genericFixed, nextRecord.get("myfixed"));
   }
@@ -573,16 +573,22 @@ public class TestReadWriteOldBehavior {
     assertEquals(3.1f, nextRecord.get("myfloat"));
     assertEquals(4.1, nextRecord.get("mydouble"));
     assertEquals(ByteBuffer.wrap("hello".getBytes(Charsets.UTF_8)), nextRecord.get("mybytes"));
-    assertEquals("hello", nextRecord.get("mystring"));
-    assertEquals("a", nextRecord.get("myenum"));
+    assertEquals(str("hello"), nextRecord.get("mystring"));
+    assertEquals(str("a"), nextRecord.get("myenum"));
     assertEquals(nestedRecord, nextRecord.get("mynestedrecord"));
     assertEquals(integerArray, nextRecord.get("myarray"));
     assertEquals(integerArray, nextRecord.get("myoptionalarray"));
     assertEquals(genericRecordArrayWithNullIntegers, nextRecord.get("myarrayofoptional"));
     assertEquals(genericRecordArray, nextRecord.get("myrecordarray"));
-    assertEquals(ImmutableMap.of("a", 1, "b", 2), nextRecord.get("mymap"));
+    assertEquals(ImmutableMap.of(str("a"), 1, str("b"), 2), nextRecord.get("mymap"));
     assertEquals(genericFixed, nextRecord.get("myfixed"));
 
   }
 
+  /**
+   * Return a String or Utf8 depending on whether compatibility is on
+   */
+  public CharSequence str(String value) {
+    return compat ? value : new Utf8(value);
+  }
 }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectReadWrite.java
@@ -30,6 +30,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.util.Utf8;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
@@ -65,14 +66,14 @@ public class TestReflectReadWrite {
 
     Path path = writePojosToParquetFile(2, CompressionCodecName.UNCOMPRESSED, false);
     ParquetReader<GenericRecord> reader = new AvroParquetReader<GenericRecord>(conf, path);
-    GenericRecord object = getGenericPojo();
+    GenericRecord object = getGenericPojoUtf8();
     for (int i = 0; i < 2; i += 1) {
       assertEquals(object, reader.read());
     }
     assertNull(reader.read());
   }
 
-  private GenericRecord getGenericPojo() {
+  private GenericRecord getGenericPojoUtf8() {
     Schema schema = ReflectData.get().getSchema(Pojo.class);
     GenericData.Record record = new GenericData.Record(schema);
     record.put("myboolean", true);
@@ -83,21 +84,21 @@ public class TestReflectReadWrite {
     record.put("myfloat", 3.1f);
     record.put("mydouble", 4.1);
     record.put("mybytes", ByteBuffer.wrap(new byte[] { 1, 2, 3, 4 }));
-    record.put("mystring", "Hello");
+    record.put("mystring", new Utf8("Hello"));
     record.put("myenum", new GenericData.EnumSymbol(
         schema.getField("myenum").schema(), "A"));
-    Map<String, String> map = new HashMap<String, String>();
-    map.put("a", "1");
-    map.put("b", "2");
+    Map<CharSequence, CharSequence> map = new HashMap<CharSequence, CharSequence>();
+    map.put(new Utf8("a"), new Utf8("1"));
+    map.put(new Utf8("b"), new Utf8("2"));
     record.put("mymap", map);
     record.put("myshortarray", new GenericData.Array<Integer>(
         schema.getField("myshortarray").schema(), Lists.newArrayList(1, 2)));
     record.put("myintarray", new GenericData.Array<Integer>(
         schema.getField("myintarray").schema(), Lists.newArrayList(1, 2)));
-    record.put("mystringarray", new GenericData.Array<String>(
-        schema.getField("mystringarray").schema(), Lists.newArrayList("a", "b")));
-    record.put("mylist", new GenericData.Array<String>(
-        schema.getField("mylist").schema(), Lists.newArrayList("a", "b", "c")));
+    record.put("mystringarray", new GenericData.Array<Utf8>(
+        schema.getField("mystringarray").schema(), Lists.newArrayList(new Utf8("a"), new Utf8("b"))));
+    record.put("mylist", new GenericData.Array<Utf8>(
+        schema.getField("mylist").schema(), Lists.newArrayList(new Utf8("a"), new Utf8("b"), new Utf8("c"))));
     return record;
   }
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestStringBehavior.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestStringBehavior.java
@@ -1,0 +1,363 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.avro;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.io.Resources;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.reflect.AvroSchema;
+import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.reflect.ReflectDatumReader;
+import org.apache.avro.reflect.Stringable;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.util.Utf8;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Map;
+
+public class TestStringBehavior {
+  public static Schema SCHEMA = null;
+  public static BigDecimal BIG_DECIMAL = new BigDecimal("3.14");
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  public Path parquetFile;
+  public File avroFile;
+
+  @BeforeClass
+  public static void readSchemaFile() throws IOException {
+    TestStringBehavior.SCHEMA = new Schema.Parser().parse(
+        Resources.getResource("stringBehavior.avsc").openStream());
+  }
+
+  @Before
+  public void writeDataFiles() throws IOException {
+    // convert BIG_DECIMAL to string by hand so generic can write it
+    GenericRecord record = new GenericRecordBuilder(SCHEMA)
+        .set("default_class", "default")
+        .set("string_class", "string")
+        .set("stringable_class", BIG_DECIMAL.toString())
+        .set("default_map", ImmutableMap.of("default_key", 34))
+        .set("string_map", ImmutableMap.of("string_key", 35))
+        .set("stringable_map", ImmutableMap.of(BIG_DECIMAL.toString(), 36))
+        .build();
+
+    File file = temp.newFile("parquet");
+    file.delete();
+    file.deleteOnExit();
+
+    parquetFile = new Path(file.getPath());
+    ParquetWriter<GenericRecord> parquet = AvroParquetWriter
+        .<GenericRecord>builder(parquetFile)
+        .withDataModel(GenericData.get())
+        .withSchema(SCHEMA)
+        .build();
+
+    try {
+      parquet.write(record);
+    } finally {
+      parquet.close();
+    }
+
+    avroFile = temp.newFile("avro");
+    avroFile.delete();
+    avroFile.deleteOnExit();
+    DataFileWriter<GenericRecord> avro = new DataFileWriter<GenericRecord>(
+        new GenericDatumWriter<GenericRecord>(SCHEMA)).create(SCHEMA, avroFile);
+
+    try {
+      avro.append(record);
+    } finally {
+      avro.close();
+    }
+  }
+
+  @Test
+  public void testGeneric() throws IOException {
+    GenericRecord avroRecord;
+    DataFileReader<GenericRecord> avro = new DataFileReader<GenericRecord>(
+        avroFile, new GenericDatumReader<GenericRecord>(SCHEMA));
+    try {
+      avroRecord = avro.next();
+    } finally {
+      avro.close();
+    }
+
+    GenericRecord parquetRecord;
+    Configuration conf = new Configuration();
+    conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, false);
+    AvroReadSupport.setAvroDataSupplier(conf, GenericDataSupplier.class);
+    AvroReadSupport.setAvroReadSchema(conf, SCHEMA);
+    ParquetReader<GenericRecord> parquet = AvroParquetReader
+        .<GenericRecord>builder(parquetFile)
+        .withConf(conf)
+        .build();
+    try {
+      parquetRecord = parquet.read();
+    } finally {
+      parquet.close();
+    }
+
+    Assert.assertEquals("Avro default string class should be Utf8",
+        Utf8.class, avroRecord.get("default_class").getClass());
+    Assert.assertEquals("Parquet default string class should be Utf8",
+        Utf8.class, parquetRecord.get("default_class").getClass());
+
+    Assert.assertEquals("Avro avro.java.string=String class should be String",
+        String.class, avroRecord.get("string_class").getClass());
+    Assert.assertEquals("Parquet avro.java.string=String class should be String",
+        String.class, parquetRecord.get("string_class").getClass());
+
+    Assert.assertEquals("Avro stringable class should be Utf8",
+        Utf8.class, avroRecord.get("stringable_class").getClass());
+    Assert.assertEquals("Parquet stringable class should be Utf8",
+        Utf8.class, parquetRecord.get("stringable_class").getClass());
+
+    Assert.assertEquals("Avro map default string class should be Utf8",
+        Utf8.class, keyClass(avroRecord.get("default_map")));
+    Assert.assertEquals("Parquet map default string class should be Utf8",
+        Utf8.class, keyClass(parquetRecord.get("default_map")));
+
+    Assert.assertEquals("Avro map avro.java.string=String class should be String",
+        String.class, keyClass(avroRecord.get("string_map")));
+    Assert.assertEquals("Parquet map avro.java.string=String class should be String",
+        String.class, keyClass(parquetRecord.get("string_map")));
+
+    Assert.assertEquals("Avro map stringable class should be Utf8",
+        Utf8.class, keyClass(avroRecord.get("stringable_map")));
+    Assert.assertEquals("Parquet map stringable class should be Utf8",
+        Utf8.class, keyClass(parquetRecord.get("stringable_map")));
+  }
+
+
+  @Test
+  public void testSpecific() throws IOException {
+    org.apache.parquet.avro.StringBehaviorTest avroRecord;
+    DataFileReader<org.apache.parquet.avro.StringBehaviorTest> avro =
+        new DataFileReader<org.apache.parquet.avro.StringBehaviorTest>(avroFile,
+            new SpecificDatumReader<org.apache.parquet.avro.StringBehaviorTest>(
+                org.apache.parquet.avro.StringBehaviorTest.getClassSchema()));
+    try {
+      avroRecord = avro.next();
+    } finally {
+      avro.close();
+    }
+
+    org.apache.parquet.avro.StringBehaviorTest parquetRecord;
+    Configuration conf = new Configuration();
+    conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, false);
+    AvroReadSupport.setAvroDataSupplier(conf, SpecificDataSupplier.class);
+    AvroReadSupport.setAvroReadSchema(conf,
+        org.apache.parquet.avro.StringBehaviorTest.getClassSchema());
+    ParquetReader<org.apache.parquet.avro.StringBehaviorTest> parquet =
+        AvroParquetReader
+            .<org.apache.parquet.avro.StringBehaviorTest>builder(parquetFile)
+            .withConf(conf)
+            .build();
+    try {
+      parquetRecord = parquet.read();
+    } finally {
+      parquet.close();
+    }
+
+    Assert.assertEquals("Avro default string class should be String",
+        Utf8.class, avroRecord.default_class.getClass());
+    Assert.assertEquals("Parquet default string class should be String",
+        Utf8.class, parquetRecord.default_class.getClass());
+
+    Assert.assertEquals("Avro avro.java.string=String class should be String",
+        String.class, avroRecord.string_class.getClass());
+    Assert.assertEquals("Parquet avro.java.string=String class should be String",
+        String.class, parquetRecord.string_class.getClass());
+
+    Assert.assertEquals("Avro stringable class should be BigDecimal",
+        BigDecimal.class, avroRecord.stringable_class.getClass());
+    Assert.assertEquals("Parquet stringable class should be BigDecimal",
+        BigDecimal.class, parquetRecord.stringable_class.getClass());
+    Assert.assertEquals("Should have the correct BigDecimal value",
+        BIG_DECIMAL, parquetRecord.stringable_class);
+
+    Assert.assertEquals("Avro map default string class should be String",
+        Utf8.class, keyClass(avroRecord.default_map));
+    Assert.assertEquals("Parquet map default string class should be String",
+        Utf8.class, keyClass(parquetRecord.default_map));
+
+    Assert.assertEquals("Avro map avro.java.string=String class should be String",
+        String.class, keyClass(avroRecord.string_map));
+    Assert.assertEquals("Parquet map avro.java.string=String class should be String",
+        String.class, keyClass(parquetRecord.string_map));
+
+    Assert.assertEquals("Avro map stringable class should be BigDecimal",
+        BigDecimal.class, keyClass(avroRecord.stringable_map));
+    Assert.assertEquals("Parquet map stringable class should be BigDecimal",
+        BigDecimal.class, keyClass(parquetRecord.stringable_map));
+  }
+
+  @Test
+  public void testReflect() throws IOException {
+    Schema reflectSchema = ReflectData.get()
+        .getSchema(ReflectRecord.class);
+
+    ReflectRecord avroRecord;
+    DataFileReader<ReflectRecord> avro = new DataFileReader<ReflectRecord>(
+        avroFile, new ReflectDatumReader<ReflectRecord>(reflectSchema));
+    try {
+      avroRecord = avro.next();
+    } finally {
+      avro.close();
+    }
+
+    ReflectRecord parquetRecord;
+    Configuration conf = new Configuration();
+    conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, false);
+    AvroReadSupport.setAvroDataSupplier(conf, ReflectDataSupplier.class);
+    AvroReadSupport.setAvroReadSchema(conf, reflectSchema);
+    ParquetReader<ReflectRecord> parquet = AvroParquetReader
+        .<ReflectRecord>builder(parquetFile)
+        .withConf(conf)
+        .build();
+    try {
+      parquetRecord = parquet.read();
+    } finally {
+      parquet.close();
+    }
+
+    Assert.assertEquals("Avro default string class should be String",
+        String.class, avroRecord.default_class.getClass());
+    Assert.assertEquals("Parquet default string class should be String",
+        String.class, parquetRecord.default_class.getClass());
+
+    Assert.assertEquals("Avro avro.java.string=String class should be String",
+        String.class, avroRecord.string_class.getClass());
+    Assert.assertEquals("Parquet avro.java.string=String class should be String",
+        String.class, parquetRecord.string_class.getClass());
+
+    Assert.assertEquals("Avro stringable class should be BigDecimal",
+        BigDecimal.class, avroRecord.stringable_class.getClass());
+    Assert.assertEquals("Parquet stringable class should be BigDecimal",
+        BigDecimal.class, parquetRecord.stringable_class.getClass());
+    Assert.assertEquals("Should have the correct BigDecimal value",
+        BIG_DECIMAL, parquetRecord.stringable_class);
+
+    Assert.assertEquals("Avro map default string class should be String",
+        String.class, keyClass(avroRecord.default_map));
+    Assert.assertEquals("Parquet map default string class should be String",
+        String.class, keyClass(parquetRecord.default_map));
+
+    Assert.assertEquals("Avro map avro.java.string=String class should be String",
+        String.class, keyClass(avroRecord.string_map));
+    Assert.assertEquals("Parquet map avro.java.string=String class should be String",
+        String.class, keyClass(parquetRecord.string_map));
+
+    Assert.assertEquals("Avro map stringable class should be BigDecimal",
+        BigDecimal.class, keyClass(avroRecord.stringable_map));
+    Assert.assertEquals("Parquet map stringable class should be BigDecimal",
+        BigDecimal.class, keyClass(parquetRecord.stringable_map));
+  }
+
+  @Test
+  public void testReflectJavaClass() throws IOException {
+    Schema reflectSchema = ReflectData.get()
+        .getSchema(ReflectRecordJavaClass.class);
+    System.err.println("Schema: " + reflectSchema.toString(true));
+    ReflectRecordJavaClass avroRecord;
+    DataFileReader<ReflectRecordJavaClass> avro =
+        new DataFileReader<ReflectRecordJavaClass>(avroFile,
+            new ReflectDatumReader<ReflectRecordJavaClass>(reflectSchema));
+    try {
+      avroRecord = avro.next();
+    } finally {
+      avro.close();
+    }
+
+    ReflectRecordJavaClass parquetRecord;
+    Configuration conf = new Configuration();
+    conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, false);
+    AvroReadSupport.setAvroDataSupplier(conf, ReflectDataSupplier.class);
+    AvroReadSupport.setAvroReadSchema(conf, reflectSchema);
+    AvroReadSupport.setRequestedProjection(conf, reflectSchema);
+    ParquetReader<ReflectRecordJavaClass> parquet = AvroParquetReader
+        .<ReflectRecordJavaClass>builder(parquetFile)
+        .withConf(conf)
+        .build();
+    try {
+      parquetRecord = parquet.read();
+    } finally {
+      parquet.close();
+    }
+
+    // Avro uses String even if CharSequence is set
+    Assert.assertEquals("Avro default string class should be String",
+        String.class, avroRecord.default_class.getClass());
+    Assert.assertEquals("Parquet default string class should be String",
+        String.class, parquetRecord.default_class.getClass());
+
+    Assert.assertEquals("Avro stringable class should be BigDecimal",
+        BigDecimal.class, avroRecord.stringable_class.getClass());
+    Assert.assertEquals("Parquet stringable class should be BigDecimal",
+        BigDecimal.class, parquetRecord.stringable_class.getClass());
+    Assert.assertEquals("Should have the correct BigDecimal value",
+        BIG_DECIMAL, parquetRecord.stringable_class);
+  }
+
+  public static class ReflectRecord {
+    private String default_class;
+    private String string_class;
+    @Stringable
+    private BigDecimal stringable_class;
+    private Map<String, Integer> default_map;
+    private Map<String, Integer> string_map;
+    private Map<BigDecimal, Integer> stringable_map;
+  }
+
+  public static class ReflectRecordJavaClass {
+    // test avro.java.string behavior
+    @AvroSchema("{\"type\": \"string\", \"avro.java.string\": \"CharSequence\"}")
+    private String default_class;
+    // test using java-class property instead of Stringable
+    @AvroSchema("{\"type\": \"string\", \"java-class\": \"java.math.BigDecimal\"}")
+    private BigDecimal stringable_class;
+  }
+
+  public static Class<?> keyClass(Object obj) {
+    Assert.assertTrue("Should be a map", obj instanceof Map);
+    Map<?, ?> map = (Map<?, ?>) obj;
+    return Iterables.getFirst(map.keySet(), null).getClass();
+  }
+}


### PR DESCRIPTION
This adds getStringableClass, which determines what String
representation upstream Avro would use. Specific and reflect will use an
alternative String class if java-class is set that is instantiated using
a constructor that takes a String. Otherwise, reflect will always use
String and both specific and generic will use Utf8 or String depending
on whether avro.java.string is set to "string".

The new string representations required two new converters: one for Utf8
and one for stringable classes (those with constructors that take a
single String). The converters have also been refactored so that all
binary converters now implement dictionary support.