### PR TITLE
PARQUET-376: Tolerate square brackets in PR titles

### DIFF
--- a/dev/merge_parquet_pr.py
+++ b/dev/merge_parquet_pr.py
@@ -141,7 +141,9 @@ def merge_pr(pr_num, target_ref):
 
     merge_message_flags = []
 
-    merge_message_flags += ["-m", title]
+    title_without_brackets = remove_brackets_from_pr_title(title)
+
+    merge_message_flags += ["-m", title_without_brackets]
     if body != None:
         merge_message_flags += ["-m", body]
 
@@ -216,6 +218,13 @@ def fix_version_from_branch(branch, versions):
     else:
         branch_ver = branch.replace("branch-", "")
         return filter(lambda x: x.name.startswith(branch_ver), versions)[-1]
+
+def remove_brackets_from_pr_title(title):
+    m = re.search(r'^\[?(PARQUET-[0-9]+)\]?(\s.*)$', title)
+    if m and len(m.groups()) == 2:
+        return m.group(1) + m.group(2)
+    else:
+        fail("PR title should be prefixed by a jira id \"PARQUET-XXX: ...\", found: \"%s\"" % title)  
 
 def exctract_jira_id(title):
     m = re.search(r'^\[?(PARQUET-[0-9]+)\]?\s.*$', title)

--- a/dev/merge_parquet_pr.py
+++ b/dev/merge_parquet_pr.py
@@ -218,7 +218,7 @@ def fix_version_from_branch(branch, versions):
         return filter(lambda x: x.name.startswith(branch_ver), versions)[-1]
 
 def exctract_jira_id(title):
-    m = re.search(r'^(PARQUET-[0-9]+)\b.*$', title)
+    m = re.search(r'^\[?(PARQUET-[0-9]+)\]?\s.*$', title)
     if m and m.groups > 0:
         return m.group(1)
     else:


### PR DESCRIPTION
This allows for PRs like:

`[PARQUET-XXXX] description`

to be parsed, as we often get this format and we usually have to ask the submitter to change the title for us.