### PR TITLE
PARQUET-356: Update LICENSE files for code from ElephantBird.

### DIFF
--- a/parquet-hadoop/src/main/resources/META-INF/LICENSE
+++ b/parquet-hadoop/src/main/resources/META-INF/LICENSE
@@ -178,27 +178,6 @@
 
 --------------------------------------------------------------------------------
 
-This project includes code from Daniel Lemire's JavaFastPFOR project. The
-"Lemire" bit packing source code produced by parquet-generator is derived from
-the JavaFastPFOR project.
-
-Copyright: 2013 Daniel Lemire
-Home page: http://lemire.me/en/
-Project page: https://github.com/lemire/JavaFastPFOR
-License: Apache License Version 2.0 http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-This product includes code from Apache Spark.
-
-* dev/merge_parquet_pr.py is based on Spark's dev/merge_spark_pr.py
-
-Copyright: 2014 The Apache Software Foundation.
-Home page: https://spark.apache.org/
-License: http://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
 This product includes code from Twitter's ElephantBird project.
 
 * parquet-hadoop's UnmaterializableRecordCounter.java includes code from


### PR DESCRIPTION
This updates the root LICENSE and the parquet-hadoop binary LICENSE files for the inclusion of code from Twitter's ElephantBird project in 9993450.