### PR TITLE
PARQUET-325: Always use row group size when padding is 0.

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -685,6 +685,10 @@ public class ParquetFileWriter {
 
     @Override
     public long nextRowGroupSize(FSDataOutputStream out) throws IOException {
+      if (maxPaddingSize <= 0) {
+        return rowGroupSize;
+      }
+
       long remaining = dfsBlockSize - (out.getPos() % dfsBlockSize);
 
       if (isPaddingNeeded(remaining)) {


### PR DESCRIPTION
For block file systems, if the size left in the block is greater than
the max padding, a row group will be targeted at the remaining size.
However, when using 0 to turn padding off, the remaining bytes will
always be greater than padding and row groups can be targeted at very
tiny spaces. When padding is off, the next row group's size should
always be the default size.