### PR TITLE
PARQUET-316: Fix the benchmark module 

### DIFF
--- a/parquet-benchmarks/README.md
+++ b/parquet-benchmarks/README.md
@@ -22,13 +22,13 @@
 First, build the ``parquet-benchmarks`` module
 
 ```
-mvn --projects parquet-benchmarks -amd -DskipTests -Denforcer.skip=true -P hadoop-2 clean package
+mvn --projects parquet-benchmarks -amd -DskipTests -Denforcer.skip=true clean package
 ```
 
 Then, you can run all the benchmarks with the following command
 
 ```
- ./parquet-benchmarks/run.sh -wi 5 -i 5 -f 3 -bm all
+./parquet-benchmarks/run.sh -wi 5 -i 5 -f 3 -bm all
 ```
 
 To understand what each command line argument means and for more arguments please see

--- a/parquet-benchmarks/run.sh
+++ b/parquet-benchmarks/run.sh
@@ -24,8 +24,8 @@ SCRIPT_PATH=$( cd "$(dirname "$0")" ; pwd -P )
 echo "Starting WRITE benchmarks"
 java -jar ${SCRIPT_PATH}/target/parquet-benchmarks.jar p*Write* "$@"
 echo "Generating test data"
-java -cp ${SCRIPT_PATH}/target/parquet-benchmarks.jar parquet.benchmarks.DataGenerator generate
+java -cp ${SCRIPT_PATH}/target/parquet-benchmarks.jar org.apache.parquet.benchmarks.DataGenerator generate
 echo "Data generated, starting READ benchmarks"
 java -jar ${SCRIPT_PATH}/target/parquet-benchmarks.jar p*Read* "$@"
 echo "Cleaning up generated data"
-java -cp ${SCRIPT_PATH}/target/parquet-benchmarks.jar parquet.benchmarks.DataGenerator cleanup
+java -cp ${SCRIPT_PATH}/target/parquet-benchmarks.jar org.apache.parquet.benchmarks.DataGenerator cleanup


### PR DESCRIPTION
`run.sh` is now broken with the packages renamed to `org.apache...` and also somehow the `hadoop-2` profile creates a jar file that doesn't include `/META-INF/BenchmarkList` -- a file that jmh needs:

```
Exception in thread "main" java.lang.RuntimeException: ERROR: Unable to find the resource: /META-INF/BenchmarkList
    at org.openjdk.jmh.runner.AbstractResourceReader.getReaders(AbstractResourceReader.java:96)
    at org.openjdk.jmh.runner.BenchmarkList.find(BenchmarkList.java:104)
    at org.openjdk.jmh.runner.Runner.internalRun(Runner.java:228)
    at org.openjdk.jmh.runner.Runner.run(Runner.java:178)
    at org.openjdk.jmh.Main.main(Main.java:66)
```