### PR TITLE
PARQUET-246: File recovery and work-arounds

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/CorruptDeltaByteArrays.java
+++ b/parquet-column/src/main/java/org/apache/parquet/CorruptDeltaByteArrays.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet;
+
+import org.apache.parquet.VersionParser.ParsedVersion;
+
+public class CorruptDeltaByteArrays {
+  private static final Log LOG = Log.getLog(CorruptStatistics.class);
+
+  private static final SemanticVersion PARQUET_246_FIXED_VERSION =
+      new SemanticVersion(1, 8, 0);
+
+  public static boolean requireSequentialReads(ParsedVersion version) {
+    if (version == null) {
+      return true;
+    }
+
+    if (!"parquet-mr".equals(version.application)) {
+      // assume other applications don't have this bug
+      return false;
+    }
+
+    if (!version.hasSemanticVersion()) {
+      LOG.warn("Requiring sequential reads because created_by did not " +
+          "contain a valid version (see PARQUET-246): " + version.version);
+      return true;
+    }
+
+    return requireSequentialReads(version.getSemanticVersion());
+  }
+
+  public static boolean requireSequentialReads(SemanticVersion semver) {
+    if (semver == null) {
+      return true;
+    }
+
+    if (semver.compareTo(PARQUET_246_FIXED_VERSION) < 0) {
+      LOG.info("Requiring sequential reads because this file was created " +
+          "prior to " + PARQUET_246_FIXED_VERSION + ". See PARQUET-246" );
+      return true;
+    }
+
+    // this file was created after the fix
+    return false;
+  }
+
+  public static boolean requireSequentialReads(String createdBy) {
+    if (Strings.isNullOrEmpty(createdBy)) {
+      LOG.info("Requiring sequential reads because file version is empty. " +
+          "See PARQUET-246");
+      return true;
+    }
+
+    try {
+      return requireSequentialReads(VersionParser.parse(createdBy));
+
+    } catch (RuntimeException e) {
+      warnParseError(createdBy, e);
+      return true;
+    } catch (VersionParser.VersionParseException e) {
+      warnParseError(createdBy, e);
+      return true;
+    }
+  }
+
+  private static void warnParseError(String createdBy, Throwable e) {
+    LOG.warn("Requiring sequential reads because created_by could not be " +
+        "parsed (see PARQUET-246): " + createdBy, e);
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/CorruptStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/CorruptStatistics.java
@@ -64,12 +64,12 @@ public class CorruptStatistics {
         return false;
       }
 
-      if (Strings.isNullOrEmpty(version.semver)) {
+      if (Strings.isNullOrEmpty(version.version)) {
         LOG.warn("Ignoring statistics because created_by did not contain a semver (see PARQUET-251): " + createdBy);
         return true;
       }
 
-      SemanticVersion semver = SemanticVersion.parse(version.semver);
+      SemanticVersion semver = SemanticVersion.parse(version.version);
 
       if (semver.compareTo(PARQUET_251_FIXED_VERSION) < 0) {
         LOG.info("Ignoring statistics because this file was created prior to "

--- a/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java
@@ -26,6 +26,9 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
 
 import java.io.IOException;
 
+import org.apache.parquet.CorruptDeltaByteArrays;
+import org.apache.parquet.VersionParser;
+import org.apache.parquet.VersionParser.ParsedVersion;
 import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.values.ValuesReader;
@@ -49,6 +52,7 @@ import org.apache.parquet.column.values.plain.PlainValuesReader.IntegerPlainValu
 import org.apache.parquet.column.values.plain.PlainValuesReader.LongPlainValuesReader;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesReader;
 import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.io.api.Binary;
 
 /**
  * encoding of the data
@@ -198,6 +202,12 @@ public enum Encoding {
       }
       return new DeltaByteArrayReader();
     }
+
+    @Override
+    public boolean requiresSequentialReads(ParsedVersion version) {
+      return CorruptDeltaByteArrays.requireSequentialReads(version);
+    }
+
   },
 
   /**
@@ -289,4 +299,7 @@ public enum Encoding {
     throw new UnsupportedOperationException(this.name() + " is not dictionary based");
   }
 
+  public boolean requiresSequentialReads(ParsedVersion version) {
+    return false;
+  }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java
@@ -26,9 +26,6 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
 
 import java.io.IOException;
 
-import org.apache.parquet.CorruptDeltaByteArrays;
-import org.apache.parquet.VersionParser;
-import org.apache.parquet.VersionParser.ParsedVersion;
 import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.values.ValuesReader;
@@ -52,7 +49,6 @@ import org.apache.parquet.column.values.plain.PlainValuesReader.IntegerPlainValu
 import org.apache.parquet.column.values.plain.PlainValuesReader.LongPlainValuesReader;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesReader;
 import org.apache.parquet.io.ParquetDecodingException;
-import org.apache.parquet.io.api.Binary;
 
 /**
  * encoding of the data
@@ -202,12 +198,6 @@ public enum Encoding {
       }
       return new DeltaByteArrayReader();
     }
-
-    @Override
-    public boolean requiresSequentialReads(ParsedVersion version) {
-      return CorruptDeltaByteArrays.requireSequentialReads(version);
-    }
-
   },
 
   /**
@@ -299,7 +289,4 @@ public enum Encoding {
     throw new UnsupportedOperationException(this.name() + " is not dictionary based");
   }
 
-  public boolean requiresSequentialReads(ParsedVersion version) {
-    return false;
-  }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/RequiresPreviousReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/RequiresPreviousReader.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values;
+
+public interface RequiresPreviousReader {
+  void setPreviousReader(ValuesReader reader);
+}

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -60,10 +60,12 @@ public class MessageColumnIO extends GroupColumnIO {
   private List<PrimitiveColumnIO> leaves;
 
   private final boolean validating;
+  private final String createdBy;
 
-  MessageColumnIO(MessageType messageType, boolean validating) {
+  MessageColumnIO(MessageType messageType, boolean validating, String createdBy) {
     super(messageType, null, 0);
     this.validating = validating;
+    this.createdBy = createdBy;
   }
 
   public List<String[]> getColumnNames() {
@@ -113,7 +115,7 @@ public class MessageColumnIO extends GroupColumnIO {
             MessageColumnIO.this,
             filteringRecordMaterializer,
             validating,
-            new ColumnReadStoreImpl(columns, filteringRecordMaterializer.getRootConverter(), getType()));
+            new ColumnReadStoreImpl(columns, filteringRecordMaterializer.getRootConverter(), getType(), createdBy));
       }
 
       @Override
@@ -122,11 +124,10 @@ public class MessageColumnIO extends GroupColumnIO {
             MessageColumnIO.this,
             recordMaterializer,
             validating,
-            new ColumnReadStoreImpl(columns, recordMaterializer.getRootConverter(), getType()),
+            new ColumnReadStoreImpl(columns, recordMaterializer.getRootConverter(), getType(), createdBy),
             unboundRecordFilterCompat.getUnboundRecordFilter(),
             columns.getRowCount()
         );
-
       }
 
       @Override
@@ -135,7 +136,7 @@ public class MessageColumnIO extends GroupColumnIO {
             MessageColumnIO.this,
             recordMaterializer,
             validating,
-            new ColumnReadStoreImpl(columns, recordMaterializer.getRootConverter(), getType()));
+            new ColumnReadStoreImpl(columns, recordMaterializer.getRootConverter(), getType(), createdBy));
       }
     });
   }

--- a/parquet-column/src/test/java/org/apache/parquet/column/impl/TestColumnReaderImpl.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/impl/TestColumnReaderImpl.java
@@ -23,6 +23,8 @@ import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_
 
 import java.util.List;
 
+import org.apache.parquet.Version;
+import org.apache.parquet.VersionParser;
 import org.junit.Test;
 
 import org.apache.parquet.column.ColumnDescriptor;
@@ -52,7 +54,7 @@ public class TestColumnReaderImpl {
   }
 
   @Test
-  public void test() {
+  public void test() throws Exception {
     MessageType schema = MessageTypeParser.parseMessageType("message test { required binary foo; }");
     ColumnDescriptor col = schema.getColumns().get(0);
     MemPageWriter pageWriter = new MemPageWriter();
@@ -76,7 +78,7 @@ public class TestColumnReaderImpl {
     assertEquals(rows, valueCount);
     MemPageReader pageReader = new MemPageReader((long)rows, pages.iterator(), pageWriter.getDictionaryPage());
     ValidatingConverter converter = new ValidatingConverter();
-    ColumnReader columnReader = new ColumnReaderImpl(col, pageReader, converter);
+    ColumnReader columnReader = new ColumnReaderImpl(col, pageReader, converter, VersionParser.parse(Version.FULL_VERSION));
     for (int i = 0; i < rows; i++) {
       assertEquals(0, columnReader.getCurrentRepetitionLevel());
       assertEquals(0, columnReader.getCurrentDefinitionLevel());
@@ -87,7 +89,7 @@ public class TestColumnReaderImpl {
   }
 
   @Test
-  public void testOptional() {
+  public void testOptional() throws Exception {
     MessageType schema = MessageTypeParser.parseMessageType("message test { optional binary foo; }");
     ColumnDescriptor col = schema.getColumns().get(0);
     MemPageWriter pageWriter = new MemPageWriter();
@@ -111,7 +113,7 @@ public class TestColumnReaderImpl {
     assertEquals(rows, valueCount);
     MemPageReader pageReader = new MemPageReader((long)rows, pages.iterator(), pageWriter.getDictionaryPage());
     ValidatingConverter converter = new ValidatingConverter();
-    ColumnReader columnReader = new ColumnReaderImpl(col, pageReader, converter);
+    ColumnReader columnReader = new ColumnReaderImpl(col, pageReader, converter, VersionParser.parse(Version.FULL_VERSION));
     for (int i = 0; i < rows; i++) {
       assertEquals(0, columnReader.getCurrentRepetitionLevel());
       assertEquals(0, columnReader.getCurrentDefinitionLevel());

--- a/parquet-column/src/test/java/org/apache/parquet/column/impl/TestCorruptDeltaByteArrays.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/impl/TestCorruptDeltaByteArrays.java
@@ -49,22 +49,29 @@ import static org.junit.Assert.fail;
 public class TestCorruptDeltaByteArrays {
   @Test
   public void testCorruptDeltaByteArrayVerisons() {
-    assertTrue(CorruptDeltaByteArrays.requireSequentialReads("parquet-mr version 1.6.0 (build abcd)"));
-    assertTrue(CorruptDeltaByteArrays.requireSequentialReads((String) null));
-    assertTrue(CorruptDeltaByteArrays.requireSequentialReads((ParsedVersion) null));
-    assertTrue(CorruptDeltaByteArrays.requireSequentialReads((SemanticVersion) null));
-    assertTrue(CorruptDeltaByteArrays.requireSequentialReads("parquet-mr version 1.8.0-SNAPSHOT (build abcd)"));
-    assertFalse(CorruptDeltaByteArrays.requireSequentialReads("parquet-mr version 1.8.0 (build abcd)"));
+    assertTrue(CorruptDeltaByteArrays.requiresSequentialReads("parquet-mr version 1.6.0 (build abcd)", Encoding.DELTA_BYTE_ARRAY));
+    assertTrue(CorruptDeltaByteArrays.requiresSequentialReads((String) null, Encoding.DELTA_BYTE_ARRAY));
+    assertTrue(CorruptDeltaByteArrays.requiresSequentialReads((ParsedVersion) null, Encoding.DELTA_BYTE_ARRAY));
+    assertTrue(CorruptDeltaByteArrays.requiresSequentialReads((SemanticVersion) null, Encoding.DELTA_BYTE_ARRAY));
+    assertTrue(CorruptDeltaByteArrays.requiresSequentialReads("parquet-mr version 1.8.0-SNAPSHOT (build abcd)", Encoding.DELTA_BYTE_ARRAY));
+    assertFalse(CorruptDeltaByteArrays.requiresSequentialReads("parquet-mr version 1.6.0 (build abcd)", Encoding.DELTA_BINARY_PACKED));
+    assertFalse(CorruptDeltaByteArrays.requiresSequentialReads((String) null, Encoding.DELTA_LENGTH_BYTE_ARRAY));
+    assertFalse(CorruptDeltaByteArrays.requiresSequentialReads((ParsedVersion) null, Encoding.PLAIN));
+    assertFalse(CorruptDeltaByteArrays.requiresSequentialReads((SemanticVersion) null, Encoding.RLE));
+    assertFalse(CorruptDeltaByteArrays.requiresSequentialReads("parquet-mr version 1.8.0-SNAPSHOT (build abcd)", Encoding.RLE_DICTIONARY));
+    assertFalse(CorruptDeltaByteArrays.requiresSequentialReads("parquet-mr version 1.8.0-SNAPSHOT (build abcd)", Encoding.PLAIN_DICTIONARY));
+    assertFalse(CorruptDeltaByteArrays.requiresSequentialReads("parquet-mr version 1.8.0-SNAPSHOT (build abcd)", Encoding.BIT_PACKED));
+    assertFalse(CorruptDeltaByteArrays.requiresSequentialReads("parquet-mr version 1.8.0 (build abcd)", Encoding.DELTA_BYTE_ARRAY));
   }
 
   @Test
   public void testEncodingRequiresSequentailRead() {
     ParsedVersion impala = new ParsedVersion("impala", "1.2.0", "abcd");
-    assertFalse(Encoding.DELTA_BYTE_ARRAY.requiresSequentialReads(impala));
+    assertFalse(CorruptDeltaByteArrays.requiresSequentialReads(impala, Encoding.DELTA_BYTE_ARRAY));
     ParsedVersion broken = new ParsedVersion("parquet-mr", "1.8.0-SNAPSHOT", "abcd");
-    assertTrue(Encoding.DELTA_BYTE_ARRAY.requiresSequentialReads(broken));
+    assertTrue(CorruptDeltaByteArrays.requiresSequentialReads(broken, Encoding.DELTA_BYTE_ARRAY));
     ParsedVersion fixed = new ParsedVersion("parquet-mr", "1.8.0", "abcd");
-    assertFalse(Encoding.DELTA_BYTE_ARRAY.requiresSequentialReads(fixed));
+    assertFalse(CorruptDeltaByteArrays.requiresSequentialReads(fixed, Encoding.DELTA_BYTE_ARRAY));
   }
 
   @Test

--- a/parquet-column/src/test/java/org/apache/parquet/column/impl/TestCorruptDeltaByteArrays.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/impl/TestCorruptDeltaByteArrays.java
@@ -1,0 +1,252 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.impl;
+
+import org.apache.parquet.CorruptDeltaByteArrays;
+import org.apache.parquet.SemanticVersion;
+import org.apache.parquet.VersionParser.ParsedVersion;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.column.page.PageWriter;
+import org.apache.parquet.column.page.mem.MemPageStore;
+import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.deltastrings.DeltaByteArrayReader;
+import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.PrimitiveConverter;
+import org.apache.parquet.schema.PrimitiveType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TestCorruptDeltaByteArrays {
+  @Test
+  public void testCorruptDeltaByteArrayVerisons() {
+    assertTrue(CorruptDeltaByteArrays.requireSequentialReads("parquet-mr version 1.6.0 (build abcd)"));
+    assertTrue(CorruptDeltaByteArrays.requireSequentialReads((String) null));
+    assertTrue(CorruptDeltaByteArrays.requireSequentialReads((ParsedVersion) null));
+    assertTrue(CorruptDeltaByteArrays.requireSequentialReads((SemanticVersion) null));
+    assertTrue(CorruptDeltaByteArrays.requireSequentialReads("parquet-mr version 1.8.0-SNAPSHOT (build abcd)"));
+    assertFalse(CorruptDeltaByteArrays.requireSequentialReads("parquet-mr version 1.8.0 (build abcd)"));
+  }
+
+  @Test
+  public void testEncodingRequiresSequentailRead() {
+    ParsedVersion impala = new ParsedVersion("impala", "1.2.0", "abcd");
+    assertFalse(Encoding.DELTA_BYTE_ARRAY.requiresSequentialReads(impala));
+    ParsedVersion broken = new ParsedVersion("parquet-mr", "1.8.0-SNAPSHOT", "abcd");
+    assertTrue(Encoding.DELTA_BYTE_ARRAY.requiresSequentialReads(broken));
+    ParsedVersion fixed = new ParsedVersion("parquet-mr", "1.8.0", "abcd");
+    assertFalse(Encoding.DELTA_BYTE_ARRAY.requiresSequentialReads(fixed));
+  }
+
+  @Test
+  public void testReassemblyWithCorruptPage() throws Exception {
+    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(10, 100);
+
+    String lastValue = null;
+    for (int i = 0; i < 10; i += 1) {
+      lastValue = str(i);
+      writer.writeBytes(Binary.fromString(lastValue));
+    }
+    byte[] firstPageBytes = writer.getBytes().toByteArray();
+
+    writer.reset(); // sets previous to new byte[0]
+    corruptWriter(writer, lastValue);
+
+    for (int i = 10; i < 20; i += 1) {
+      writer.writeBytes(Binary.fromString(str(i)));
+    }
+    byte[] corruptPageBytes = writer.getBytes().toByteArray();
+
+    DeltaByteArrayReader firstPageReader = new DeltaByteArrayReader();
+    firstPageReader.initFromPage(10, firstPageBytes, 0);
+    for (int i = 0; i < 10; i += 1) {
+      assertEquals(firstPageReader.readBytes().toStringUsingUTF8(), str(i));
+    }
+
+    DeltaByteArrayReader corruptPageReader = new DeltaByteArrayReader();
+    corruptPageReader.initFromPage(10, corruptPageBytes, 0);
+    try {
+      corruptPageReader.readBytes();
+      fail("Corrupt page did not throw an exception when read");
+    } catch (ArrayIndexOutOfBoundsException e) {
+      // expected, this is a corrupt page
+    }
+
+    DeltaByteArrayReader secondPageReader = new DeltaByteArrayReader();
+    secondPageReader.initFromPage(10, corruptPageBytes, 0);
+    secondPageReader.setPreviousReader(firstPageReader);
+
+    for (int i = 10; i < 20; i += 1) {
+      assertEquals(secondPageReader.readBytes().toStringUsingUTF8(), str(i));
+    }
+  }
+
+  @Test
+  public void testReassemblyWithoutCorruption() throws Exception {
+    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(10, 100);
+
+    for (int i = 0; i < 10; i += 1) {
+      writer.writeBytes(Binary.fromString(str(i)));
+    }
+    byte[] firstPageBytes = writer.getBytes().toByteArray();
+
+    writer.reset(); // sets previous to new byte[0]
+
+    for (int i = 10; i < 20; i += 1) {
+      writer.writeBytes(Binary.fromString(str(i)));
+    }
+    byte[] secondPageBytes = writer.getBytes().toByteArray();
+
+    DeltaByteArrayReader firstPageReader = new DeltaByteArrayReader();
+    firstPageReader.initFromPage(10, firstPageBytes, 0);
+    for (int i = 0; i < 10; i += 1) {
+      assertEquals(firstPageReader.readBytes().toStringUsingUTF8(), str(i));
+    }
+
+    DeltaByteArrayReader secondPageReader = new DeltaByteArrayReader();
+    secondPageReader.initFromPage(10, secondPageBytes, 0);
+    secondPageReader.setPreviousReader(firstPageReader);
+
+    for (int i = 10; i < 20; i += 1) {
+      assertEquals(secondPageReader.readBytes().toStringUsingUTF8(), str(i));
+    }
+  }
+
+  @Test
+  public void testOldReassemblyWithoutCorruption() throws Exception {
+    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(10, 100);
+
+    for (int i = 0; i < 10; i += 1) {
+      writer.writeBytes(Binary.fromString(str(i)));
+    }
+    byte[] firstPageBytes = writer.getBytes().toByteArray();
+
+    writer.reset(); // sets previous to new byte[0]
+
+    for (int i = 10; i < 20; i += 1) {
+      writer.writeBytes(Binary.fromString(str(i)));
+    }
+    byte[] secondPageBytes = writer.getBytes().toByteArray();
+
+    DeltaByteArrayReader firstPageReader = new DeltaByteArrayReader();
+    firstPageReader.initFromPage(10, firstPageBytes, 0);
+    for (int i = 0; i < 10; i += 1) {
+      assertEquals(firstPageReader.readBytes().toStringUsingUTF8(), str(i));
+    }
+
+    DeltaByteArrayReader secondPageReader = new DeltaByteArrayReader();
+    secondPageReader.initFromPage(10, secondPageBytes, 0);
+
+    for (int i = 10; i < 20; i += 1) {
+      assertEquals(secondPageReader.readBytes().toStringUsingUTF8(), str(i));
+    }
+  }
+
+  @Test
+  public void testColumnReaderImplWithCorruptPage() throws Exception {
+    ColumnDescriptor column = new ColumnDescriptor(
+        new String[] {"s"}, PrimitiveType.PrimitiveTypeName.BINARY, 0, 0);
+    MemPageStore pages = new MemPageStore(0);
+    PageWriter memWriter = pages.getPageWriter(column);
+
+    // get generic repetition and definition level bytes to use for pages
+    ValuesWriter rdValues = ParquetProperties
+        .getColumnDescriptorValuesWriter(0, 10, 100);
+    for (int i = 0; i < 10; i += 1) {
+      rdValues.writeInteger(0);
+    }
+    // use a byte array backed BytesInput because it is reused
+    BytesInput rd = BytesInput.from(rdValues.getBytes().toByteArray());
+    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(10, 100);
+    String lastValue = null;
+    List<String> values = new ArrayList<String>();
+    for (int i = 0; i < 10; i += 1) {
+      lastValue = str(i);
+      writer.writeBytes(Binary.fromString(lastValue));
+      values.add(lastValue);
+    }
+
+    memWriter.writePage(BytesInput.concat(rd, rd, writer.getBytes()),
+        10, /* number of values in the page */
+        new BinaryStatistics(),
+        rdValues.getEncoding(),
+        rdValues.getEncoding(),
+        writer.getEncoding());
+    pages.addRowCount(10);
+
+    writer.reset(); // sets previous to new byte[0]
+    corruptWriter(writer, lastValue);
+    for (int i = 10; i < 20; i += 1) {
+      String value = str(i);
+      writer.writeBytes(Binary.fromString(value));
+      values.add(value);
+    }
+
+    memWriter.writePage(BytesInput.concat(rd, rd, writer.getBytes()),
+        10, /* number of values in the page */
+        new BinaryStatistics(),
+        rdValues.getEncoding(),
+        rdValues.getEncoding(),
+        writer.getEncoding());
+    pages.addRowCount(10);
+
+    final List<String> actualValues = new ArrayList<String>();
+    PrimitiveConverter converter = new PrimitiveConverter() {
+      @Override
+      public void addBinary(Binary value) {
+        actualValues.add(value.toStringUsingUTF8());
+      }
+    };
+
+    ColumnReaderImpl columnReader = new ColumnReaderImpl(
+        column, pages.getPageReader(column), converter,
+        new ParsedVersion("parquet-mr", "1.6.0", "abcd"));
+
+    while (actualValues.size() < columnReader.getTotalValueCount()) {
+      columnReader.writeCurrentValueToConverter();
+      columnReader.consume();
+    }
+
+    Assert.assertEquals(values, actualValues);
+  }
+
+  public void corruptWriter(DeltaByteArrayWriter writer, String data) throws Exception {
+    Field previous = writer.getClass().getDeclaredField("previous");
+    previous.setAccessible(true);
+    previous.set(writer, Binary.fromString(data).getBytesUnsafe());
+  }
+
+  public String str(int i) {
+    char c = 'a';
+    return "aaaaaaaaaaa" + (char) (c + i);
+  }
+}

--- a/parquet-column/src/test/java/org/apache/parquet/column/mem/TestMemColumn.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/mem/TestMemColumn.java
@@ -67,7 +67,8 @@ public class TestMemColumn {
     return new ColumnReadStoreImpl(
         memPageStore,
         new DummyRecordConverter(schema).getRootConverter(),
-        schema
+        schema,
+        null
         ).getColumnReader(path);
   }
 

--- a/parquet-common/src/test/java/org/apache/parquet/SemanticVersionTest.java
+++ b/parquet-common/src/test/java/org/apache/parquet/SemanticVersionTest.java
@@ -41,13 +41,17 @@ public class SemanticVersionTest {
     assertTrue(new SemanticVersion(2, 0, 0).compareTo(new SemanticVersion(1, 0, 0)) > 0);
 
     assertTrue(new SemanticVersion(1, 8, 100).compareTo(new SemanticVersion(1, 9, 0)) < 0);
+
+    assertTrue(new SemanticVersion(1, 8, 0).compareTo(new SemanticVersion(1, 8, 0, true)) > 0);
+    assertTrue(new SemanticVersion(1, 8, 0, true).compareTo(new SemanticVersion(1, 8, 0, true)) == 0);
+    assertTrue(new SemanticVersion(1, 8, 0, true).compareTo(new SemanticVersion(1, 8, 0)) < 0);
   }
 
   @Test
   public void testParse() throws Exception {
     assertEquals(new SemanticVersion(1, 8, 0), SemanticVersion.parse("1.8.0"));
-    assertEquals(new SemanticVersion(1, 8, 0), SemanticVersion.parse("1.8.0rc3"));
-    assertEquals(new SemanticVersion(1, 8, 0), SemanticVersion.parse("1.8.0rc3-SNAPSHOT"));
-    assertEquals(new SemanticVersion(1, 8, 0), SemanticVersion.parse("1.8.0-SNAPSHOT"));
+    assertEquals(new SemanticVersion(1, 8, 0, true), SemanticVersion.parse("1.8.0rc3"));
+    assertEquals(new SemanticVersion(1, 8, 0, true), SemanticVersion.parse("1.8.0rc3-SNAPSHOT"));
+    assertEquals(new SemanticVersion(1, 8, 0, true), SemanticVersion.parse("1.8.0-SNAPSHOT"));
   }
 }

--- a/parquet-common/src/test/java/org/apache/parquet/VersionTest.java
+++ b/parquet-common/src/test/java/org/apache/parquet/VersionTest.java
@@ -18,16 +18,11 @@
  */
 package org.apache.parquet;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.parquet.VersionParser.ParsedVersion;
 import org.apache.parquet.VersionParser.VersionParseException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -55,8 +50,8 @@ public class VersionTest {
   public void testFullVersion() throws Exception {
     ParsedVersion version = VersionParser.parse(Version.FULL_VERSION);
 
-    assertVersionValid(version.semver);
-    assertEquals(Version.VERSION_NUMBER, version.semver);
+    assertVersionValid(version.version);
+    assertEquals(Version.VERSION_NUMBER, version.version);
     assertEquals("parquet-mr", version.application);
   }
   

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
@@ -57,7 +57,7 @@ import static org.apache.parquet.hadoop.ParquetInputFormat.STRICT_TYPE_CHECKING;
 class InternalParquetRecordReader<T> {
   private static final Log LOG = Log.getLog(InternalParquetRecordReader.class);
 
-  private final ColumnIOFactory columnIOFactory = new ColumnIOFactory();
+  private ColumnIOFactory columnIOFactory = null;
   private final Filter filter;
 
   private MessageType requestedSchema;
@@ -171,6 +171,7 @@ class InternalParquetRecordReader<T> {
     Map<String, String> fileMetadata = parquetFileMetadata.getKeyValueMetaData();
     ReadSupport.ReadContext readContext = readSupport.init(new InitContext(
         configuration, toSetMultiMap(fileMetadata), fileSchema));
+    this.columnIOFactory = new ColumnIOFactory(parquetFileMetadata.getCreatedBy());
     this.requestedSchema = readContext.getRequestedSchema();
     this.fileSchema = fileSchema;
     this.file = file;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.parquet.Log;
-import org.apache.parquet.Version;
 import org.apache.parquet.column.ColumnWriteStore;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.ParquetProperties.WriterVersion;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.parquet.Log;
+import org.apache.parquet.Version;
 import org.apache.parquet.column.ColumnWriteStore;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.ParquetProperties.WriterVersion;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -120,6 +120,11 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
    */
   public static final String TASK_SIDE_METADATA = "parquet.task.side.metadata";
 
+  /**
+   * key to turn off file splitting. See PARQUET-246.
+   */
+  public static final String SPLIT_FILES = "parquet.split.files";
+
   private static final int MIN_FOOTER_CACHE_SIZE = 100;
 
   public static void setTaskSideMetaData(Job job,  boolean taskSideMetadata) {
@@ -278,6 +283,11 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
     } catch (IllegalAccessException e) {
       throw new BadConfigurationException("could not instantiate read support class", e);
     }
+  }
+
+  @Override
+  protected boolean isSplitable(JobContext context, Path filename) {
+    return ContextUtil.getConfiguration(context).getBoolean(SPLIT_FILES, true);
   }
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordReader.java
@@ -22,6 +22,7 @@ import static org.apache.parquet.filter2.compat.RowGroupFilter.filterRowGroups;
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.range;
 import static org.apache.parquet.hadoop.ParquetFileReader.readFooter;
+import static org.apache.parquet.hadoop.ParquetInputFormat.SPLIT_FILES;
 import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
 
 import java.io.IOException;
@@ -29,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
@@ -41,15 +41,20 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.TaskInputOutputContext;
 
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.parquet.CorruptDeltaByteArrays;
 import org.apache.parquet.Log;
+import org.apache.parquet.column.Encoding;
 import org.apache.parquet.filter.UnboundRecordFilter;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.compat.FilterCompat.Filter;
 import org.apache.parquet.hadoop.api.ReadSupport;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.util.ContextUtil;
 import org.apache.parquet.hadoop.util.counters.BenchmarkCounter;
+import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.MessageType;
 
 /**
@@ -187,9 +192,28 @@ public class ParquetRecordReader<T> extends RecordReader<Void, T> {
             + " in range " + split.getStart() + ", " + split.getEnd());
       }
     }
+
+    checkDeltaByteArrayProblem(footer.getFileMetaData(), configuration, filteredBlocks.get(0));
+
     MessageType fileSchema = footer.getFileMetaData().getSchema();
     internalReader.initialize(
         fileSchema, footer.getFileMetaData(), path, filteredBlocks, configuration);
+  }
+
+  private void checkDeltaByteArrayProblem(FileMetaData meta, Configuration conf, BlockMetaData block) {
+    // splitting files but required to read sequentially?
+    if (CorruptDeltaByteArrays.requireSequentialReads(meta.getCreatedBy()) &&
+        conf.getBoolean(ParquetInputFormat.SPLIT_FILES, true)) {
+      // this is okay if not using DELTA_BYTE_ARRAY
+      Set<Encoding> encodings = new HashSet<Encoding>();
+      for (ColumnChunkMetaData column : block.getColumns()) {
+        encodings.addAll(column.getEncodings());
+      }
+      if (encodings.contains(Encoding.DELTA_BYTE_ARRAY)) {
+        throw new ParquetDecodingException("Cannot read data due to " +
+            "PARQUET-246: to read safely, set " + SPLIT_FILES + " to false");
+      }
+    }
   }
 
   /**

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -24,7 +24,11 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.CorruptStatistics;
+import org.apache.parquet.Version;
+import org.apache.parquet.VersionParser;
 import org.apache.parquet.bytes.BytesUtils;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.apache.parquet.Log;
@@ -50,6 +54,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
+import static org.apache.parquet.CorruptStatistics.shouldIgnoreStatistics;
 import static org.apache.parquet.hadoop.ParquetFileWriter.Mode.OVERWRITE;
 import static org.junit.Assert.*;
 import static org.apache.parquet.column.Encoding.BIT_PACKED;
@@ -438,6 +443,9 @@ public class TestParquetFileWriter {
 
   @Test
   public void testWriteReadStatistics() throws Exception {
+    // this test assumes statistics will be read
+    Assume.assumeTrue(!shouldIgnoreStatistics(Version.FULL_VERSION, BINARY));
+
     File testFile = temp.newFile();
     testFile.delete();
 
@@ -568,6 +576,9 @@ public class TestParquetFileWriter {
 
   @Test
   public void testWriteReadStatisticsAllNulls() throws Exception {
+    // this test assumes statistics will be read
+    Assume.assumeTrue(!shouldIgnoreStatistics(Version.FULL_VERSION, BINARY));
+
     File testFile = temp.newFile();
     testFile.delete();
 

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/DumpCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/DumpCommand.java
@@ -216,7 +216,9 @@ public class DumpCommand extends ArgsOnlyCommand {
                         conf, meta.getFileMetaData(), inpath, blocks, Collections.singletonList(column));
                     PageReadStore store = freader.readNextRowGroup();
                     while (store != null) {
-                        ColumnReadStoreImpl crstore = new ColumnReadStoreImpl(store, new DumpGroupConverter(), schema);
+                        ColumnReadStoreImpl crstore = new ColumnReadStoreImpl(
+                            store, new DumpGroupConverter(), schema,
+                            meta.getFileMetaData().getCreatedBy());
                         dump(out, crstore, column, page++, total, offset);
 
                         offset += store.getRowCount();

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,8 @@
                      <exclude>org/apache/parquet/thrift/ThriftSchemaConvertVisitor</exclude> <!-- not public -->
                      <exclude>org/apache/parquet/avro/AvroParquetReader</exclude> <!-- returns subclass of old return class -->
                      <exclude>org/apache/parquet/avro/SpecificDataSupplier</exclude> <!-- made public -->
+                     <exclude>org/apache/parquet/io/ColumnIOFactory$ColumnIOCreatorVisitor</exclude> <!-- removed non-API class -->
+                     <exclude>org/apache/parquet/io/ColumnIOFactory/**</exclude> <!-- removed non-API class and methods-->
                    </excludes>
                  </requireBackwardCompatibility>
                </rules>


### PR DESCRIPTION
This is another way to recover data written with the delta byte array problem in PARQUET-246. This builds on @isnotinvain's strategy for solving the problem by adding a method to the encoding to detect it. This version is more similar to the fix for PARQUET-251 and includes a CorruptDeltaByteArrays helper class that uses the writer version. Most of the file changes are to get the file writer version to Encoding and the ColumnReaderImpl.

This also repairs the problem by using a new interface, RequiresPreviousReader, to pass the previous ValuesReader, which is slightly cleaner because the reader doesn't need to expose getter and setter methods.

The problem affects pages written to different row groups, so it was necessary to detect the problem in parquet-hadoop and fail jobs that cannot reconstruct data. The work-around to recover is to set "parquet.split.files" to false so that files are read sequentially. This could be set automatically in isSplittable, but this would require reading all file footers before submitting jobs, which was recently fixed. I think it is a fair compromise to detect the error case and recommend a solution.

This also includes tests for the problem to verify the fix.

Replaces old pull requests: closes #217 closes #235 