### PR TITLE
PARQUET-340: MemoryManager: max memory can be truncated

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/MemoryManager.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/MemoryManager.java
@@ -57,7 +57,7 @@ public class MemoryManager {
 
     memoryPoolRatio = ratio;
     minMemoryAllocation = minAllocation;
-    totalMemoryPool = Math.round(ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax
+    totalMemoryPool = Math.round((double) ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax
         () * ratio);
     LOG.debug(String.format("Allocated total memory pool is: %,d", totalMemoryPool));
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestMemoryManager.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestMemoryManager.java
@@ -54,7 +54,7 @@ public class TestMemoryManager {
   @Before
   public void setUp() {
     GroupWriteSupport.setSchema(MessageTypeParser.parseMessageType(writeSchema),conf);
-    expectPoolSize = Math.round(ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax
+    expectPoolSize = Math.round((double) ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax
         () * MemoryManager.DEFAULT_MEMORY_POOL_RATIO);
     rowGroupSize = (int) Math.floor(expectPoolSize / 2);
     conf.setInt(ParquetOutputFormat.BLOCK_SIZE, rowGroupSize);


### PR DESCRIPTION
Using float will cause the max heap limit to be limited to 2147483647
due to math.round(float) if used with a large heap. This should be a double
precision to prevent rounding to an int32 before storing into a long.