### PR TITLE
PARQUET-308: Add ParquetWriter#getDataSize accessor.

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -301,6 +301,13 @@ public class ParquetWriter<T> implements Closeable {
   }
 
   /**
+   * @return the total size of data written to the file and buffered in memory
+   */
+  public long getDataSize() {
+    return writer.getDataSize();
+  }
+
+  /**
    * An abstract builder class for ParquetWriter instances.
    *
    * Object models should extend this builder to provide writer configuration


### PR DESCRIPTION
This returns the current file position plus the amount of data buffered
in the current row group as an estimate of final data size.