### PR TITLE
PARQUET-360: Handle all map key types with cat tool's json dump

### DIFF
--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/CatCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/CatCommand.java
@@ -70,7 +70,7 @@ public class CatCommand extends ArgsOnlyCommand {
     ParquetReader<SimpleRecord> reader = null;
     try {
       PrintWriter writer = new PrintWriter(Main.out, true);
-      reader = new ParquetReader<SimpleRecord>(new Path(input), new SimpleReadSupport());
+      reader = ParquetReader.builder(new SimpleReadSupport(), new Path(input)).build();
       for (SimpleRecord value = reader.read(); value != null; value = reader.read()) {
         if (options.hasOption('j')) {
           value.prettyPrintJson(writer);

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/DumpCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/DumpCommand.java
@@ -47,6 +47,7 @@ import org.apache.parquet.column.page.DataPageV2;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -61,6 +62,8 @@ import org.apache.parquet.tools.util.PrettyPrintWriter;
 import org.apache.parquet.tools.util.PrettyPrintWriter.WhiteSpaceHandler;
 
 import com.google.common.base.Joiner;
+
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 
 public class DumpCommand extends ArgsOnlyCommand {
     private static final Charset UTF8 = Charset.forName("UTF-8");
@@ -115,7 +118,7 @@ public class DumpCommand extends ArgsOnlyCommand {
         Configuration conf = new Configuration();
         Path inpath = new Path(input);
 
-        ParquetMetadata metaData = ParquetFileReader.readFooter(conf, inpath);
+        ParquetMetadata metaData = ParquetFileReader.readFooter(conf, inpath, NO_FILTER);
         MessageType schema = metaData.getFileMetaData().getSchema();
 
         PrettyPrintWriter out = PrettyPrintWriter.stdoutPrettyPrinter()

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/HeadCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/HeadCommand.java
@@ -78,7 +78,7 @@ public class HeadCommand extends ArgsOnlyCommand {
     ParquetReader<SimpleRecord> reader = null;
     try {
       PrintWriter writer = new PrintWriter(Main.out, true);
-      reader = new ParquetReader<SimpleRecord>(new Path(input), new SimpleReadSupport());
+      reader = ParquetReader.builder(new SimpleReadSupport(), new Path(input)).build();
       for (SimpleRecord value = reader.read(); value != null && num-- > 0; value = reader.read()) {
         value.prettyPrint(writer);
         writer.println();

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/ShowSchemaCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/ShowSchemaCommand.java
@@ -37,6 +37,8 @@ import org.apache.parquet.tools.Main;
 import org.apache.parquet.tools.util.MetadataUtils;
 import org.apache.parquet.tools.util.PrettyPrintWriter;
 
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
+
 public class ShowSchemaCommand extends ArgsOnlyCommand {
   public static final String[] USAGE = new String[] {
     "<input>",
@@ -88,7 +90,7 @@ public class ShowSchemaCommand extends ArgsOnlyCommand {
     } else {
       file = path;
     }
-    metaData = ParquetFileReader.readFooter(conf, file);
+    metaData = ParquetFileReader.readFooter(conf, file, NO_FILTER);
     MessageType schema = metaData.getFileMetaData().getSchema();
 
     Main.out.println(schema);

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/read/SimpleMapRecord.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/read/SimpleMapRecord.java
@@ -45,10 +45,13 @@ public class SimpleMapRecord extends SimpleRecord {
     return result;
   }
 
-  private String keyToString(Object kvValue) {
+  String keyToString(Object kvValue) {
+    if (kvValue == null) {
+      return "null";
+    }
+
     Class<?> type = kvValue.getClass();
     if (type.isArray()) {
-
       if (type.getComponentType() == boolean.class) {
         return Arrays.toString((boolean[]) kvValue);
       }

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/read/SimpleMapRecord.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/read/SimpleMapRecord.java
@@ -20,6 +20,7 @@ package org.apache.parquet.tools.read;
 
 import com.google.common.collect.Maps;
 
+import java.util.Arrays;
 import java.util.Map;
 
 public class SimpleMapRecord extends SimpleRecord {
@@ -30,14 +31,52 @@ public class SimpleMapRecord extends SimpleRecord {
       String key = null;
       Object val = null;
       for (NameValue kv : ((SimpleRecord) value.getValue()).values) {
-        if (kv.getName().equals("key")) {
-          key = (String) kv.getValue();
-        } else if (kv.getName().equals("value")) {
-          val = toJsonValue(kv.getValue());
+        String kvName = kv.getName();
+        Object kvValue = kv.getValue();
+        if (kvName.equals("key")) {
+          key = keyToString(kvValue);
+        } else if (kvName.equals("value")) {
+          val = toJsonValue(kvValue);
         }
       }
       result.put(key, val);
     }
     return result;
+  }
+
+  private String keyToString(Object kvValue) {
+    Class<?> type = kvValue.getClass();
+    if (type.isArray()) {
+
+      if (type.getComponentType() == boolean.class) {
+        return Arrays.toString((boolean[]) kvValue);
+      }
+      else if (type.getComponentType() == byte.class) {
+        return Arrays.toString((byte[]) kvValue);
+      }
+      else if (type.getComponentType() == char.class) {
+        return Arrays.toString((char[]) kvValue);
+      }
+      else if (type.getComponentType() == double.class) {
+        return Arrays.toString((double[]) kvValue);
+      }
+      else if (type.getComponentType() == float.class) {
+        return Arrays.toString((float[]) kvValue);
+      }
+      else if (type.getComponentType() == int.class) {
+        return Arrays.toString((int[]) kvValue);
+      }
+      else if (type.getComponentType() == long.class) {
+        return Arrays.toString((long[]) kvValue);
+      }
+      else if (type.getComponentType() == short.class) {
+        return Arrays.toString((short[]) kvValue);
+      }
+      else {
+        return Arrays.toString((Object[]) kvValue);
+      }
+    } else {
+      return String.valueOf(kvValue);
+    }
   }
 }

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/read/SimpleMapRecord.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/read/SimpleMapRecord.java
@@ -19,6 +19,7 @@
 package org.apache.parquet.tools.read;
 
 import com.google.common.collect.Maps;
+import org.codehaus.jackson.node.BinaryNode;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -52,7 +53,7 @@ public class SimpleMapRecord extends SimpleRecord {
         return Arrays.toString((boolean[]) kvValue);
       }
       else if (type.getComponentType() == byte.class) {
-        return Arrays.toString((byte[]) kvValue);
+        return new BinaryNode((byte[]) kvValue).asText();
       }
       else if (type.getComponentType() == char.class) {
         return Arrays.toString((char[]) kvValue);

--- a/parquet-tools/src/test/java/org/apache/parquet/tools/read/TestSimpleMapRecord.java
+++ b/parquet-tools/src/test/java/org/apache/parquet/tools/read/TestSimpleMapRecord.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.tools.read;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSimpleMapRecord {
+
+  class TestRecord {
+    private int x;
+    private int y;
+
+    public TestRecord(int x, int y) {
+      this.x = x;
+      this.y = y;
+    }
+
+    @Override
+    public String toString() {
+      return "TestRecord {" + x + "," + y + "}";
+    }
+  }
+
+  @Test
+  public void testBinary() {
+    SimpleMapRecord r = new SimpleMapRecord();
+    Assert.assertEquals("null", r.keyToString(null));
+    Assert.assertEquals("[true, false, true]", r.keyToString(new boolean[]{true, false, true}));
+    Assert.assertEquals("[a, z]", r.keyToString(new char[] { 'a', 'z' }));
+    Assert.assertEquals("[1.0, 3.0]", r.keyToString(new double[]{1.0, 3.0 }));
+    Assert.assertEquals("[2.0, 4.0]", r.keyToString(new float[]{2.0f, 4.0f }));
+    Assert.assertEquals("[100, 999]", r.keyToString(new int[]{100, 999 }));
+    Assert.assertEquals("[23, 37]", r.keyToString(new long[] { 23l, 37l }));
+    Assert.assertEquals("[-1, -2]", r.keyToString(new short[]{(short) -1, (short) -2}));
+    Assert.assertEquals("dGVzdA==", r.keyToString("test".getBytes()));
+    Assert.assertEquals("TestRecord {222,333}", r.keyToString(new TestRecord(222, 333)));
+  }
+}


### PR DESCRIPTION
When dumping a parquet map with `parquet-cat --json` it throws a class cast exception as it doesn't properly handle all map key types.

```
java.lang.ClassCastException: [B cannot be cast to java.lang.String
	at org.apache.parquet.tools.read.SimpleMapRecord.toJsonObject(SimpleMapRecord.java:34)
	at org.apache.parquet.tools.read.SimpleRecord.toJsonValue(SimpleRecord.java:119)
	at org.apache.parquet.tools.read.SimpleRecord.toJsonObject(SimpleRecord.java:112)
	at org.apache.parquet.tools.read.SimpleRecord.prettyPrintJson(SimpleRecord.java:106)
	at org.apache.parquet.tools.command.CatCommand.execute(CatCommand.java:76)
	at org.apache.parquet.tools.Main.main(Main.java:222)
[B cannot be cast to java.lang.String
```