### PR TITLE
PARQUET-315: Add PARQUET_1_0 and non-repeated data performance tests …

### DIFF
--- a/parquet-benchmarks/pom.xml
+++ b/parquet-benchmarks/pom.xml
@@ -32,7 +32,7 @@
   <url>https://parquet.apache.org</url>
 
   <properties>
-    <jmh.version>1.3.4</jmh.version>
+    <jmh.version>1.9.3</jmh.version>
     <uberjar.name>parquet-benchmarks</uberjar.name>
   </properties>
 

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/BenchmarkConstants.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/BenchmarkConstants.java
@@ -39,4 +39,9 @@ public class BenchmarkConstants {
   public static final int PAGE_SIZE_8M = 8 * 1024 * 1024;
 
   public static final int DICT_PAGE_SIZE = 512;
+
+  //In order to improve the benchmark speed, we generate a random sample data.
+  //This data will be written as many times as rows are needed in the file.
+  //The sample is 100k of random records, enough to write many pages of unique data.
+  public static final int RANDOM_SAMPLE_ROWS = 100000;
 }

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/BenchmarkFiles.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/BenchmarkFiles.java
@@ -18,12 +18,9 @@
  */
 package org.apache.parquet.benchmarks;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
 public class BenchmarkFiles {
-  public static final Configuration configuration = new Configuration();
-
   public static final String TARGET_DIR = "target/tests/ParquetBenchmarks";
   public static final Path file_1M = new Path(TARGET_DIR + "/PARQUET-1M");
 

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DataGenerator.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DataGenerator.java
@@ -18,9 +18,11 @@
  */
 package org.apache.parquet.benchmarks;
 
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.math.RandomUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -30,12 +32,12 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 import static java.util.UUID.randomUUID;
 import static org.apache.parquet.benchmarks.BenchmarkUtils.deleteIfExists;
-import static org.apache.parquet.benchmarks.BenchmarkUtils.exists;
-import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.SNAPPY;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
@@ -44,72 +46,104 @@ import static org.apache.parquet.benchmarks.BenchmarkConstants.*;
 import static org.apache.parquet.benchmarks.BenchmarkFiles.*;
 
 public class DataGenerator {
+  public static final String DEFAULT_SCHEMA = "message simple_test { "
+      + " required binary binary_field; "
+      + " required int32 int32_field; "
+      + " required int64 int64_field; "
+      + " required boolean boolean_field; "
+      + " required float float_field; "
+      + " required double double_field; "
+      + " required fixed_len_byte_array(100) flba_field; "
+      + " required int96 int96_field; "
+      + "} ";
+
+  private MessageType schema;
+  private Configuration configuration;
+  private WriterVersion writerVersion;
+  private SimpleGroupFactory groupFactory;
+  private GroupWriteSupport groupWriteSupport;
+
+  //use a constant seed to generate the same random data for all tests
+  private Random rand = new Random(1);
+  private List<Group> randomData;
+
+  public DataGenerator(Configuration configuration) {
+    this(configuration, WriterVersion.PARQUET_2_0);
+  }
+
+  public DataGenerator(Configuration configuration, WriterVersion writerVersion) {
+    this.configuration = configuration;
+    this.writerVersion = writerVersion;
+    this.schema = parseMessageType(DEFAULT_SCHEMA);
+    this.groupFactory = new SimpleGroupFactory(schema);
+
+    GroupWriteSupport.setSchema(schema, configuration);
+    this.groupWriteSupport = new GroupWriteSupport();
+
+    randomData = new ArrayList<Group>();
+
+    //generates just one random record by default
+    initializeRandomSampleData(1);
+  }
+
+  public void setWriterVersion(WriterVersion writerVersion) {
+    this.writerVersion = writerVersion;
+  }
+
+  public void initializeRandomSampleData(int sampleSize) {
+    randomData.clear();
+    for (int i = 0; i < sampleSize; i++) {
+      randomData.add(randomRecord());
+    }
+  }
+
+  public Group randomRecord() {
+    byte[] int96 = new byte[12];
+    rand.nextBytes(int96);
+
+    return groupFactory.newGroup()
+        .append("binary_field", randomUUID().toString())
+        .append("int32_field", RandomUtils.nextInt())
+        .append("int64_field", RandomUtils.nextLong())
+        .append("boolean_field", RandomUtils.nextBoolean())
+        .append("float_field", RandomUtils.nextFloat())
+        .append("double_field", RandomUtils.nextDouble())
+        .append("flba_field", RandomStringUtils.randomAlphanumeric(100))
+        .append("int96_field", Binary.fromByteArray(int96));
+  }
 
   public void generateAll() {
     try {
-      generateData(file_1M, configuration, PARQUET_2_0, BLOCK_SIZE_DEFAULT, PAGE_SIZE_DEFAULT, FIXED_LEN_BYTEARRAY_SIZE, UNCOMPRESSED, ONE_MILLION);
+      generateData(file_1M, BLOCK_SIZE_DEFAULT, PAGE_SIZE_DEFAULT, UNCOMPRESSED, ONE_MILLION);
 
       //generate data for different block and page sizes
-      generateData(file_1M_BS256M_PS4M, configuration, PARQUET_2_0, BLOCK_SIZE_256M, PAGE_SIZE_4M, FIXED_LEN_BYTEARRAY_SIZE, UNCOMPRESSED, ONE_MILLION);
-      generateData(file_1M_BS256M_PS8M, configuration, PARQUET_2_0, BLOCK_SIZE_256M, PAGE_SIZE_8M, FIXED_LEN_BYTEARRAY_SIZE, UNCOMPRESSED, ONE_MILLION);
-      generateData(file_1M_BS512M_PS4M, configuration, PARQUET_2_0, BLOCK_SIZE_512M, PAGE_SIZE_4M, FIXED_LEN_BYTEARRAY_SIZE, UNCOMPRESSED, ONE_MILLION);
-      generateData(file_1M_BS512M_PS8M, configuration, PARQUET_2_0, BLOCK_SIZE_512M, PAGE_SIZE_8M, FIXED_LEN_BYTEARRAY_SIZE, UNCOMPRESSED, ONE_MILLION);
+      generateData(file_1M_BS256M_PS4M, BLOCK_SIZE_256M, PAGE_SIZE_4M, UNCOMPRESSED, ONE_MILLION);
+      generateData(file_1M_BS256M_PS8M, BLOCK_SIZE_256M, PAGE_SIZE_8M, UNCOMPRESSED, ONE_MILLION);
+      generateData(file_1M_BS512M_PS4M, BLOCK_SIZE_512M, PAGE_SIZE_4M, UNCOMPRESSED, ONE_MILLION);
+      generateData(file_1M_BS512M_PS8M, BLOCK_SIZE_512M, PAGE_SIZE_8M, UNCOMPRESSED, ONE_MILLION);
 
       //generate data for different codecs
-//      generateData(parquetFile_1M_LZO, configuration, PARQUET_2_0, BLOCK_SIZE_DEFAULT, PAGE_SIZE_DEFAULT, FIXED_LEN_BYTEARRAY_SIZE, LZO, ONE_MILLION);
-      generateData(file_1M_SNAPPY, configuration, PARQUET_2_0, BLOCK_SIZE_DEFAULT, PAGE_SIZE_DEFAULT, FIXED_LEN_BYTEARRAY_SIZE, SNAPPY, ONE_MILLION);
-      generateData(file_1M_GZIP, configuration, PARQUET_2_0, BLOCK_SIZE_DEFAULT, PAGE_SIZE_DEFAULT, FIXED_LEN_BYTEARRAY_SIZE, GZIP, ONE_MILLION);
+//      generateData(parquetFile_1M_LZO, configuration, BLOCK_SIZE_DEFAULT, PAGE_SIZE_DEFAULT, LZO, ONE_MILLION);
+      generateData(file_1M_SNAPPY, BLOCK_SIZE_DEFAULT, PAGE_SIZE_DEFAULT, SNAPPY, ONE_MILLION);
+      generateData(file_1M_GZIP, BLOCK_SIZE_DEFAULT, PAGE_SIZE_DEFAULT, GZIP, ONE_MILLION);
     }
     catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public void generateData(Path outFile, Configuration configuration, ParquetProperties.WriterVersion version,
-                           int blockSize, int pageSize, int fixedLenByteArraySize, CompressionCodecName codec, int nRows)
+  public void generateData(Path outFile, int blockSize, int pageSize, CompressionCodecName codec, int nRows)
           throws IOException
   {
-    if (exists(configuration, outFile)) {
-      System.out.println("File already exists " + outFile);
-      return;
+    ParquetWriter<Group> writer = new ParquetWriter<Group>(outFile, groupWriteSupport, codec, blockSize,
+                                                           pageSize, pageSize, true, false, writerVersion, configuration);
+
+    for (int i = 0; i < nRows; i += randomData.size()) {
+      for (int j = 0; j < randomData.size() && j < (nRows - i); j++) {
+        writer.write(randomData.get(j));
+      }
     }
 
-    System.out.println("Generating data @ " + outFile);
-
-    MessageType schema = parseMessageType(
-            "message test { "
-                    + "required binary binary_field; "
-                    + "required int32 int32_field; "
-                    + "required int64 int64_field; "
-                    + "required boolean boolean_field; "
-                    + "required float float_field; "
-                    + "required double double_field; "
-                    + "required fixed_len_byte_array(" + fixedLenByteArraySize +") flba_field; "
-                    + "required int96 int96_field; "
-                    + "} ");
-
-    GroupWriteSupport.setSchema(schema, configuration);
-    SimpleGroupFactory f = new SimpleGroupFactory(schema);
-    ParquetWriter<Group> writer = new ParquetWriter<Group>(outFile, new GroupWriteSupport(), codec, blockSize,
-                                                           pageSize, DICT_PAGE_SIZE, true, false, version, configuration);
-
-    //generate some data for the fixed len byte array field
-    char[] chars = new char[fixedLenByteArraySize];
-    Arrays.fill(chars, '*');
-
-    for (int i = 0; i < nRows; i++) {
-      writer.write(
-        f.newGroup()
-          .append("binary_field", randomUUID().toString())
-          .append("int32_field", i)
-          .append("int64_field", 64l)
-          .append("boolean_field", true)
-          .append("float_field", 1.0f)
-          .append("double_field", 2.0d)
-          .append("flba_field", new String(chars))
-          .append("int96_field", Binary.fromByteArray(new byte[12]))
-      );
-    }
     writer.close();
   }
 
@@ -126,14 +160,36 @@ public class DataGenerator {
   }
 
   public static void main(String[] args) {
-    DataGenerator generator = new DataGenerator();
+    DataGenerator generator = new DataGenerator(new Configuration());
+
     if (args.length < 1) {
-      System.err.println("Please specify a command (generate|cleanup).");
+      System.err.println("Please specify a command (generate VERSION|cleanup).");
       System.exit(1);
     }
 
     String command = args[0];
     if (command.equalsIgnoreCase("generate")) {
+      if (args.length < 2 || args.length > 3) {
+        System.err.println("Usage: generate VERSION [-randomData]\n");
+        System.err.println("Options:");
+        System.err.println("  VERSION         Use a specific parquet file version to generate data.");
+        System.err.println("                  - v1 for PARQUET_1_0 version.");
+        System.err.println("                  - v2 for PARQUET_2_0 version.");
+        System.err.println("  -randomData     This flag specifies if random data will be used to generate data.");
+        System.err.println("                  By default, only 1 random row is generated, and repeated across the file.");
+        System.exit(1);
+      }
+
+      String parquetVersion = args[1];
+
+      if (args.length == 3 && args[2].equalsIgnoreCase("-randomData")) {
+        generator.initializeRandomSampleData(RANDOM_SAMPLE_ROWS);
+      } else {
+        System.err.println("Unknown option: " + args[2]);
+        System.exit(1);
+      }
+
+      generator.setWriterVersion(WriterVersion.fromString(parquetVersion));
       generator.generateAll();
     } else if (command.equalsIgnoreCase("cleanup")) {
       generator.cleanup();

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/ReadBenchmarks.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/ReadBenchmarks.java
@@ -18,23 +18,36 @@
  */
 package org.apache.parquet.benchmarks;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.example.GroupReadSupport;
-import static org.apache.parquet.benchmarks.BenchmarkConstants.*;
 import static org.apache.parquet.benchmarks.BenchmarkFiles.*;
 
 import java.io.IOException;
 
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
 public class ReadBenchmarks {
-  private void read(Path parquetFile, int nRows, Blackhole blackhole) throws IOException
+  private Configuration configuration;
+  private GroupReadSupport groupReadSupport;
+
+  @Setup(Level.Trial)
+  public void setupBenchmark() throws IOException {
+    configuration = new Configuration();
+    groupReadSupport = new GroupReadSupport();
+  }
+
+  private void read(Path parquetFile, Blackhole blackhole) throws IOException
   {
-    ParquetReader<Group> reader = ParquetReader.builder(new GroupReadSupport(), parquetFile).withConf(configuration).build();
-    for (int i = 0; i < nRows; i++) {
-      Group group = reader.read();
+    ParquetReader<Group> reader = ParquetReader.builder(groupReadSupport, parquetFile).withConf(configuration).build();
+
+    Group group;
+    while ((group = reader.read()) != null) {
       blackhole.consume(group.getBinary("binary_field", 0));
       blackhole.consume(group.getInteger("int32_field", 0));
       blackhole.consume(group.getLong("int64_field", 0));
@@ -51,35 +64,35 @@ public class ReadBenchmarks {
   public void read1MRowsDefaultBlockAndPageSizeUncompressed(Blackhole blackhole)
           throws IOException
   {
-    read(file_1M, ONE_MILLION, blackhole);
+    read(file_1M, blackhole);
   }
 
   @Benchmark
   public void read1MRowsBS256MPS4MUncompressed(Blackhole blackhole)
           throws IOException
   {
-    read(file_1M_BS256M_PS4M, ONE_MILLION, blackhole);
+    read(file_1M_BS256M_PS4M, blackhole);
   }
 
   @Benchmark
   public void read1MRowsBS256MPS8MUncompressed(Blackhole blackhole)
           throws IOException
   {
-    read(file_1M_BS256M_PS8M, ONE_MILLION, blackhole);
+    read(file_1M_BS256M_PS8M, blackhole);
   }
 
   @Benchmark
   public void read1MRowsBS512MPS4MUncompressed(Blackhole blackhole)
           throws IOException
   {
-    read(file_1M_BS512M_PS4M, ONE_MILLION, blackhole);
+    read(file_1M_BS512M_PS4M, blackhole);
   }
 
   @Benchmark
   public void read1MRowsBS512MPS8MUncompressed(Blackhole blackhole)
           throws IOException
   {
-    read(file_1M_BS512M_PS8M, ONE_MILLION, blackhole);
+    read(file_1M_BS512M_PS8M, blackhole);
   }
 
   //TODO how to handle lzo jar?
@@ -87,20 +100,20 @@ public class ReadBenchmarks {
 //  public void read1MRowsDefaultBlockAndPageSizeLZO(Blackhole blackhole)
 //          throws IOException
 //  {
-//    read(parquetFile_1M_LZO, ONE_MILLION, blackhole);
+//    read(parquetFile_1M_LZO, blackhole);
 //  }
 
   @Benchmark
   public void read1MRowsDefaultBlockAndPageSizeSNAPPY(Blackhole blackhole)
           throws IOException
   {
-    read(file_1M_SNAPPY, ONE_MILLION, blackhole);
+    read(file_1M_SNAPPY, blackhole);
   }
 
   @Benchmark
   public void read1MRowsDefaultBlockAndPageSizeGZIP(Blackhole blackhole)
           throws IOException
   {
-    read(file_1M_GZIP, ONE_MILLION, blackhole);
+    read(file_1M_GZIP, blackhole);
   }
 }

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/WriteBenchmarks.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/WriteBenchmarks.java
@@ -18,27 +18,42 @@
  */
 package org.apache.parquet.benchmarks;
 
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Level;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
+import org.apache.hadoop.conf.Configuration;
+import org.openjdk.jmh.annotations.*;
 
-import static org.openjdk.jmh.annotations.Scope.Thread;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion;
+import static org.openjdk.jmh.annotations.Scope.Benchmark;
 import static org.apache.parquet.benchmarks.BenchmarkConstants.*;
 import static org.apache.parquet.benchmarks.BenchmarkFiles.*;
 
 import java.io.IOException;
 
-import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.SNAPPY;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
 
-@State(Thread)
+@State(Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
 public class WriteBenchmarks {
-  private DataGenerator dataGenerator = new DataGenerator();
+  private DataGenerator dataGenerator;
 
-  @Setup(Level.Iteration)
+  @Param("v2")
+  public String parquetVersion;
+
+  @Param("false")
+  public boolean randomData;
+
+  @Setup(Level.Trial)
+  public void setupBenchmark() throws IOException {
+    dataGenerator = new DataGenerator(new Configuration(), WriterVersion.fromString(parquetVersion));
+
+    if (randomData) {
+      dataGenerator.initializeRandomSampleData(RANDOM_SAMPLE_ROWS);
+    }
+  }
+
+  @Setup(Level.Invocation)
   public void cleanup() {
     //clean existing test data at the beginning of each iteration
     dataGenerator.cleanup();
@@ -49,11 +64,8 @@ public class WriteBenchmarks {
           throws IOException
   {
     dataGenerator.generateData(file_1M,
-                               configuration,
-                               PARQUET_2_0,
                                BLOCK_SIZE_DEFAULT,
                                PAGE_SIZE_DEFAULT,
-                               FIXED_LEN_BYTEARRAY_SIZE,
                                UNCOMPRESSED,
                                ONE_MILLION);
   }
@@ -63,11 +75,8 @@ public class WriteBenchmarks {
           throws IOException
   {
     dataGenerator.generateData(file_1M_BS256M_PS4M,
-                               configuration,
-                               PARQUET_2_0,
                                BLOCK_SIZE_256M,
                                PAGE_SIZE_4M,
-                               FIXED_LEN_BYTEARRAY_SIZE,
                                UNCOMPRESSED,
                                ONE_MILLION);
   }
@@ -77,11 +86,8 @@ public class WriteBenchmarks {
           throws IOException
   {
     dataGenerator.generateData(file_1M_BS256M_PS8M,
-                               configuration,
-                               PARQUET_2_0,
                                BLOCK_SIZE_256M,
                                PAGE_SIZE_8M,
-                               FIXED_LEN_BYTEARRAY_SIZE,
                                UNCOMPRESSED,
                                ONE_MILLION);
   }
@@ -91,11 +97,8 @@ public class WriteBenchmarks {
           throws IOException
   {
     dataGenerator.generateData(file_1M_BS512M_PS4M,
-                               configuration,
-                               PARQUET_2_0,
                                BLOCK_SIZE_512M,
                                PAGE_SIZE_4M,
-                               FIXED_LEN_BYTEARRAY_SIZE,
                                UNCOMPRESSED,
                                ONE_MILLION);
   }
@@ -105,11 +108,8 @@ public class WriteBenchmarks {
           throws IOException
   {
     dataGenerator.generateData(file_1M_BS512M_PS8M,
-                               configuration,
-                               PARQUET_2_0,
                                BLOCK_SIZE_512M,
                                PAGE_SIZE_8M,
-                               FIXED_LEN_BYTEARRAY_SIZE,
                                UNCOMPRESSED,
                                ONE_MILLION);
   }
@@ -120,11 +120,8 @@ public class WriteBenchmarks {
 //          throws IOException
 //  {
 //    dataGenerator.generateData(parquetFile_1M_LZO,
-//            configuration,
-//            WriterVersion.PARQUET_2_0,
 //            BLOCK_SIZE_DEFAULT,
 //            PAGE_SIZE_DEFAULT,
-//            FIXED_LEN_BYTEARRAY_SIZE,
 //            LZO,
 //            ONE_MILLION);
 //  }
@@ -134,11 +131,8 @@ public class WriteBenchmarks {
           throws IOException
   {
     dataGenerator.generateData(file_1M_SNAPPY,
-                               configuration,
-                               PARQUET_2_0,
                                BLOCK_SIZE_DEFAULT,
                                PAGE_SIZE_DEFAULT,
-                               FIXED_LEN_BYTEARRAY_SIZE,
                                SNAPPY,
                                ONE_MILLION);
   }
@@ -148,11 +142,8 @@ public class WriteBenchmarks {
           throws IOException
   {
     dataGenerator.generateData(file_1M_GZIP,
-                               configuration,
-                               PARQUET_2_0,
                                BLOCK_SIZE_DEFAULT,
                                PAGE_SIZE_DEFAULT,
-                               FIXED_LEN_BYTEARRAY_SIZE,
                                GZIP,
                                ONE_MILLION);
   }

--- a/parquet-benchmarks/write-benchmark.sh
+++ b/parquet-benchmarks/write-benchmark.sh
@@ -17,11 +17,12 @@
 # under the License.
 #
 
+
 # !/usr/bin/env bash
 
 set -e
 
 SCRIPT_PATH=$( cd "$(dirname "$0")" ; pwd -P )
 
-bash write-benchmark.sh "$@"
-bash read-benchmark.sh "$@"
+echo "Starting WRITE benchmarks"
+java -jar ${SCRIPT_PATH}/target/parquet-benchmarks.jar p*Write* "$@"


### PR DESCRIPTION
Here's a list of changes I did on the parquet-benchmarks module:
- Add variable to test PARQUET_1_0 format
- Add variable to generate random data for the tests
- Move part of the DataGenerator.generate() code to constructors so that we measure time when
  when writing data only.
- Add annotation to display AverageTime. The Throughput mode was always displaying less than 1 op/s. So I thought time was a better mode here.

@nezihyigitbasi @danielcweeks You did a good job starting the parquet-benchmarks module. Could you please review these changes?