### PR TITLE
PARQUET-152: Add validation on Encoding.DELTA_BYTE_ARRAY to allow FIX…

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java
@@ -19,6 +19,7 @@
 package org.apache.parquet.column;
 
 import static org.apache.parquet.column.values.bitpacking.Packer.BIG_ENDIAN;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
@@ -192,8 +193,8 @@ public enum Encoding {
     @Override
     public ValuesReader getValuesReader(ColumnDescriptor descriptor,
         ValuesType valuesType) {
-      if (descriptor.getType() != BINARY) {
-        throw new ParquetDecodingException("Encoding DELTA_BYTE_ARRAY is only supported for type BINARY");
+      if (descriptor.getType() != BINARY && descriptor.getType() != FIXED_LEN_BYTE_ARRAY) {
+        throw new ParquetDecodingException("Encoding DELTA_BYTE_ARRAY is only supported for type BINARY and FIXED_LEN_BYTE_ARRAY");
       }
       return new DeltaByteArrayReader();
     }


### PR DESCRIPTION
PARQUET-152: Add validation on Encoding.DELTA_BYTE_ARRAY to allow FIXED_LEN_BYTE_ARRAY types.

  * FIXED_LEN_BYTE_ARRAY types are binary values that may use DELTA_BYTE_ARRAY encoding,
    so they should be allowed to be decoded using the same DELTA_BYTE_ARRAY encoding.

@rdblue @nezihyigitbasi  Could you review this fix? 

I executed a test by writing a file that fall backs to DELTA_BYTE_ARRAY encoding, then read the file, and compare the read values with the written values, and it worked fine.