### PR TITLE
PARQUET-335: Remove Avro check for MAP_KEY_VALUE.

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
@@ -303,7 +303,6 @@ public class AvroSchemaConverter {
             }
             GroupType mapKeyValType = parquetGroupType.getType(0).asGroupType();
             if (!mapKeyValType.isRepetition(Type.Repetition.REPEATED) ||
-                !mapKeyValType.getOriginalType().equals(OriginalType.MAP_KEY_VALUE) ||
                 mapKeyValType.getFieldCount()!=2) {
               throw new UnsupportedOperationException("Invalid map type " + parquetGroupType);
             }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
@@ -21,6 +21,7 @@ package org.apache.parquet.avro;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import java.util.Arrays;
+import java.util.Collections;
 import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.codehaus.jackson.node.NullNode;
@@ -390,6 +391,25 @@ public class TestAvroSchemaConverter {
         "    }\n" +
         "  }\n" +
         "}\n");
+  }
+
+  @Test
+  public void testParquetMapWithoutMapKeyValueAnnotation() throws Exception {
+    Schema schema = Schema.createRecord("myrecord", null, null, false);
+    Schema map = Schema.createMap(Schema.create(Schema.Type.INT));
+    schema.setFields(Collections.singletonList(new Schema.Field("mymap", map, null, null)));
+    String parquetSchema =
+        "message myrecord {\n" +
+            "  required group mymap (MAP) {\n" +
+            "    repeated group map {\n" +
+            "      required binary key (UTF8);\n" +
+            "      required int32 value;\n" +
+            "    }\n" +
+            "  }\n" +
+            "}\n";
+
+    testParquetToAvroConversion(schema, parquetSchema);
+    testParquetToAvroConversion(NEW_BEHAVIOR, schema, parquetSchema);
   }
 
   public static Schema optional(Schema original) {


### PR DESCRIPTION
This is not required by the map type spec. This does not affect data
written by the Avro object model because this bug is in the conversion
from a Parquet schema to an Avro schema. Files written with parquet-avro
do not convert the underlying schema because they use the Avro schema.