### PR TITLE
PARQUET-344: Limit the number of rows per block and per split

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -50,6 +50,7 @@ class InternalParquetRecordWriter<T> {
   private final MessageType schema;
   private final Map<String, String> extraMetaData;
   private final long rowGroupSize;
+  private final long rowGroupMaxRowCount;
   private long rowGroupSizeThreshold;
   private long nextRowGroupSize;
   private final int pageSize;
@@ -84,13 +85,15 @@ class InternalParquetRecordWriter<T> {
       int dictionaryPageSize,
       boolean enableDictionary,
       boolean validating,
-      WriterVersion writerVersion) {
+      WriterVersion writerVersion,
+      long maxRowCount) {
     this.parquetFileWriter = parquetFileWriter;
     this.writeSupport = checkNotNull(writeSupport, "writeSupport");
     this.schema = schema;
     this.extraMetaData = extraMetaData;
     this.rowGroupSize = rowGroupSize;
     this.rowGroupSizeThreshold = rowGroupSize;
+    this.rowGroupMaxRowCount = maxRowCount;
     this.nextRowGroupSize = rowGroupSizeThreshold;
     this.pageSize = pageSize;
     this.compressor = compressor;
@@ -136,7 +139,7 @@ class InternalParquetRecordWriter<T> {
       long recordSize = memSize / recordCount;
       // flush the row group if it is within ~2 records of the limit
       // it is much better to be slightly under size than to be over at all
-      if (memSize > (nextRowGroupSize - 2 * recordSize)) {
+      if (memSize > (nextRowGroupSize - 2 * recordSize) || recordCount >= this.rowGroupMaxRowCount) {
         LOG.info(format("mem size %,d > %,d: flushing %,d records to disk.", memSize, nextRowGroupSize, recordCount));
         flushRowGroupToStore();
         initStore();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -91,8 +91,7 @@ import org.apache.parquet.schema.MessageTypeParser;
  */
 public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
 
-  // private static Log LOG = Log.getLog(ParquetInputFormat.class);
-  private static org.apache.commons.logging.Log LOG = org.apache.commons.logging.LogFactory.getLog(ParquetInputFormat.class);
+  private static Log LOG = Log.getLog(ParquetInputFormat.class);
 
   /**
    * key to configure the ReadSupport implementation
@@ -373,6 +372,7 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
         result.add(file);
       }
     }
+    LOG.info("Total input paths to process : " + result.size());
     return result;
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,6 +22,7 @@ import static org.apache.parquet.Log.INFO;
 import static org.apache.parquet.Preconditions.checkNotNull;
 import static org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE;
 import static org.apache.parquet.hadoop.ParquetWriter.DEFAULT_PAGE_SIZE;
+import static org.apache.parquet.hadoop.ParquetWriter.DEFAULT_MAX_ROW_COUNT;
 import static org.apache.parquet.hadoop.util.ContextUtil.getConfiguration;
 
 import java.io.IOException;
@@ -115,6 +116,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static final String MEMORY_POOL_RATIO    = "parquet.memory.pool.ratio";
   public static final String MIN_MEMORY_ALLOCATION = "parquet.memory.min.chunk.size";
   public static final String MAX_PADDING_BYTES    = "parquet.writer.max-padding";
+  public static final String MAX_ROW_COUNT        = "parquet.writer.max.row.count";
 
   // default to no padding for now
   private static final int DEFAULT_MAX_PADDING_SIZE = 0;
@@ -246,6 +248,14 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
     // default to no padding, 0% of the row group size
     return conf.getInt(MAX_PADDING_BYTES, DEFAULT_MAX_PADDING_SIZE);
   }
+  public static void setMaxRowCount(Configuration conf, long maxRowCount) {
+    conf.setLong(MAX_ROW_COUNT, maxRowCount);
+  }
+
+  private static long getMaxRowCount(Configuration conf) {
+    // default to infinity, i.e. no maximum row count per row group
+    return conf.getLong(MAX_ROW_COUNT, DEFAULT_MAX_ROW_COUNT);
+  }
 
 
   private WriteSupport<T> writeSupport;
@@ -307,6 +317,8 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
     if (INFO) LOG.info("Writer version is: " + writerVersion);
     int maxPaddingSize = getMaxPaddingSize(conf);
     if (INFO) LOG.info("Maximum row group padding size is " + maxPaddingSize + " bytes");
+    long maxRowCount = getMaxRowCount(conf);
+    if (INFO) LOG.info("Maximum row count per row group is " + maxRowCount);
 
     WriteContext init = writeSupport.init(conf);
     ParquetFileWriter w = new ParquetFileWriter(
@@ -335,7 +347,8 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
         enableDictionary,
         validating,
         writerVersion,
-        memoryManager);
+        memoryManager,
+        maxRowCount);
   }
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordWriter.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -67,10 +67,11 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
       int dictionaryPageSize,
       boolean enableDictionary,
       boolean validating,
-      WriterVersion writerVersion) {
+      WriterVersion writerVersion,
+      long maxRowCount) {
     internalWriter = new InternalParquetRecordWriter<T>(w, writeSupport, schema,
         extraMetaData, blockSize, pageSize, compressor, dictionaryPageSize, enableDictionary,
-        validating, writerVersion);
+        validating, writerVersion, maxRowCount);
   }
 
   /**
@@ -96,10 +97,11 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
       boolean enableDictionary,
       boolean validating,
       WriterVersion writerVersion,
-      MemoryManager memoryManager) {
+      MemoryManager memoryManager,
+      long maxRowCount) {
     internalWriter = new InternalParquetRecordWriter<T>(w, writeSupport, schema,
         extraMetaData, blockSize, pageSize, compressor, dictionaryPageSize, enableDictionary,
-        validating, writerVersion);
+        validating, writerVersion, maxRowCount);
     this.memoryManager = checkNotNull(memoryManager, "memoryManager");
     memoryManager.addWriter(internalWriter, blockSize);
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -43,6 +43,7 @@ public class ParquetWriter<T> implements Closeable {
   public static final boolean DEFAULT_IS_VALIDATING_ENABLED = false;
   public static final WriterVersion DEFAULT_WRITER_VERSION =
       WriterVersion.PARQUET_1_0;
+  public static final long DEFAULT_MAX_ROW_COUNT = (long)Double.POSITIVE_INFINITY;
 
   // max size (bytes) to write as padding and the min size of a row group
   public static final int MAX_PADDING_SIZE_DEFAULT = 0;
@@ -216,7 +217,7 @@ public class ParquetWriter<T> implements Closeable {
       Configuration conf) throws IOException {
     this(file, mode, writeSupport, compressionCodecName, blockSize, pageSize,
         dictionaryPageSize, enableDictionary, validating, writerVersion, conf,
-        MAX_PADDING_SIZE_DEFAULT);
+        MAX_PADDING_SIZE_DEFAULT, DEFAULT_MAX_ROW_COUNT);
   }
 
   /**
@@ -258,7 +259,8 @@ public class ParquetWriter<T> implements Closeable {
       boolean validating,
       WriterVersion writerVersion,
       Configuration conf,
-      int maxPaddingSize) throws IOException {
+      int maxPaddingSize,
+      long maxRowCount) throws IOException {
 
     WriteSupport.WriteContext writeContext = writeSupport.init(conf);
     MessageType schema = writeContext.getSchema();
@@ -280,7 +282,8 @@ public class ParquetWriter<T> implements Closeable {
         dictionaryPageSize,
         enableDictionary,
         validating,
-        writerVersion);
+        writerVersion,
+        maxRowCount);
   }
 
   public void write(T object) throws IOException {
@@ -325,6 +328,7 @@ public class ParquetWriter<T> implements Closeable {
     private int pageSize = DEFAULT_PAGE_SIZE;
     private int dictionaryPageSize = DEFAULT_PAGE_SIZE;
     private int maxPaddingSize = MAX_PADDING_SIZE_DEFAULT;
+    private long maxRowCount = DEFAULT_MAX_ROW_COUNT;
     private boolean enableDictionary = DEFAULT_IS_DICTIONARY_ENABLED;
     private boolean enableValidation = DEFAULT_IS_VALIDATING_ENABLED;
     private WriterVersion writerVersion = DEFAULT_WRITER_VERSION;
@@ -480,6 +484,17 @@ public class ParquetWriter<T> implements Closeable {
     }
 
     /**
+    * Set the maximum number of rows per row group
+    *
+    * @param maxPaddingSize a long (number of rows)
+    * @return this builder for method chaining.
+     */
+    public SELF withMaxRowCount(long maxRowCount) {
+      this.maxRowCount = maxRowCount;
+      return self();
+    }
+
+    /**
      * Build a {@link ParquetWriter} with the accumulated configuration.
      *
      * @return a configured {@code ParquetWriter} instance.
@@ -488,7 +503,7 @@ public class ParquetWriter<T> implements Closeable {
     public ParquetWriter<T> build() throws IOException {
       return new ParquetWriter<T>(file, mode, getWriteSupport(conf), codecName,
           rowGroupSize, pageSize, dictionaryPageSize, enableDictionary,
-          enableValidation, writerVersion, conf, maxPaddingSize);
+          enableValidation, writerVersion, conf, maxPaddingSize, maxRowCount);
     }
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -486,7 +486,7 @@ public class ParquetWriter<T> implements Closeable {
     /**
     * Set the maximum number of rows per row group
     *
-    * @param maxPaddingSize a long (number of rows)
+    * @param maxRowCount a long (number of rows)
     * @return this builder for method chaining.
      */
     public SELF withMaxRowCount(long maxRowCount) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputFormat.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputFormat.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -101,7 +101,7 @@ public class TestInputFormat {
       generateSplitByMinMaxSize(50, 49);
       fail("should throw exception when max split size is smaller than the min split size");
     } catch (ParquetDecodingException e) {
-      assertEquals("maxSplitSize and minSplitSize should be positive and max should be greater or equal to the minSplitSize: maxSplitSize = 49; minSplitSize is 50"
+      assertEquals("maxSplitSize, minSplitSize and maxSplitRecordCount should be positive and max should be greater or equal to the minSplitSize: maxSplitSize = 49; minSplitSize is 50"
               , e.getMessage());
     }
   }
@@ -112,7 +112,7 @@ public class TestInputFormat {
       generateSplitByMinMaxSize(-100, -50);
       fail("should throw exception when max split size is negative");
     } catch (ParquetDecodingException e) {
-      assertEquals("maxSplitSize and minSplitSize should be positive and max should be greater or equal to the minSplitSize: maxSplitSize = -50; minSplitSize is -100"
+      assertEquals("maxSplitSize, minSplitSize and maxSplitRecordCount should be positive and max should be greater or equal to the minSplitSize: maxSplitSize = -50; minSplitSize is -100"
               , e.getMessage());
     }
   }
@@ -408,14 +408,15 @@ public class TestInputFormat {
         fileStatus,
         schema.toString(),
         extramd,
-        min, max);
+        min, max,
+        ParquetInputFormat.DEFAULT_MAX_SPLIT_RECORD_COUNT);
   }
 
   private List<ParquetInputSplit> generateSplitByDeprecatedConstructor(long min, long max) throws
       IOException {
     List<ParquetInputSplit> splits = new ArrayList<ParquetInputSplit>();
     List<ClientSideMetadataSplitStrategy.SplitInfo> splitInfos = ClientSideMetadataSplitStrategy
-        .generateSplitInfo(blocks, hdfsBlocks, min, max);
+        .generateSplitInfo(blocks, hdfsBlocks, min, max, ParquetInputFormat.DEFAULT_MAX_SPLIT_RECORD_COUNT);
 
     for (ClientSideMetadataSplitStrategy.SplitInfo splitInfo : splitInfos) {
       BlockMetaData lastRowGroup = splitInfo.getRowGroups().get(splitInfo.getRowGroupCount() - 1);


### PR DESCRIPTION
As said in the JIRA ticket, we use Parquet to store raw metrics data and then query this data with Hadoop-Pig. The issue is that sometimes we end up with small Parquet files (~80mo) that contain more than 300 000 000 rows, usually because of a constant metric which results in a very good compression. Too good. As a result we have a very few number of maps that process up to 10x more rows than the other maps and we lose the benefits of the parallelization.

I introduced two changes here:
* Add a parameter to limit the number of rows in a block (parquet.writer.max.row.count)
* Add a parameter to limit the number of rows in a split (parquet.max.split.record.count) I'd probably need to add some unit tests for this.

I still need to add unit tests for this but I already wanted your feedback. Also the parquet.max.split.record.count parameter uses the split planning using file footer which is marked as deprecated...