### PR TITLE
PARQUET-338: Fix pull request example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ To contribute a patch:
 
   1. Break your work into small, single-purpose patches if possible. It’s much harder to merge in a large change with a lot of disjoint features.
   2. Create a JIRA for your patch on the [Parquet Project JIRA](https://issues.apache.org/jira/browse/PARQUET).
-  3. Submit the patch as a GitHub pull request against the master branch. For a tutorial, see the GitHub guides on forking a repo and sending a pull request. Prefix your pull request name with the JIRA name (ex: https://github.com/apache/parquet-mr/pull/117).
+  3. Submit the patch as a GitHub pull request against the master branch. For a tutorial, see the GitHub guides on forking a repo and sending a pull request. Prefix your pull request name with the JIRA name (ex: https://github.com/apache/parquet-mr/pull/240).
   4. Make sure that your code passes the unit tests. You can run the tests with `mvn test` in the root directory. 
   5. Add new unit tests for your code. 
 


### PR DESCRIPTION
The example PR has the wrong format, it uses [PARQUET-123] instead of PARQUET-123: 