### PR TITLE
PARQUET-317: Fix writeMetadataFile crash when a relative root path is used

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -484,10 +484,9 @@ public class ParquetFileWriter {
    * @throws IOException
    */
   public static void writeMetadataFile(Configuration configuration, Path outputPath, List<Footer> footers) throws IOException {
-    Path qualifiedPath = FileSystem.get(configuration).makeQualified(outputPath);
-    ParquetMetadata metadataFooter = mergeFooters(qualifiedPath, footers);
     FileSystem fs = outputPath.getFileSystem(configuration);
     outputPath = outputPath.makeQualified(fs);
+    ParquetMetadata metadataFooter = mergeFooters(outputPath, footers);
     writeMetadataFile(outputPath, metadataFooter, fs, PARQUET_METADATA_FILE);
     metadataFooter.getBlocks().clear();
     writeMetadataFile(outputPath, metadataFooter, fs, PARQUET_COMMON_METADATA_FILE);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -484,7 +484,8 @@ public class ParquetFileWriter {
    * @throws IOException
    */
   public static void writeMetadataFile(Configuration configuration, Path outputPath, List<Footer> footers) throws IOException {
-    ParquetMetadata metadataFooter = mergeFooters(outputPath, footers);
+    Path qualifiedPath = FileSystem.get(configuration).makeQualified(outputPath);
+    ParquetMetadata metadataFooter = mergeFooters(qualifiedPath, footers);
     FileSystem fs = outputPath.getFileSystem(configuration);
     outputPath = outputPath.makeQualified(fs);
     writeMetadataFile(outputPath, metadataFooter, fs, PARQUET_METADATA_FILE);


### PR DESCRIPTION
This commit ensures the fully-qualified path is used prior to calling mergeFooters(..).