### PR TITLE
PARQUET-324: row count incorrect if data file has more than 2^31 rows

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -90,7 +90,7 @@ public class ParquetMetadataConverter {
   public static FileMetaData toParquetMetadata(int currentVersion, ParquetMetadata parquetMetadata) {
     List<BlockMetaData> blocks = parquetMetadata.getBlocks();
     List<RowGroup> rowGroups = new ArrayList<RowGroup>();
-    int numRows = 0;
+    long numRows = 0;
     for (BlockMetaData block : blocks) {
       numRows += block.getRowCount();
       addRowGroup(parquetMetadata, rowGroups, block);


### PR DESCRIPTION
Need to change numRows counter from int to long to account for input files with more than 2^31 rows.