### PR TITLE
PARQUET-362 - Fix parquet buffered writer being oversensitive to union schema changes

### DIFF
--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/BufferedProtocolReadToWrite.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/BufferedProtocolReadToWrite.java
@@ -375,6 +375,9 @@ public class BufferedProtocolReadToWrite implements ProtocolPipe {
         hasFieldsIgnored |= true;
         continue;
       }
+      
+      childFieldsPresent++;
+
       buffer.add(new Action() {
         @Override
         public void write(TProtocol out) throws TException {
@@ -386,11 +389,7 @@ public class BufferedProtocolReadToWrite implements ProtocolPipe {
           return "f=" + currentField.id + "<t=" + typeName(currentField.type) + ">: ";
         }
       });
-      boolean wasIgnored = readOneValue(in, field.type, buffer, expectedField.getType());
-      if (!wasIgnored) {
-        childFieldsPresent++;
-      }
-      hasFieldsIgnored |= wasIgnored;
+      hasFieldsIgnored |= readOneValue(in, field.type, buffer, expectedField.getType());
       in.readFieldEnd();
       buffer.add(FIELD_END);
     }

--- a/parquet-thrift/src/test/thrift/compat.thrift
+++ b/parquet-thrift/src/test/thrift/compat.thrift
@@ -152,6 +152,10 @@ union UnionV2 {
   3: ABool aNewBool
 }
 
+union UnionV3 {
+  1: StructV1 aStruct
+}
+
 struct StructWithUnionV1 {  
   1: required string name,
   2: required UnionV1 aUnion
@@ -171,6 +175,10 @@ struct AStructThatLooksLikeUnionV2 {
 struct StructWithAStructThatLooksLikeUnionV2 {  
   1: required string name,
   2: required AStructThatLooksLikeUnionV2 aNotQuiteUnion
+}
+
+union UnionThatLooksLikeUnionV3 {
+  1: StructV2 aStruct
 }
 
 union UnionOfStructs {


### PR DESCRIPTION
Parquet does prevent records with unknown union fields to be written as it would
create a TProtocol violation. But it also prevents records with unions having one their field
itself having an unknown field (which is acceptable if it is a struct).