### PR TITLE
PARQUET-304: Add an option to make requested schema case insensitive in read path

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/schema/MessageType.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/MessageType.java
@@ -50,6 +50,13 @@ public final class MessageType extends GroupType {
    super(Repetition.REPEATED, name, fields);
  }
 
+ public MessageType(String name, List<Type> fields, boolean isCaseSensitive) {
+     super(Repetition.REPEATED, name, fields, isCaseSensitive);
+ }
+
+ public MessageType(MessageType base, boolean isCaseSensitive) {
+     super(Repetition.REPEATED, base.getName(), base.getFields(), isCaseSensitive);
+ }
   /**
    * {@inheritDoc}
    */

--- a/parquet-common/src/main/java/org/apache/parquet/hadoop/metadata/ColumnPath.java
+++ b/parquet-common/src/main/java/org/apache/parquet/hadoop/metadata/ColumnPath.java
@@ -39,6 +39,17 @@ public final class ColumnPath implements Iterable<String>, Serializable {
     }
   };
 
+  private static Canonicalizer<ColumnPath> pathsLowerCase = new Canonicalizer<ColumnPath>() {
+    @Override
+    protected ColumnPath toCanonical(ColumnPath value) {
+      String[] path = new String[value.p.length];
+      for (int i = 0; i < value.p.length; i++) {
+        path[i] = value.p[i].toLowerCase().intern();
+      }
+      return new ColumnPath(path);
+    }
+  };
+
   public static ColumnPath fromDotString(String path) {
     checkNotNull(path, "path");
     return get(path.split("\\."));
@@ -46,6 +57,10 @@ public final class ColumnPath implements Iterable<String>, Serializable {
 
   public static ColumnPath get(String... path){
     return paths.canonicalize(new ColumnPath(path));
+  }
+
+  public static ColumnPath getLowerCase(String... path){
+    return pathsLowerCase.canonicalize(new ColumnPath(path));
   }
 
   private final String[] p;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/compat/RowGroupFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/compat/RowGroupFilter.java
@@ -40,15 +40,26 @@ import static org.apache.parquet.Preconditions.checkNotNull;
 public class RowGroupFilter implements Visitor<List<BlockMetaData>> {
   private final List<BlockMetaData> blocks;
   private final MessageType schema;
+  private final boolean isCaseSensitive;
 
   public static List<BlockMetaData> filterRowGroups(Filter filter, List<BlockMetaData> blocks, MessageType schema) {
+   return filterRowGroups(filter, blocks, schema, true);
+  }
+
+  public static List<BlockMetaData> filterRowGroups(Filter filter, List<BlockMetaData> blocks, MessageType schema,
+                                                    boolean isCaseSensitive) {
     checkNotNull(filter, "filter");
-    return filter.accept(new RowGroupFilter(blocks, schema));
+    return filter.accept(new RowGroupFilter(blocks, schema, isCaseSensitive));
   }
 
   private RowGroupFilter(List<BlockMetaData> blocks, MessageType schema) {
+   this(blocks, schema, true);
+  }
+
+  private RowGroupFilter(List<BlockMetaData> blocks, MessageType schema, boolean isCaseSensitive) {
     this.blocks = checkNotNull(blocks, "blocks");
     this.schema = checkNotNull(schema, "schema");
+    this.isCaseSensitive = isCaseSensitive;
   }
 
   @Override
@@ -56,7 +67,7 @@ public class RowGroupFilter implements Visitor<List<BlockMetaData>> {
     FilterPredicate filterPredicate = filterPredicateCompat.getFilterPredicate();
 
     // check that the schema of the filter matches the schema of the file
-    SchemaCompatibilityValidator.validate(filterPredicate, schema);
+    SchemaCompatibilityValidator.validate(filterPredicate, schema, isCaseSensitive);
 
     List<BlockMetaData> filteredBlocks = new ArrayList<BlockMetaData>();
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -114,6 +114,11 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
   public static final String FILTER_PREDICATE = "parquet.private.read.filter.predicate";
 
   /**
+   * key to configure case sensitivity
+   */
+  public static final String CASE_SENSITIVITY = "parquet.read.case.sensitivity";
+
+  /**
    * key to turn on or off task side metadata loading (default true)
    * if true then metadata is read on the task side and some tasks may finish immediately.
    * if false metadata is read on the client which is slower if there is a lot of metadata but tasks will only be spawn if there is work to do.
@@ -126,8 +131,16 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
     ContextUtil.getConfiguration(job).setBoolean(TASK_SIDE_METADATA, taskSideMetadata);
   }
 
+  public static void setCaseSensitiveRead(Job job, boolean isCaseSensitive) {
+    ContextUtil.getConfiguration(job).setBoolean(CASE_SENSITIVITY, isCaseSensitive);
+  }
+
   public static boolean isTaskSideMetaData(Configuration configuration) {
     return configuration.getBoolean(TASK_SIDE_METADATA, TRUE);
+  }
+
+  public static boolean isCaseSensitiveRead(Configuration configuration) {
+    return configuration.getBoolean(CASE_SENSITIVITY, TRUE);
   }
 
   public static void setReadSupportClass(Job job,  Class<?> readSupportClass) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetReader.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.hadoop;
 
+import static java.lang.Boolean.TRUE;
 import static org.apache.parquet.Preconditions.checkNotNull;
 
 import java.io.Closeable;
@@ -144,8 +145,9 @@ public class ParquetReader<T> implements Closeable {
 
       MessageType fileSchema = footer.getParquetMetadata().getFileMetaData().getSchema();
 
+      boolean isCaseSensitive = conf.getBoolean(ParquetInputFormat.CASE_SENSITIVITY, TRUE);
       List<BlockMetaData> filteredBlocks = RowGroupFilter.filterRowGroups(
-          filter, blocks, fileSchema);
+          filter, blocks, fileSchema, isCaseSensitive);
 
       reader = new InternalParquetRecordReader<T>(readSupport, filter);
       reader.initialize(fileSchema,


### PR DESCRIPTION
For projects such as hive and spark-sql which use parquet, the schema of the stored tables is always lowercase (because of limitations of hive metastore). It would be great if we can have a configurable option to read data from parquet irrespective of the case of the requested schema , supplied via ReadContext object.

This PR adds configurable option of ParquetInputFormat.CASE_SENSITIVITY which can be set to false. In that case, parquet will resolve requested columns irrespective of case. This alleviates projects like spark-sql to read footers at the driver side and reconcile schema (to be read from footers) with metastore schema before calling parquet read.