### PR TITLE
PARQUET-309: remove unnecessary compile dependency on parquet-generator

### DIFF
--- a/parquet-column/pom.xml
+++ b/parquet-column/pom.xml
@@ -118,6 +118,13 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.2.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-generator</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <phase>generate-sources</phase>
@@ -128,6 +135,7 @@
         </executions>
         <configuration>
           <mainClass>org.apache.parquet.filter2.Generator</mainClass>
+          <includePluginDependencies>true</includePluginDependencies>
           <arguments>
             <argument>${basedir}/target/generated-src</argument>
           </arguments>

--- a/parquet-encoding/pom.xml
+++ b/parquet-encoding/pom.xml
@@ -42,11 +42,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-generator</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.5</version>
@@ -67,6 +62,13 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.2.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-generator</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <phase>generate-sources</phase>
@@ -77,6 +79,7 @@
         </executions>
         <configuration>
           <mainClass>org.apache.parquet.encoding.Generator</mainClass>
+          <includePluginDependencies>true</includePluginDependencies>
           <arguments>
             <argument>${basedir}/target/generated-src</argument>
           </arguments>


### PR DESCRIPTION
parquet-generator is build-time dependency only and shouldn't be listed in
pom.xml dependencies section.