### PR TITLE
PARQUET-343 Caching nulls on group node to improve write performance on wide schema sparse data

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -52,9 +52,7 @@ import static org.apache.parquet.Preconditions.checkNotNull;
 /**
  * Message level of the IO structure
  *
- *
  * @author Julien Le Dem
- *
  */
 public class MessageColumnIO extends GroupColumnIO {
   private static final Log logger = Log.getLog(MessageColumnIO.class);
@@ -484,6 +482,6 @@ public class MessageColumnIO extends GroupColumnIO {
 
   @Override
   public MessageType getType() {
-    return (MessageType)super.getType();
+    return (MessageType) super.getType();
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -185,14 +185,17 @@ public class MessageColumnIO extends GroupColumnIO {
       GroupColumnIO  parent = primitive.getParent();
       do {
         getLeafWriters(parent).add(writer);
-      } while ((parent = parent.getParent()) != null);
+        parent = parent.getParent();
+      } while (parent != null);
     }
 
     private List<ColumnWriter> getLeafWriters(GroupColumnIO group) {
-      if (!groupToLeafWriter.containsKey(group)) {
-        groupToLeafWriter.put(group, new ArrayList<ColumnWriter>());
+      List<ColumnWriter> writers = groupToLeafWriter.get(group);
+      if (writers == null) {
+        writers = new ArrayList<ColumnWriter>();
+        groupToLeafWriter.put(group, writers);
       }
-      return groupToLeafWriter.get(group);
+      return writers;
     }
 
     public MessageColumnIORecordConsumer(ColumnWriteStore columns) {

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -30,6 +30,7 @@ import org.apache.parquet.column.ColumnWriteStore;
 import org.apache.parquet.column.ColumnWriter;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
 import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.example.data.simple.Primitive;
 import org.apache.parquet.filter.UnboundRecordFilter;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.compat.FilterCompat.Filter;

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -320,7 +320,7 @@ public class MessageColumnIO extends GroupColumnIO {
 
     private List<NullValue> nullListFor(GroupColumnIO group) {
       if (!groupPreviousNullCount.containsKey(group)){
-        groupPreviousNullCount.put(group,new LinkedList<NullValue>());
+        groupPreviousNullCount.put(group,new ArrayList<NullValue>());
       }
       return groupPreviousNullCount.get(group);
     }

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -52,6 +52,7 @@ import static org.apache.parquet.Preconditions.checkNotNull;
 /**
  * Message level of the IO structure
  *
+ *
  * @author Julien Le Dem
  */
 public class MessageColumnIO extends GroupColumnIO {
@@ -174,13 +175,19 @@ public class MessageColumnIO extends GroupColumnIO {
     private final FieldsMarker[] fieldsWritten;
     private final int[] r;
     private final ColumnWriter[] columnWriter;
+
     /**
-     * maintain a map of a group and all the leaf nodes underneath it. It's used to optimize writing null for a group node
-     * all the leaves can be called directly without traversing the sub tree of the group node
+     * maintain a map of groups and all the leaf nodes underneath it. It's used to optimize writing null for a group node.
+     * Instead of using recursion calls, all the leaves can be called directly without traversing the sub tree of the group node
      */
     private Map<GroupColumnIO, List<ColumnWriter>> groupToLeafWriter = new HashMap<GroupColumnIO, List<ColumnWriter>>();
 
     /**
+     * To improve null writing performance, we cache nulls on group node. We flush nulls when a
+     * non-null value hits the group node.
+     *
+     * Intuitively, when we encounter a group node that is null, all the leaves underneath it should be null
+     *
      * cache the nulls for a group node. It only stores the repetition level, since the definition level
      * should always be the definition level of the parent node
      */

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -185,17 +185,14 @@ public class MessageColumnIO extends GroupColumnIO {
       GroupColumnIO  parent = primitive.getParent();
       do {
         getLeafWriters(parent).add(writer);
-        parent = parent.getParent();
-      } while (parent != null);
+      } while ((parent = parent.getParent()) != null);
     }
 
     private List<ColumnWriter> getLeafWriters(GroupColumnIO group) {
-      List<ColumnWriter> writers = groupToLeafWriter.get(group);
-      if (writers == null) {
-        writers = new ArrayList<ColumnWriter>();
-        groupToLeafWriter.put(group, writers);
+      if (!groupToLeafWriter.containsKey(group)) {
+        groupToLeafWriter.put(group, new ArrayList<ColumnWriter>());
       }
-      return writers;
+      return groupToLeafWriter.get(group);
     }
 
     public MessageColumnIORecordConsumer(ColumnWriteStore columns) {

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -180,16 +180,6 @@ public class MessageColumnIO extends GroupColumnIO {
      */
     private Map<GroupColumnIO, List<ColumnWriter>> groupToLeafWriter = new HashMap<GroupColumnIO, List<ColumnWriter>>();
 
-    class NullValue {
-      int r;
-      int d;
-
-      public NullValue(int r, int d) {
-        this.r = r;
-        this.d = d;
-      }
-    }
-
     /**
      * cache the nulls for a group node. It only stores the repetition level, since the definition level
      * should always be the definition level of the parent node

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -379,9 +379,11 @@ public class MessageColumnIO extends GroupColumnIO {
     public void startGroup() {
       if (DEBUG) log("startGroup()");
       GroupColumnIO group = (GroupColumnIO) currentColumnIO;
+
       // current group is not null, need to flush all the nulls that were cached before
-      if (hasNullCache(group))
+      if (hasNullCache(group)) {
         flushCachedNulls(group);
+      }
 
       ++currentLevel;
       r[currentLevel] = r[currentLevel - 1];

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -331,9 +331,10 @@ public class MessageColumnIO extends GroupColumnIO {
       if (nullValues == null || nullValues.isEmpty())
         return;
 
+      int parentDefinitionLevel = group.getParent().getDefinitionLevel();
       for(ColumnWriter leafWriter: groupToLeafWriter.get(group)) {
         for(int n:groupPreviousNullCount.get(group)) {
-          leafWriter.writeNull(n, group.getDefinitionLevel());
+          leafWriter.writeNull(n, parentDefinitionLevel);
         }
       }
     }

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -345,10 +345,12 @@ public class MessageColumnIO extends GroupColumnIO {
     }
 
     private void cacheNullForGroup(GroupColumnIO group, int r) {
-      if (!groupNullCache.containsKey(group)) {
-        groupNullCache.put(group, new IntArrayList());
+      IntArrayList nulls = groupNullCache.get(group);
+      if (nulls == null) {
+        nulls = new IntArrayList();
+        groupNullCache.put(group, nulls);
       }
-      groupNullCache.get(group).add(r);
+      nulls.add(r);
     }
 
     private void writeNullToLeaves(GroupColumnIO group) {

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -318,6 +318,13 @@ public class MessageColumnIO extends GroupColumnIO {
       groupPreviousNullCount.get(group).add(new NullValue(r,d));
     }
 
+    private List<NullValue> nullListFor(GroupColumnIO group) {
+      if (!groupPreviousNullCount.containsKey(group)){
+        groupPreviousNullCount.put(group,new LinkedList<NullValue>());
+      }
+      return groupPreviousNullCount.get(group);
+    }
+
     private void writeNullForGroupChildren(GroupColumnIO group) {
       List<NullValue> nullValues = groupPreviousNullCount.get(group);
       if (nullValues == null || nullValues.isEmpty())
@@ -338,7 +345,8 @@ public class MessageColumnIO extends GroupColumnIO {
     @Override
     public void startGroup() {
       if (DEBUG) log("startGroup()");
-      flushNullForGroup((GroupColumnIO)currentColumnIO);
+      if (!nullListFor((GroupColumnIO)currentColumnIO).isEmpty())
+        flushNullForGroup((GroupColumnIO)currentColumnIO);
       ++ currentLevel;
       r[currentLevel] = r[currentLevel - 1];
 

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -30,6 +30,7 @@ import org.apache.parquet.column.ColumnWriteStore;
 import org.apache.parquet.column.ColumnWriter;
 import org.apache.parquet.column.impl.ColumnReadStoreImpl;
 import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.column.values.dictionary.IntList;
 import org.apache.parquet.filter.UnboundRecordFilter;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.compat.FilterCompat.Filter;
@@ -47,6 +48,7 @@ import org.apache.parquet.io.api.RecordMaterializer;
 import org.apache.parquet.schema.MessageType;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntIterator;
 import static org.apache.parquet.Preconditions.checkNotNull;
 
 /**
@@ -360,7 +362,8 @@ public class MessageColumnIO extends GroupColumnIO {
 
       int parentDefinitionLevel = group.getParent().getDefinitionLevel();
       for (ColumnWriter leafWriter : groupToLeafWriter.get(group)) {
-        for (int repetitionLevel : groupNullCache.get(group)) {
+        for (IntIterator iter = nullCache.iterator(); iter.hasNext();) {
+          int repetitionLevel = iter.nextInt();
           leafWriter.writeNull(repetitionLevel, parentDefinitionLevel);
         }
       }

--- a/parquet-column/src/main/java/org/apache/parquet/io/ValidatingRecordConsumer.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/ValidatingRecordConsumer.java
@@ -126,6 +126,10 @@ public class ValidatingRecordConsumer extends RecordConsumer {
     types.pop();
     previousField.pop();
   }
+  @Override
+  public void flush(){
+    delegate.flush();
+  }
 
   private void validate(PrimitiveTypeName p) {
     Type currentType = types.peek().asGroupType().getType(fields.peek());

--- a/parquet-column/src/main/java/org/apache/parquet/io/api/RecordConsumer.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/RecordConsumer.java
@@ -125,4 +125,10 @@ abstract public class RecordConsumer {
    */
   abstract public void addDouble(double value);
 
+  /**
+   * no op by default
+   */
+  public void flush() {
+  }
+
 }

--- a/parquet-column/src/main/java/org/apache/parquet/io/api/RecordConsumer.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/RecordConsumer.java
@@ -126,7 +126,8 @@ abstract public class RecordConsumer {
   abstract public void addDouble(double value);
 
   /**
-   * no op by default
+   * NoOps by default
+   * Subclass class can implement its own flushing logic
    */
   public void flush() {
   }

--- a/parquet-column/src/test/java/org/apache/parquet/io/TestFiltered.java
+++ b/parquet-column/src/test/java/org/apache/parquet/io/TestFiltered.java
@@ -21,6 +21,7 @@ package org.apache.parquet.io;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.parquet.io.api.RecordConsumer;
 import org.junit.Test;
 
 import org.apache.parquet.column.ParquetProperties.WriterVersion;
@@ -259,11 +260,13 @@ public class TestFiltered {
     MemPageStore memPageStore = new MemPageStore(number * 2);
     ColumnWriteStoreV1 columns = new ColumnWriteStoreV1(memPageStore, 800, 800, false, WriterVersion.PARQUET_1_0);
 
-    GroupWriter groupWriter = new GroupWriter(columnIO.getRecordWriter(columns), schema);
+    RecordConsumer recordWriter = columnIO.getRecordWriter(columns);
+    GroupWriter groupWriter = new GroupWriter(recordWriter, schema);
     for ( int i = 0; i < number; i++ ) {
       groupWriter.write(r1);
       groupWriter.write(r2);
     }
+    recordWriter.flush();
     columns.flush();
     return memPageStore;
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
@@ -62,7 +62,6 @@ class InternalParquetRecordReader<T> {
 
   private MessageType requestedSchema;
   private MessageType fileSchema;
-  private MessageColumnIO columnIO;
   private int columnCount;
   private final ReadSupport<T> readSupport;
 
@@ -137,6 +136,7 @@ class InternalParquetRecordReader<T> {
       BenchmarkCounter.incrementTime(timeSpentReading);
       if (Log.INFO) LOG.info("block read in memory in " + timeSpentReading + " ms. row count = " + pages.getRowCount());
       if (Log.DEBUG) LOG.debug("initializing Record assembly with requested schema " + requestedSchema);
+      MessageColumnIO columnIO = columnIOFactory.getColumnIO(requestedSchema, fileSchema, strictTypeChecking);
       recordReader = columnIO.getRecordReader(pages, recordConverter, filter);
       startedAssemblingCurrentBlockAt = System.currentTimeMillis();
       totalCountLoadedSoFar += pages.getRowCount();
@@ -174,7 +174,6 @@ class InternalParquetRecordReader<T> {
     this.columnIOFactory = new ColumnIOFactory(parquetFileMetadata.getCreatedBy());
     this.requestedSchema = readContext.getRequestedSchema();
     this.fileSchema = fileSchema;
-    this.columnIO = columnIOFactory.getColumnIO(requestedSchema, fileSchema, strictTypeChecking);
     this.file = file;
     this.columnCount = requestedSchema.getPaths().size();
     this.recordConverter = readSupport.prepareForRead(

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestParquetReadProtocol.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestParquetReadProtocol.java
@@ -154,6 +154,7 @@ public class TestParquetReadProtocol {
     ParquetWriteProtocol parquetWriteProtocol = new ParquetWriteProtocol(recordWriter, columnIO, thriftType);
 
     expected.write(parquetWriteProtocol);
+    recordWriter.flush();
     columns.flush();
 
     ThriftRecordConverter<T> converter = new TBaseRecordConverter<T>(thriftClass, schema, thriftType);


### PR DESCRIPTION
For really wide schema with sparse data, If a group node is empty, it could have a huge number of leaves underneath it. Calling writeMull for each leaf every time when it's ancestor group node is null is in-effcient and is bad for data locality in the memory especially when the number of leaves is huge.

Instead, null can be cached on the group node. Flushing is only triggered when a group node becomes non-null from null. This way, all the cached null values will be flushed to the leaf nodes in a tight loop and improves write performance.

We tested this approach combined with PARQUET-341 on a really large schema and gave us ~2X improvement on write performance