### PR TITLE
PARQUET-151: Skip writing _metadata file in case of no footers since schema cannot be determined.

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputCommitter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputCommitter.java
@@ -54,6 +54,11 @@ public class ParquetOutputCommitter extends FileOutputCommitter {
         final FileSystem fileSystem = outputPath.getFileSystem(configuration);
         FileStatus outputStatus = fileSystem.getFileStatus(outputPath);
         List<Footer> footers = ParquetFileReader.readAllFootersInParallel(configuration, outputStatus);
+        // If there are no footers, _metadata file cannot be written since there is no way to determine schema!
+        // Onus of writing any summary files lies with the caller in this case.
+        if (footers.isEmpty()) {
+          return;
+        }
         try {
           ParquetFileWriter.writeMetadataFile(configuration, outputPath, footers);
         } catch (Exception e) {


### PR DESCRIPTION
This fixes npe seen during mergeFooters in such a case.
 For this scenario onus of writing any summary files lies with the caller (It might have some global schema available) So for example spark does it when persisting empty RDD.