### PR TITLE
PARQUET-306: Add row group alignment

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -41,6 +41,7 @@ import org.apache.parquet.Version;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
@@ -69,6 +70,20 @@ public class ParquetFileWriter {
   public static final byte[] MAGIC = "PAR1".getBytes(Charset.forName("ASCII"));
   public static final int CURRENT_VERSION = 1;
 
+  // need to supply a buffer size when setting block size. this is the default
+  // for hadoop 1 to present. copying it avoids loading DFSConfigKeys.
+  private static final int DFS_BUFFER_SIZE_DEFAULT = 4096;
+
+  // visible for testing
+  static final Set<String> BLOCK_FS_SCHEMES = new HashSet<String>();
+  static {
+    BLOCK_FS_SCHEMES.add("hdfs");
+  }
+
+  private static boolean supportsBlockSize(FileSystem fs) {
+    return BLOCK_FS_SCHEMES.contains(fs.getUri().getScheme());
+  }
+
   // File creation modes
   public static enum Mode {
     CREATE,
@@ -79,13 +94,13 @@ public class ParquetFileWriter {
 
   private final MessageType schema;
   private final FSDataOutputStream out;
+  private final AlignmentStrategy alignment;
   private BlockMetaData currentBlock;
-  private ColumnChunkMetaData currentColumn;
   private long currentRecordCount;
   private List<BlockMetaData> blocks = new ArrayList<BlockMetaData>();
   private long uncompressedLength;
   private long compressedLength;
-  private Set<org.apache.parquet.column.Encoding> currentEncodings;
+  private Set<Encoding> currentEncodings;
 
   private CompressionCodecName currentChunkCodec;
   private ColumnPath currentChunkPath;
@@ -157,7 +172,7 @@ public class ParquetFileWriter {
    */
   public ParquetFileWriter(Configuration configuration, MessageType schema,
       Path file) throws IOException {
-    this(configuration, schema, file, Mode.CREATE);
+    this(configuration, schema, file, Mode.CREATE, ParquetWriter.DEFAULT_BLOCK_SIZE);
   }
 
   /**
@@ -168,12 +183,55 @@ public class ParquetFileWriter {
    * @throws IOException if the file can not be created
    */
   public ParquetFileWriter(Configuration configuration, MessageType schema,
-      Path file, Mode mode) throws IOException {
-    super();
+                           Path file, Mode mode) throws IOException {
+    this(configuration, schema, file, mode, ParquetWriter.DEFAULT_BLOCK_SIZE);
+  }
+
+  /**
+   * @param configuration Hadoop configuration
+   * @param schema the schema of the data
+   * @param file the file to write to
+   * @param mode file creation mode
+   * @param rowGroupSize the row group size
+   * @throws IOException if the file can not be created
+   */
+  public ParquetFileWriter(Configuration configuration, MessageType schema,
+      Path file, Mode mode, long rowGroupSize) throws IOException {
     this.schema = schema;
     FileSystem fs = file.getFileSystem(configuration);
     boolean overwriteFlag = (mode == Mode.OVERWRITE);
-    this.out = fs.create(file, overwriteFlag);
+
+    if (supportsBlockSize(fs)) {
+      // use the default block size, unless row group size is larger
+      long dfsBlockSize = Math.max(fs.getDefaultBlockSize(file), rowGroupSize);
+
+      this.alignment = PaddingAlignment.get(dfsBlockSize, rowGroupSize);
+      this.out = fs.create(file, overwriteFlag, DFS_BUFFER_SIZE_DEFAULT,
+          fs.getDefaultReplication(file), dfsBlockSize);
+
+    } else {
+      this.alignment = NoAlignment.get(rowGroupSize);
+      this.out = fs.create(file, overwriteFlag);
+    }
+  }
+
+  /**
+   * FOR TESTING ONLY.
+   *
+   * @param configuration Hadoop configuration
+   * @param schema the schema of the data
+   * @param file the file to write to
+   * @param rowAndBlockSize the row group size
+   * @throws IOException if the file can not be created
+   */
+  ParquetFileWriter(Configuration configuration, MessageType schema,
+                    Path file, long rowAndBlockSize)
+      throws IOException {
+    FileSystem fs = file.getFileSystem(configuration);
+    this.schema = schema;
+    this.alignment = PaddingAlignment.get(rowAndBlockSize, rowAndBlockSize);
+    this.out = fs.create(file, true, DFS_BUFFER_SIZE_DEFAULT,
+        fs.getDefaultReplication(file), rowAndBlockSize);
   }
 
   /**
@@ -195,6 +253,9 @@ public class ParquetFileWriter {
     state = state.startBlock();
     if (DEBUG) LOG.debug(out.getPos() + ": start block");
 //    out.write(MAGIC); // TODO: add a magic delimiter
+
+    alignment.alignForRowGroup(out);
+
     currentBlock = new BlockMetaData();
     currentRecordCount = recordCount;
   }
@@ -211,8 +272,7 @@ public class ParquetFileWriter {
                           long valueCount,
                           CompressionCodecName compressionCodecName) throws IOException {
     state = state.startColumn();
-    if (DEBUG) LOG.debug(out.getPos() + ": start column: " + descriptor + " count=" + valueCount);
-    currentEncodings = new HashSet<org.apache.parquet.column.Encoding>();
+    currentEncodings = new HashSet<Encoding>();
     currentChunkPath = ColumnPath.get(descriptor.getPath());
     currentChunkType = descriptor.getType();
     currentChunkCodec = compressionCodecName;
@@ -263,9 +323,9 @@ public class ParquetFileWriter {
   public void writeDataPage(
       int valueCount, int uncompressedPageSize,
       BytesInput bytes,
-      org.apache.parquet.column.Encoding rlEncoding,
-      org.apache.parquet.column.Encoding dlEncoding,
-      org.apache.parquet.column.Encoding valuesEncoding) throws IOException {
+      Encoding rlEncoding,
+      Encoding dlEncoding,
+      Encoding valuesEncoding) throws IOException {
     state = state.write();
     long beforeHeader = out.getPos();
     if (DEBUG) LOG.debug(beforeHeader + ": write data page: " + valueCount + " values");
@@ -300,9 +360,9 @@ public class ParquetFileWriter {
       int valueCount, int uncompressedPageSize,
       BytesInput bytes,
       Statistics statistics,
-      org.apache.parquet.column.Encoding rlEncoding,
-      org.apache.parquet.column.Encoding dlEncoding,
-      org.apache.parquet.column.Encoding valuesEncoding) throws IOException {
+      Encoding rlEncoding,
+      Encoding dlEncoding,
+      Encoding valuesEncoding) throws IOException {
     state = state.write();
     long beforeHeader = out.getPos();
     if (DEBUG) LOG.debug(beforeHeader + ": write data page: " + valueCount + " values");
@@ -337,7 +397,7 @@ public class ParquetFileWriter {
                        long uncompressedTotalPageSize,
                        long compressedTotalPageSize,
                        Statistics totalStats,
-                       List<org.apache.parquet.column.Encoding> encodings) throws IOException {
+                       List<Encoding> encodings) throws IOException {
     state = state.write();
     if (DEBUG) LOG.debug(out.getPos() + ": write data pages");
     long headersSize = bytes.size() - compressedTotalPageSize;
@@ -367,8 +427,6 @@ public class ParquetFileWriter {
         currentChunkValueCount,
         compressedLength,
         uncompressedLength));
-    if (DEBUG) LOG.info("ended Column chumk: " + currentColumn);
-    currentColumn = null;
     this.currentBlock.setTotalByteSize(currentBlock.getTotalByteSize() + uncompressedLength);
     this.uncompressedLength = 0;
     this.compressedLength = 0;
@@ -464,6 +522,10 @@ public class ParquetFileWriter {
     return out.getPos();
   }
 
+  public long getNextRowGroupSize() throws IOException {
+    return alignment.nextRowGroupSize(out);
+  }
+
   /**
    * Will merge the metadata of all the footers together
    * @param footers the list files footers to merge
@@ -550,4 +612,79 @@ public class ParquetFileWriter {
     return mergedSchema.union(toMerge, strict);
   }
 
+  private interface AlignmentStrategy {
+    void alignForRowGroup(FSDataOutputStream out) throws IOException;
+
+    long nextRowGroupSize(FSDataOutputStream out) throws IOException;
+  }
+
+  private static class NoAlignment implements AlignmentStrategy {
+    public static NoAlignment get(long rowGroupSize) {
+      return new NoAlignment(rowGroupSize);
+    }
+
+    private final long rowGroupSize;
+
+    private NoAlignment(long rowGroupSize) {
+      this.rowGroupSize = rowGroupSize;
+    }
+
+    @Override
+    public void alignForRowGroup(FSDataOutputStream out) {
+    }
+
+    @Override
+    public long nextRowGroupSize(FSDataOutputStream out) {
+      return rowGroupSize;
+    }
+  }
+
+  /**
+   * Alignment strategy that pads when less than half the row group size is
+   * left before the next DFS block.
+   */
+  private static class PaddingAlignment implements AlignmentStrategy {
+    private static final byte[] zeros = new byte[4096];
+
+    public static PaddingAlignment get(long dfsBlockSize, long rowGroupSize) {
+      return new PaddingAlignment(dfsBlockSize, rowGroupSize);
+    }
+
+    protected final long dfsBlockSize;
+    protected final long rowGroupSize;
+
+    public PaddingAlignment(long dfsBlockSize, long rowGroupSize) {
+      this.dfsBlockSize = dfsBlockSize;
+      this.rowGroupSize = rowGroupSize;
+    }
+
+    @Override
+    public void alignForRowGroup(FSDataOutputStream out) throws IOException {
+      long remaining = dfsBlockSize - (out.getPos() % dfsBlockSize);
+
+      if (isPaddingNeeded(remaining)) {
+        if (DEBUG) LOG.debug("Adding " + remaining + " bytes of padding (" +
+            "row group size=" + rowGroupSize + "," +
+            "block size=" + dfsBlockSize + ")");
+        for (; remaining > 0; remaining -= zeros.length) {
+          out.write(zeros, 0, (int) Math.min((long) zeros.length, remaining));
+        }
+      }
+    }
+
+    @Override
+    public long nextRowGroupSize(FSDataOutputStream out) throws IOException {
+      long remaining = dfsBlockSize - (out.getPos() % dfsBlockSize);
+
+      if (isPaddingNeeded(remaining)) {
+        return rowGroupSize;
+      }
+
+      return Math.min(remaining, rowGroupSize);
+    }
+
+    protected boolean isPaddingNeeded(long remaining) {
+      return (remaining < (rowGroupSize / 2));
+    }
+  }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -664,8 +664,8 @@ public class ParquetFileWriter {
 
       if (isPaddingNeeded(remaining)) {
         if (DEBUG) LOG.debug("Adding " + remaining + " bytes of padding (" +
-            "row group size=" + rowGroupSize + "," +
-            "block size=" + dfsBlockSize + ")");
+            "row group size=" + rowGroupSize + "B, " +
+            "block size=" + dfsBlockSize + "B)");
         for (; remaining > 0; remaining -= zeros.length) {
           out.write(zeros, 0, (int) Math.min((long) zeros.length, remaining));
         }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -662,10 +662,10 @@ public class ParquetFileWriter {
 
     protected final long dfsBlockSize;
     protected final long rowGroupSize;
-    protected final float maxPaddingSize;
+    protected final int maxPaddingSize;
 
     private PaddingAlignment(long dfsBlockSize, long rowGroupSize,
-                            float maxPaddingSize) {
+                             int maxPaddingSize) {
       this.dfsBlockSize = dfsBlockSize;
       this.rowGroupSize = rowGroupSize;
       this.maxPaddingSize = maxPaddingSize;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 
 import org.apache.parquet.Log;
 import org.apache.parquet.column.ParquetProperties.WriterVersion;
+import org.apache.parquet.hadoop.ParquetFileWriter.Mode;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.api.WriteSupport.WriteContext;
 import org.apache.parquet.hadoop.codec.CodecConfig;
@@ -286,7 +287,8 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
     if (INFO) LOG.info("Writer version is: " + writerVersion);
 
     WriteContext init = writeSupport.init(conf);
-    ParquetFileWriter w = new ParquetFileWriter(conf, init.getSchema(), file);
+    ParquetFileWriter w = new ParquetFileWriter(
+        conf, init.getSchema(), file, Mode.CREATE, blockSize);
     w.start();
 
     float maxLoad = conf.getFloat(ParquetOutputFormat.MEMORY_POOL_RATIO,

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -81,6 +81,10 @@ import org.apache.parquet.hadoop.util.ConfigurationUtil;
  * # To enable/disable summary metadata aggregation at the end of a MR job
  * # The default is true (enabled)
  * parquet.enable.summary-metadata=true # false to disable summary aggregation
+ *
+ * # Maximum size (in bytes) allowed as padding to align row groups
+ * # This is also the minimum size of a row group. Default: 0
+ * parquet.writer.max-padding=2097152 # 2 MB
  * </pre>
  *
  * If parquet.compression is not set, the following properties are checked (FileOutputFormat behavior).
@@ -110,6 +114,10 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static final String ENABLE_JOB_SUMMARY   = "parquet.enable.summary-metadata";
   public static final String MEMORY_POOL_RATIO    = "parquet.memory.pool.ratio";
   public static final String MIN_MEMORY_ALLOCATION = "parquet.memory.min.chunk.size";
+  public static final String MAX_PADDING_BYTES    = "parquet.writer.max-padding";
+
+  // default to no padding for now
+  private static final int DEFAULT_MAX_PADDING_SIZE = 0;
 
   public static void setWriteSupportClass(Job job,  Class<?> writeSupportClass) {
     getConfiguration(job).set(WRITE_SUPPORT_CLASS, writeSupportClass.getName());
@@ -226,6 +234,18 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
     return CodecConfig.from(taskAttemptContext).getCodec();
   }
 
+  public static void setMaxPaddingSize(JobContext jobContext, int maxPaddingSize) {
+    setMaxPaddingSize(getConfiguration(jobContext), maxPaddingSize);
+  }
+
+  public static void setMaxPaddingSize(Configuration conf, int maxPaddingSize) {
+    conf.setInt(MAX_PADDING_BYTES, maxPaddingSize);
+  }
+
+  private static int getMaxPaddingSize(Configuration conf) {
+    // default to no padding, 0% of the row group size
+    return conf.getInt(MAX_PADDING_BYTES, DEFAULT_MAX_PADDING_SIZE);
+  }
 
 
   private WriteSupport<T> writeSupport;
@@ -285,10 +305,12 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
     if (INFO) LOG.info("Validation is " + (validating ? "on" : "off"));
     WriterVersion writerVersion = getWriterVersion(conf);
     if (INFO) LOG.info("Writer version is: " + writerVersion);
+    int maxPaddingSize = getMaxPaddingSize(conf);
+    if (INFO) LOG.info("Maximum row group padding size is " + maxPaddingSize + " bytes");
 
     WriteContext init = writeSupport.init(conf);
     ParquetFileWriter w = new ParquetFileWriter(
-        conf, init.getSchema(), file, Mode.CREATE, blockSize);
+        conf, init.getSchema(), file, Mode.CREATE, blockSize, maxPaddingSize);
     w.start();
 
     float maxLoad = conf.getFloat(ParquetOutputFormat.MEMORY_POOL_RATIO,

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -209,7 +209,7 @@ public class ParquetWriter<T> implements Closeable {
     MessageType schema = writeContext.getSchema();
 
     ParquetFileWriter fileWriter = new ParquetFileWriter(conf, schema, file,
-        mode);
+        mode, blockSize);
     fileWriter.start();
 
     CodecFactory codecFactory = new CodecFactory(conf);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -44,6 +44,9 @@ public class ParquetWriter<T> implements Closeable {
   public static final WriterVersion DEFAULT_WRITER_VERSION =
       WriterVersion.PARQUET_1_0;
 
+  // max size (bytes) to write as padding and the min size of a row group
+  public static final int MAX_PADDING_SIZE_DEFAULT = 0;
+
   private final InternalParquetRecordWriter<T> writer;
 
   /**
@@ -208,8 +211,9 @@ public class ParquetWriter<T> implements Closeable {
     WriteSupport.WriteContext writeContext = writeSupport.init(conf);
     MessageType schema = writeContext.getSchema();
 
+    // TODO: in a follow-up issue, add max padding to the builder
     ParquetFileWriter fileWriter = new ParquetFileWriter(conf, schema, file,
-        mode, blockSize);
+        mode, blockSize, MAX_PADDING_SIZE_DEFAULT);
     fileWriter.start();
 
     CodecFactory codecFactory = new CodecFactory(conf);

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputOutputFormatWithPadding.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputOutputFormatWithPadding.java
@@ -1,0 +1,216 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.example.GroupReadSupport;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Types;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import static java.lang.Thread.sleep;
+import static org.apache.parquet.schema.OriginalType.UTF8;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+
+public class TestInputOutputFormatWithPadding {
+  public static final String FILE_CONTENT = "" +
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ," +
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ," +
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  public static MessageType PARQUET_TYPE = Types.buildMessage()
+      .required(BINARY).as(UTF8).named("uuid")
+      .required(BINARY).as(UTF8).named("char")
+      .named("FormatTestObject");
+
+  /**
+   * ParquetInputFormat that will not split the input file (easier validation)
+   */
+  private static class NoSplits extends ParquetInputFormat {
+    @Override
+    protected boolean isSplitable(JobContext context, Path filename) {
+      return false;
+    }
+  }
+
+  public static class Writer extends Mapper<LongWritable, Text, Void, Group> {
+    public static final SimpleGroupFactory GROUP_FACTORY = new SimpleGroupFactory(PARQUET_TYPE);
+    @Override
+    protected void map(LongWritable key, Text value, Context context)
+        throws IOException, InterruptedException {
+      // writes each character of the line with a UUID
+      String line = value.toString();
+      for (int i = 0; i < line.length(); i += 1) {
+        Group group = GROUP_FACTORY.newGroup();
+        group.add(0, Binary.fromString(UUID.randomUUID().toString()));
+        group.add(1, Binary.fromString(line.substring(i, i+1)));
+        context.write(null, group);
+      }
+    }
+  }
+
+  public static class Reader extends Mapper<Void, Group, LongWritable, Text> {
+    @Override
+    protected void map(Void key, Group value, Context context)
+        throws IOException, InterruptedException {
+      context.write(null, new Text(value.getString("char", 0)));
+    }
+  }
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Test
+  public void testBasicBehaviorWithPadding() throws Exception {
+    ParquetFileWriter.BLOCK_FS_SCHEMES.add("file");
+
+    File inputFile = temp.newFile();
+    FileOutputStream out = new FileOutputStream(inputFile);
+    out.write(FILE_CONTENT.getBytes("UTF-8"));
+    out.close();
+
+    File tempFolder = temp.newFolder();
+    tempFolder.delete();
+    Path tempPath = new Path(tempFolder.toURI());
+
+    File outputFolder = temp.newFile();
+    outputFolder.delete();
+
+    Configuration conf = new Configuration();
+    // May test against multiple hadoop versions
+    conf.set("dfs.block.size", "1024");
+    conf.set("dfs.blocksize", "1024");
+    conf.set("dfs.blockSize", "1024");
+    conf.set("fs.local.block.size", "1024");
+
+    // don't use a cached FS with a different block size
+    conf.set("fs.file.impl.disable.cache", "true");
+
+    // disable summary metadata, it isn't needed
+    conf.set("parquet.enable.summary-metadata", "false");
+    conf.set("parquet.example.schema", PARQUET_TYPE.toString());
+
+    {
+      Job writeJob = new Job(conf, "write");
+      writeJob.setInputFormatClass(TextInputFormat.class);
+      TextInputFormat.addInputPath(writeJob, new Path(inputFile.toString()));
+
+      writeJob.setOutputFormatClass(ParquetOutputFormat.class);
+      writeJob.setMapperClass(Writer.class);
+      writeJob.setNumReduceTasks(0); // write directly to Parquet without reduce
+      ParquetOutputFormat.setWriteSupportClass(writeJob, GroupWriteSupport.class);
+      ParquetOutputFormat.setBlockSize(writeJob, 1024);
+      ParquetOutputFormat.setPageSize(writeJob, 512);
+      ParquetOutputFormat.setDictionaryPageSize(writeJob, 512);
+      ParquetOutputFormat.setEnableDictionary(writeJob, true);
+      ParquetOutputFormat.setMaxPaddingSize(writeJob, 1023); // always pad
+      ParquetOutputFormat.setOutputPath(writeJob, tempPath);
+
+      waitForJob(writeJob);
+    }
+
+    // make sure padding was added
+    File parquetFile = getDataFile(tempFolder);
+    ParquetMetadata footer = ParquetFileReader.readFooter(conf,
+        new Path(parquetFile.toString()), ParquetMetadataConverter.NO_FILTER);
+    for (BlockMetaData block : footer.getBlocks()) {
+      Assert.assertTrue("Block should start at a multiple of the block size",
+          block.getStartingPos() % 1024 == 0);
+    }
+
+    {
+      Job readJob = new Job(conf, "read");
+      readJob.setInputFormatClass(NoSplits.class);
+      ParquetInputFormat.setReadSupportClass(readJob, GroupReadSupport.class);
+      TextInputFormat.addInputPath(readJob, tempPath);
+
+      readJob.setOutputFormatClass(TextOutputFormat.class);
+      readJob.setMapperClass(Reader.class);
+      readJob.setNumReduceTasks(0); // write directly to text without reduce
+      TextOutputFormat.setOutputPath(readJob, new Path(outputFolder.toString()));
+
+      waitForJob(readJob);
+    }
+
+    File dataFile = getDataFile(outputFolder);
+    Assert.assertNotNull("Should find a data file", dataFile);
+
+    StringBuilder contentBuilder = new StringBuilder();
+    for (String line : Files.readAllLines(
+        Paths.get(dataFile.toURI()), Charset.forName("UTF-8"))) {
+      contentBuilder.append(line);
+    }
+    String reconstructed = contentBuilder.toString();
+    Assert.assertEquals("Should match written file content",
+        FILE_CONTENT, reconstructed);
+
+    ParquetFileWriter.BLOCK_FS_SCHEMES.remove("file");
+  }
+
+  private void waitForJob(Job job) throws Exception {
+    job.submit();
+    while (!job.isComplete()) {
+      sleep(100);
+    }
+    if (!job.isSuccessful()) {
+      throw new RuntimeException("job failed " + job.getJobName());
+    }
+  }
+
+  private File getDataFile(File location) {
+    File[] files = location.listFiles();
+    File dataFile = null;
+    if (files != null) {
+      for (File file : files) {
+        if (file.getName().startsWith("part-")) {
+          dataFile = file;
+          break;
+        }
+      }
+    }
+    return dataFile;
+  }
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -210,7 +210,7 @@ public class TestParquetFileWriter {
     Configuration conf = new Configuration();
 
     // uses the test constructor
-    ParquetFileWriter w = new ParquetFileWriter(conf, SCHEMA, path, 120);
+    ParquetFileWriter w = new ParquetFileWriter(conf, SCHEMA, path, 120, 60);
 
     w.start();
     w.startBlock(3);
@@ -313,7 +313,7 @@ public class TestParquetFileWriter {
     Configuration conf = new Configuration();
 
     // uses the test constructor
-    ParquetFileWriter w = new ParquetFileWriter(conf, SCHEMA, path, 100);
+    ParquetFileWriter w = new ParquetFileWriter(conf, SCHEMA, path, 100, 50);
 
     w.start();
     w.startBlock(3);


### PR DESCRIPTION
This adds `AlignmentStrategy` to the `ParquetFileWriter` that can alter the position of row groups and recommend a target size for the next row group. There are two strategies: `NoAlignment` and `PaddingAlignment`. Padding alignment is used for HDFS and no alignment is used for all other file systems. When HDFS-3689 is available, we can add a strategy to use that.

The amount of padding is controlled by a threshold between 0 and 1 that controls the fraction of the row group size that can be padded. This is interpreted as the maximum amount of padding that is acceptable, in terms of the row group size. For example, setting this to 5% will write padding when the bytes left in a HDFS block are less than 5% of the row group size. This defaults to 0%, which prevents padding from being added and matches the current behavior. The threshold is controlled by a new OutputFormat configuration property, `parquet.writer.padding-thresh`.