### PR TITLE
Parquet-313: Implement 3 level list writing rule for Parquet-Thrift

### DIFF
--- a/parquet-scrooge/src/main/java/org/apache/parquet/scrooge/ScroogeReadSupport.java
+++ b/parquet-scrooge/src/main/java/org/apache/parquet/scrooge/ScroogeReadSupport.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.scrooge;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.thrift.ThriftReadSupport;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.thrift.ThriftSchemaConverter;
@@ -37,8 +38,13 @@ public class ScroogeReadSupport extends ThriftReadSupport{
   }
 
   @Override
-  protected MessageType getProjectedSchema(FieldProjectionFilter fieldProjectionFilter) {
+  protected MessageType getProjectedSchema(Configuration configuration, FieldProjectionFilter fieldProjectionFilter) {
     ThriftType.StructType thriftStruct = new ScroogeStructConverter().convert(thriftClass);
-    return new ThriftSchemaConverter(fieldProjectionFilter).convert(thriftStruct);
+    return new ThriftSchemaConverter(configuration, fieldProjectionFilter).convert(thriftStruct);
+  }
+
+  @Deprecated
+  protected MessageType getProjectedSchema(FieldProjectionFilter fieldProjectionFilter) {
+    return getProjectedSchema(new Configuration(), fieldProjectionFilter);
   }
 }

--- a/parquet-thrift/README.md
+++ b/parquet-thrift/README.md
@@ -1,0 +1,33 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+# Apache Thrift Integration
+
+**Todo:** Add a description and examples on how to use Parquet-Thrift integration.
+
+## Available options via Hadoop Configuration
+
+### Configuration for reading
+**Todo:** Add read configs
+
+### Configuration for writing
+**Todo:** Add all write configs
+| Name                                    | Type      | Description                                                          |
+|-----------------------------------------|-----------|----------------------------------------------------------------------|
+| `parquet.thrift.write-three-level-lists`| `boolean` | Write lists with 3-level structure to allow list and list elements to be nullable. When set to `true`, lists will be written as per https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists|

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ParquetThriftBytesOutputFormat.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ParquetThriftBytesOutputFormat.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.hadoop.thrift;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.thrift.TBase;
@@ -57,13 +58,33 @@ public class ParquetThriftBytesOutputFormat extends ParquetOutputFormat<BytesWri
    *  when catching an exception the record can be discarded.
    *  The non-buffered implementation will stream field by field. Exceptions are unrecoverable and the file must be closed when an invalid record is written.
    *
+   * @param configuration configuration
    * @param protocolFactory the protocol factory to use to read the bytes
-   * @param thriftClass thriftClass the class to exctract the schema from
+   * @param thriftClass thriftClass the class to extract the schema from
    * @param buffered whether we should buffer each record
    * @param errorHandler handle record corruption and schema incompatible exception
    */
-  public ParquetThriftBytesOutputFormat(TProtocolFactory protocolFactory, Class<? extends TBase<?, ?>> thriftClass, boolean buffered, FieldIgnoredHandler errorHandler) {
-    super(new ThriftBytesWriteSupport(protocolFactory, thriftClass, buffered, errorHandler));
+  public ParquetThriftBytesOutputFormat(Configuration configuration,
+                                        TProtocolFactory protocolFactory,
+                                        Class<? extends TBase<?, ?>> thriftClass,
+                                        boolean buffered,
+                                        FieldIgnoredHandler errorHandler) {
+    super(new ThriftBytesWriteSupport(
+        configuration, protocolFactory, thriftClass, buffered, errorHandler));
+  }
+
+  @Deprecated
+  /**
+   * @deprecated Use @link{ParquetThriftBytesOutputFormat(
+   * Configuration configuration, TProtocolFactory protocolFactory,
+   * Class<? extends TBase<?, ?>> thriftClass, boolean buffered,
+   * FieldIgnoredHandler errorHandler)} instead
+   */
+  public ParquetThriftBytesOutputFormat(TProtocolFactory protocolFactory,
+                                        Class<? extends TBase<?, ?>> thriftClass,
+                                        boolean buffered,
+                                        FieldIgnoredHandler errorHandler) {
+    this(new Configuration(), protocolFactory, thriftClass, buffered, errorHandler);
   }
 
 }

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ParquetThriftBytesOutputFormat.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ParquetThriftBytesOutputFormat.java
@@ -56,7 +56,8 @@ public class ParquetThriftBytesOutputFormat extends ParquetOutputFormat<BytesWri
   /**
    *  The buffered implementation will buffer each record and deal with invalid records (more expansive).
    *  when catching an exception the record can be discarded.
-   *  The non-buffered implementation will stream field by field. Exceptions are unrecoverable and the file must be closed when an invalid record is written.
+   *  The non-buffered implementation will stream field by field. Exceptions are unrecoverable and the file
+   *  must be closed when an invalid record is written.
    *
    * @param configuration configuration
    * @param protocolFactory the protocol factory to use to read the bytes
@@ -76,8 +77,13 @@ public class ParquetThriftBytesOutputFormat extends ParquetOutputFormat<BytesWri
   /**
    * @deprecated Use @link{ParquetThriftBytesOutputFormat(
    * Configuration configuration, TProtocolFactory protocolFactory,
-   * Class<\? extends TBase<\?, ?>> thriftClass, boolean buffered,
-   * FieldIgnoredHandler errorHandler)} instead
+   * {@literal Class<\? extends TBase<\?, ?>>} thriftClass, boolean buffered,
+   * FieldIgnoredHandler errorHandler)} instead.
+   *
+   * @param protocolFactory the protocol factory to use to read the bytes
+   * @param thriftClass thriftClass the class to extract the schema from
+   * @param buffered whether we should buffer each record
+   * @param errorHandler handle record corruption and schema incompatible exception
    */
   @Deprecated
   public ParquetThriftBytesOutputFormat(TProtocolFactory protocolFactory,

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ParquetThriftBytesOutputFormat.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ParquetThriftBytesOutputFormat.java
@@ -76,7 +76,7 @@ public class ParquetThriftBytesOutputFormat extends ParquetOutputFormat<BytesWri
   /**
    * @deprecated Use @link{ParquetThriftBytesOutputFormat(
    * Configuration configuration, TProtocolFactory protocolFactory,
-   * Class<? extends TBase<?, ?>> thriftClass, boolean buffered,
+   * Class<\? extends TBase<\?, ?>> thriftClass, boolean buffered,
    * FieldIgnoredHandler errorHandler)} instead
    */
   @Deprecated

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ParquetThriftBytesOutputFormat.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ParquetThriftBytesOutputFormat.java
@@ -73,13 +73,13 @@ public class ParquetThriftBytesOutputFormat extends ParquetOutputFormat<BytesWri
         configuration, protocolFactory, thriftClass, buffered, errorHandler));
   }
 
-  @Deprecated
   /**
    * @deprecated Use @link{ParquetThriftBytesOutputFormat(
    * Configuration configuration, TProtocolFactory protocolFactory,
    * Class<? extends TBase<?, ?>> thriftClass, boolean buffered,
    * FieldIgnoredHandler errorHandler)} instead
    */
+  @Deprecated
   public ParquetThriftBytesOutputFormat(TProtocolFactory protocolFactory,
                                         Class<? extends TBase<?, ?>> thriftClass,
                                         boolean buffered,

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/TBaseWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/TBaseWriteSupport.java
@@ -25,7 +25,10 @@ import org.apache.parquet.thrift.struct.ThriftType.StructType;
 
 public class TBaseWriteSupport<T extends TBase<?, ?>> extends AbstractThriftWriteSupport<T> {
 
+  private static Configuration conf;
+
   public static <U extends TBase<?,?>> void setThriftClass(Configuration configuration, Class<U> thriftClass) {
+    conf = configuration;
     AbstractThriftWriteSupport.setGenericThriftClass(configuration, thriftClass);
   }
 
@@ -52,7 +55,8 @@ public class TBaseWriteSupport<T extends TBase<?, ?>> extends AbstractThriftWrit
 
   @Override
   protected StructType getThriftStruct() {
-    return ThriftSchemaConverter.toStructType(thriftClass);
+    ThriftSchemaConverter thriftSchemaConverter = new ThriftSchemaConverter(conf);
+    return thriftSchemaConverter.toStructType((Class<TBase<?, ?>>)thriftClass);
   }
 
   @Override

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
@@ -86,12 +86,12 @@ public class ThriftBytesWriteSupport extends WriteSupport<BytesWritable> {
     this.errorHandler = null;
   }
 
-  @Deprecated
   /**
    * @deprecated Use @link{ThriftBytesWriteSupport(Configuration configuration,
    * TProtocolFactory protocolFactory, Class<? extends TBase<?, ?>> thriftClass,
    * boolean buffered, FieldIgnoredHandler errorHandler)} instead
    */
+  @Deprecated
   public ThriftBytesWriteSupport(TProtocolFactory protocolFactory,
                                  Class<? extends TBase<?, ?>> thriftClass,
                                  boolean buffered,

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
@@ -88,7 +88,7 @@ public class ThriftBytesWriteSupport extends WriteSupport<BytesWritable> {
 
   /**
    * @deprecated Use @link{ThriftBytesWriteSupport(Configuration configuration,
-   * TProtocolFactory protocolFactory, Class<\? extends TBase<\?, ?>> thriftClass,
+   * TProtocolFactory protocolFactory, {@literal Class<? extends TBase<?,?>>} thriftClass,
    * boolean buffered, FieldIgnoredHandler errorHandler)} instead
    */
   @Deprecated

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
@@ -88,7 +88,7 @@ public class ThriftBytesWriteSupport extends WriteSupport<BytesWritable> {
 
   /**
    * @deprecated Use @link{ThriftBytesWriteSupport(Configuration configuration,
-   * TProtocolFactory protocolFactory, Class<? extends TBase<?, ?>> thriftClass,
+   * TProtocolFactory protocolFactory, Class<\? extends TBase<\?, ?>> thriftClass,
    * boolean buffered, FieldIgnoredHandler errorHandler)} instead
    */
   @Deprecated

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftReadSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftReadSupport.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -178,7 +178,7 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
     } else if (projectionFilter != null) {
       try {
         initThriftClassFromMultipleFiles(context.getKeyValueMetadata(), configuration);
-        requestedProjection =  getProjectedSchema(projectionFilter);
+        requestedProjection =  getProjectedSchema(configuration, projectionFilter);
       } catch (ClassNotFoundException e) {
         throw new ThriftProjectionException("can not find thriftClass from configuration", e);
       }
@@ -189,8 +189,18 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
   }
 
   @SuppressWarnings("unchecked")
-  protected MessageType getProjectedSchema(FieldProjectionFilter fieldProjectionFilter) {
-    return new ThriftSchemaConverter(fieldProjectionFilter).convert((Class<TBase<?, ?>>)thriftClass);
+  protected MessageType getProjectedSchema(Configuration configuration, FieldProjectionFilter
+      fieldProjectionFilter) {
+    return new ThriftSchemaConverter(configuration, fieldProjectionFilter)
+        .convert((Class<TBase<?, ?>>)thriftClass);
+  }
+
+  @Deprecated
+  @SuppressWarnings("unchecked")
+  protected MessageType getProjectedSchema(FieldProjectionFilter
+    fieldProjectionFilter) {
+    return new ThriftSchemaConverter(new Configuration(), fieldProjectionFilter)
+      .convert((Class<TBase<?, ?>>)thriftClass);
   }
 
   @SuppressWarnings("unchecked")

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftToParquetFileWriter.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftToParquetFileWriter.java
@@ -93,7 +93,9 @@ public class ThriftToParquetFileWriter implements Closeable {
       boolean buffered,
       FieldIgnoredHandler errorHandler) throws IOException, InterruptedException {
     this.taskAttemptContext = taskAttemptContext;
-    this.recordWriter = new ParquetThriftBytesOutputFormat(protocolFactory, thriftClass, buffered, errorHandler).getRecordWriter(taskAttemptContext, fileToCreate);
+    this.recordWriter = new ParquetThriftBytesOutputFormat(
+        taskAttemptContext.getConfiguration(), protocolFactory, thriftClass, buffered, errorHandler)
+        .getRecordWriter(taskAttemptContext, fileToCreate);
   }
 
   /**

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
@@ -78,7 +78,7 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
   private final boolean doProjection;
   private final boolean keepOneOfEachUnion;
 
-  private boolean writeThreeLevelList = ParquetWriteProtocol.WRITE_THREE_LEVEL_LISTS_DEFAULT;
+  private final boolean writeThreeLevelList;
 
   private ThriftSchemaConvertVisitor(FieldProjectionFilter fieldProjectionFilter, boolean doProjection,
                                      boolean keepOneOfEachUnion, Configuration configuration) {
@@ -90,6 +90,8 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
       this.writeThreeLevelList = configuration.getBoolean(
         ParquetWriteProtocol.WRITE_THREE_LEVEL_LISTS,
         ParquetWriteProtocol.WRITE_THREE_LEVEL_LISTS_DEFAULT);
+    } else {
+      writeThreeLevelList = ParquetWriteProtocol.WRITE_THREE_LEVEL_LISTS_DEFAULT;
     }
   }
 

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.ShouldNeverHappenException;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
@@ -53,6 +54,7 @@ import org.apache.parquet.thrift.struct.ThriftType.StringType;
 import org.apache.parquet.thrift.struct.ThriftType.StructType;
 import org.apache.parquet.thrift.struct.ThriftType.StructType.StructOrUnionType;
 
+import static org.apache.parquet.schema.ConversionPatterns.listOfElements;
 import static org.apache.parquet.schema.ConversionPatterns.listType;
 import static org.apache.parquet.schema.ConversionPatterns.mapType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
@@ -76,22 +78,37 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
   private final boolean doProjection;
   private final boolean keepOneOfEachUnion;
 
-  private ThriftSchemaConvertVisitor(FieldProjectionFilter fieldProjectionFilter, boolean doProjection, boolean keepOneOfEachUnion) {
+  private boolean writeThreeLevelList = ParquetWriteProtocol.WRITE_THREE_LEVEL_LISTS_DEFAULT;
+
+  private ThriftSchemaConvertVisitor(FieldProjectionFilter fieldProjectionFilter, boolean doProjection,
+                                     boolean keepOneOfEachUnion, Configuration configuration) {
     this.fieldProjectionFilter = Objects.requireNonNull(fieldProjectionFilter,
-        "fieldProjectionFilter cannot be null");
+      "fieldProjectionFilter cannot be null");
     this.doProjection = doProjection;
     this.keepOneOfEachUnion = keepOneOfEachUnion;
+    if (configuration != null) {
+      this.writeThreeLevelList = configuration.getBoolean(
+        ParquetWriteProtocol.WRITE_THREE_LEVEL_LISTS,
+        ParquetWriteProtocol.WRITE_THREE_LEVEL_LISTS_DEFAULT);
+    }
+  }
+
+  private ThriftSchemaConvertVisitor(FieldProjectionFilter fieldProjectionFilter, boolean doProjection,
+                                     boolean keepOneOfEachUnion) {
+    this(fieldProjectionFilter, doProjection, keepOneOfEachUnion, new Configuration());
   }
 
   @Deprecated
   public static MessageType convert(StructType struct, FieldProjectionFilter filter) {
-    return convert(struct, filter, true);
+    return convert(struct, filter, true, new Configuration());
   }
 
-  public static MessageType convert(StructType struct, FieldProjectionFilter filter, boolean keepOneOfEachUnion) {
+  public static MessageType convert(StructType struct, FieldProjectionFilter filter, boolean keepOneOfEachUnion,
+                                    Configuration conf) {
     State state = new State(new FieldsPath(), REPEATED, "ParquetSchema");
 
-    ConvertedField converted = struct.accept(new ThriftSchemaConvertVisitor(filter, true, keepOneOfEachUnion), state);
+    ConvertedField converted = struct.accept(
+      new ThriftSchemaConvertVisitor(filter, true, keepOneOfEachUnion, conf), state);
 
     if (!converted.isKeep()) {
       throw new ThriftProjectionException("No columns have been selected");
@@ -178,7 +195,12 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
   }
 
   private ConvertedField visitListLike(ThriftField listLike, State state, boolean isSet) {
-    State childState = new State(state.path, REPEATED, state.name + "_tuple");
+    State childState;
+    if (writeThreeLevelList) {
+      childState = new State(state.path, REQUIRED, "element");
+    } else {
+      childState = new State(state.path, REPEATED, state.name + "_tuple");
+    }
 
     ConvertedField converted = listLike.getType().accept(this, childState);
 
@@ -194,7 +216,13 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
         }
       }
 
-      return new Keep(state.path, listType(state.repetition, state.name, converted.asKeep().getType()));
+      if (writeThreeLevelList) {
+        return new Keep(
+            state.path, listOfElements(state.repetition, state.name, converted.asKeep().getType()));
+      } else {
+        return new Keep(
+            state.path, listType(state.repetition, state.name, converted.asKeep().getType()));
+      }
     }
 
     return new Drop(state.path);

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConverter.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConverter.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,6 +22,8 @@ import com.twitter.elephantbird.thrift.TStructDescriptor;
 import com.twitter.elephantbird.thrift.TStructDescriptor.Field;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TEnum;
 import org.apache.thrift.TUnion;
@@ -50,8 +52,21 @@ import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 public class ThriftSchemaConverter {
   private final FieldProjectionFilter fieldProjectionFilter;
 
+  private Configuration conf;
+
   public ThriftSchemaConverter() {
     this(FieldProjectionFilter.ALL_COLUMNS);
+  }
+
+  public ThriftSchemaConverter(Configuration configuration) {
+    this();
+    conf = configuration;
+  }
+
+  public ThriftSchemaConverter(
+      Configuration configuration, FieldProjectionFilter fieldProjectionFilter) {
+    this(fieldProjectionFilter);
+    conf = configuration;
   }
 
   public ThriftSchemaConverter(FieldProjectionFilter fieldProjectionFilter) {
@@ -72,7 +87,7 @@ public class ThriftSchemaConverter {
    * @return the struct as a Parquet message type
    */
   public MessageType convert(StructType struct) {
-    MessageType messageType = ThriftSchemaConvertVisitor.convert(struct, fieldProjectionFilter, true);
+    MessageType messageType = ThriftSchemaConvertVisitor.convert(struct, fieldProjectionFilter, true, conf);
     fieldProjectionFilter.assertNoUnmatchedPatterns();
     return messageType;
   }
@@ -85,7 +100,7 @@ public class ThriftSchemaConverter {
    * @return the struct as a Parquet message type
    */
   public static MessageType convertWithoutProjection(StructType struct) {
-    return ThriftSchemaConvertVisitor.convert(struct, FieldProjectionFilter.ALL_COLUMNS, false);
+    return ThriftSchemaConvertVisitor.convert(struct, FieldProjectionFilter.ALL_COLUMNS, false, new Configuration());
   }
 
   public static <T extends TBase<?,?>> StructOrUnionType structOrUnionType(Class<T> klass) {

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestParquetWriteProtocol.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestParquetWriteProtocol.java
@@ -30,6 +30,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import com.twitter.elephantbird.thrift.test.TestMapInList;
+import com.twitter.elephantbird.thrift.test.TestNameSet;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.ComparisonFailure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,8 +51,6 @@ import org.apache.parquet.io.RecordConsumerLoggingWrapper;
 import org.apache.parquet.pig.PigSchemaConverter;
 import org.apache.parquet.pig.TupleWriteSupport;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.thrift.ParquetWriteProtocol;
-import org.apache.parquet.thrift.ThriftSchemaConverter;
 import org.apache.parquet.thrift.struct.ThriftType.StructType;
 
 import com.twitter.data.proto.tutorial.thrift.AddressBook;
@@ -518,9 +519,175 @@ public class TestParquetWriteProtocol {
    validateThrift(thriftExpectations, a);
   }
 
+  @Test
+  public void testSetWithTwoLevelList() throws TException {
+    final Set<String> names = new HashSet<String>();
+    names.add("John");
+    names.add("Jack");
+    final TestNameSet o = new TestNameSet("name", names);
+
+    String[] expectations = {
+      "startMessage()",
+        "startField(name, 0)",
+          "addBinary(name)",
+        "endField(name, 0)",
+        "startField(names, 1)",
+          "startGroup()",
+            "startField(names_tuple, 0)",
+              "addBinary(John)",
+              "addBinary(Jack)",
+            "endField(names_tuple, 0)",
+          "endGroup()",
+        "endField(names, 1)",
+      "endMessage()"};
+    Configuration conf = new Configuration();
+    conf.set(ParquetWriteProtocol.WRITE_THREE_LEVEL_LISTS, "false");
+    validateThrift(conf, expectations, o);
+  }
+
+  @Test
+  public void testSetWithThreeLevelList() throws TException {
+    final Set<String> names = new HashSet<String>();
+    names.add("John");
+    names.add("Jack");
+    final TestNameSet o = new TestNameSet("name", names);
+
+    String[] expectations = {
+      "startMessage()",
+        "startField(name, 0)",
+          "addBinary(name)",
+        "endField(name, 0)",
+        "startField(names, 1)",
+          "startGroup()",
+            "startField(list, 0)",
+              "startGroup()",
+                "startField(element, 0)",
+                  "addBinary(John)",
+                "endField(element, 0)",
+              "endGroup()",
+              "startGroup()",
+                "startField(element, 0)",
+                  "addBinary(Jack)",
+                "endField(element, 0)",
+              "endGroup()",
+            "endField(list, 0)",
+          "endGroup()",
+        "endField(names, 1)",
+      "endMessage()"};
+    Configuration conf = new Configuration();
+    conf.set(ParquetWriteProtocol.WRITE_THREE_LEVEL_LISTS, "true");
+    validateThrift(conf, expectations, o);
+  }
+
+  @Test
+  public void testNameThreeLevelList() throws TException {
+    final List<String> names = new ArrayList<String>();
+    names.add("John");
+    names.add("Jack");
+    final TestNameList o = new TestNameList("name", names);
+
+    String[] expectations = {
+        "startMessage()",
+          "startField(name, 0)",
+            "addBinary(name)",
+          "endField(name, 0)",
+          "startField(names, 1)",
+            "startGroup()",
+              "startField(list, 0)",
+                "startGroup()",
+                  "startField(element, 0)",
+                    "addBinary(John)",
+                  "endField(element, 0)",
+                "endGroup()",
+                "startGroup()",
+                  "startField(element, 0)",
+                    "addBinary(Jack)",
+                  "endField(element, 0)",
+                "endGroup()",
+              "endField(list, 0)",
+            "endGroup()",
+          "endField(names, 1)",
+        "endMessage()"};
+    Configuration conf = new Configuration();
+    conf.set(ParquetWriteProtocol.WRITE_THREE_LEVEL_LISTS, "true");
+    validateThrift(conf, expectations, o);
+  }
+
+  @Test
+  public void testListOfMapThreeLevelList() throws TException {
+    Map<String, String> map1 = new HashMap<String,String>();
+    map1.put("key11", "value11");
+    map1.put("key12", "value12");
+    Map<String, String> map2 = new HashMap<String,String>();
+    map2.put("key21", "value21");
+    final TestMapInList listMap = new TestMapInList("listmap",
+        Arrays.asList(map1, map2));
+
+    String[] expectations = {
+        "startMessage()",
+          "startField(name, 0)",
+            "addBinary(listmap)",
+          "endField(name, 0)",
+          "startField(names, 1)",
+            "startGroup()",
+              "startField(list, 0)",
+                "startGroup()",
+                  "startField(element, 0)",
+                    "startGroup()",
+                      "startField(key_value, 0)",
+                        "startGroup()",
+                          "startField(key, 0)",
+                            "addBinary(key12)",
+                          "endField(key, 0)",
+                          "startField(value, 1)",
+                            "addBinary(value12)",
+                          "endField(value, 1)",
+                        "endGroup()",
+                        "startGroup()",
+                          "startField(key, 0)",
+                            "addBinary(key11)",
+                          "endField(key, 0)",
+                          "startField(value, 1)",
+                            "addBinary(value11)",
+                          "endField(value, 1)",
+                        "endGroup()",
+                      "endField(key_value, 0)",
+                    "endGroup()",
+                  "endField(element, 0)",
+                "endGroup()",
+                "startGroup()",
+                  "startField(element, 0)",
+                    "startGroup()",
+                      "startField(key_value, 0)",
+                        "startGroup()",
+                          "startField(key, 0)",
+                            "addBinary(key21)",
+                          "endField(key, 0)",
+                          "startField(value, 1)",
+                            "addBinary(value21)",
+                          "endField(value, 1)",
+                        "endGroup()",
+                      "endField(key_value, 0)",
+                    "endGroup()",
+                  "endField(element, 0)",
+                "endGroup()",
+              "endField(list, 0)",
+            "endGroup()",
+          "endField(names, 1)",
+        "endMessage()"};
+    Configuration conf = new Configuration();
+    conf.set(ParquetWriteProtocol.WRITE_THREE_LEVEL_LISTS, "true");
+    validateThrift(conf, expectations, listMap);
+  }
+
   private void validateThrift(String[] expectations, TBase<?, ?> a)
       throws TException {
-    final ThriftSchemaConverter thriftSchemaConverter = new ThriftSchemaConverter();
+    validateThrift(new Configuration(), expectations, a);
+  }
+
+  private void validateThrift(Configuration configuration, String[] expectations, TBase<?, ?> a)
+      throws TException {
+    final ThriftSchemaConverter thriftSchemaConverter = new ThriftSchemaConverter(configuration);
 //      System.out.println(a);
     final Class<TBase<?,?>> class1 = (Class<TBase<?,?>>)a.getClass();
     final MessageType schema = thriftSchemaConverter.convert(class1);
@@ -528,7 +695,8 @@ public class TestParquetWriteProtocol {
     final StructType structType = thriftSchemaConverter.toStructType(class1);
     ExpectationValidatingRecordConsumer recordConsumer = new ExpectationValidatingRecordConsumer(new ArrayDeque<String>(Arrays.asList(expectations)));
     final MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(schema);
-    ParquetWriteProtocol p = new ParquetWriteProtocol(new RecordConsumerLoggingWrapper(recordConsumer), columnIO, structType);
+    ParquetWriteProtocol p = new ParquetWriteProtocol(
+        configuration, new RecordConsumerLoggingWrapper(recordConsumer), columnIO, structType);
     a.write(p);
   }
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftParquetReaderWriter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftParquetReaderWriter.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,7 +39,17 @@ public class TestThriftParquetReaderWriter {
 
   @Test
   public void testWriteRead() throws IOException {
+    readWriteTest(true);
+  }
+
+  @Test
+  public void testWriteReadTwoLevelList() throws IOException {
+    readWriteTest(false);
+  }
+
+  private void readWriteTest(Boolean useThreeLevelLists) throws IOException {
     Configuration configuration = new Configuration();
+    configuration.set(ParquetWriteProtocol.WRITE_THREE_LEVEL_LISTS, useThreeLevelLists.toString());
     Path f = new Path("target/test/TestThriftParquetReaderWriter");
     FileSystem fs = f.getFileSystem(configuration);
     if (fs.exists(f)) {


### PR DESCRIPTION
Parquet-thrift does not write three level lists, unlike other object models in the project. This JIRA should add 3 level list writing rule's implementation for parquet-thrift.
