### PR TITLE
PARQUET-364: Fix compatibility for Avro lists of lists.

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -50,6 +50,7 @@ import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 
+import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
 
 /**
@@ -744,11 +745,12 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
    * @param elementSchema the expected Schema for list elements
    * @return {@code true} if the repeatedType is the element schema
    */
-  private static boolean isElementType(Type repeatedType, Schema elementSchema) {
+  static boolean isElementType(Type repeatedType, Schema elementSchema) {
     if (repeatedType.isPrimitive() ||
-        repeatedType.asGroupType().getFieldCount() > 1) {
+        repeatedType.asGroupType().getFieldCount() > 1 ||
+        repeatedType.asGroupType().getType(0).isRepetition(REPEATED)) {
       // The repeated type must be the element type because it is an invalid
-      // synthetic wrapper (must be a group with one field).
+      // synthetic wrapper. Must be a group with one optional or required field
       return true;
     } else if (elementSchema != null &&
         elementSchema.getType() == Schema.Type.RECORD &&

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
@@ -394,6 +394,98 @@ public class TestAvroSchemaConverter {
   }
 
   @Test
+  public void testOldAvroListOfLists() throws Exception {
+    Schema listOfLists = optional(Schema.createArray(Schema.createArray(
+        Schema.create(Schema.Type.INT))));
+    Schema schema = Schema.createRecord("AvroCompatListInList", null, null, false);
+    schema.setFields(Lists.newArrayList(
+        new Schema.Field("listOfLists", listOfLists, null, NullNode.getInstance())
+    ));
+    System.err.println("Avro schema: " + schema.toString(true));
+
+    testRoundTripConversion(schema,
+        "message AvroCompatListInList {\n" +
+            "  optional group listOfLists (LIST) {\n" +
+            "    repeated group array (LIST) {\n" +
+            "      repeated int32 array;\n" +
+            "    }\n" +
+            "  }\n" +
+            "}");
+    // Cannot use round-trip assertion because 3-level representation is used
+    testParquetToAvroConversion(NEW_BEHAVIOR, schema,
+        "message AvroCompatListInList {\n" +
+            "  optional group listOfLists (LIST) {\n" +
+            "    repeated group array (LIST) {\n" +
+            "      repeated int32 array;\n" +
+            "    }\n" +
+            "  }\n" +
+            "}");
+  }
+
+  @Test
+  public void testOldThriftListOfLists() throws Exception {
+    Schema listOfLists = optional(Schema.createArray(Schema.createArray(
+        Schema.create(Schema.Type.INT))));
+    Schema schema = Schema.createRecord("ThriftCompatListInList", null, null, false);
+    schema.setFields(Lists.newArrayList(
+        new Schema.Field("listOfLists", listOfLists, null, NullNode.getInstance())
+    ));
+    System.err.println("Avro schema: " + schema.toString(true));
+
+    // Cannot use round-trip assertion because repeated group names differ
+    testParquetToAvroConversion(schema,
+        "message ThriftCompatListInList {\n" +
+            "  optional group listOfLists (LIST) {\n" +
+            "    repeated group listOfLists_tuple (LIST) {\n" +
+            "      repeated int32 listOfLists_tuple_tuple;\n" +
+            "    }\n" +
+            "  }\n" +
+            "}");
+    // Cannot use round-trip assertion because 3-level representation is used
+    testParquetToAvroConversion(NEW_BEHAVIOR, schema,
+        "message ThriftCompatListInList {\n" +
+        "  optional group listOfLists (LIST) {\n" +
+        "    repeated group listOfLists_tuple (LIST) {\n" +
+        "      repeated int32 listOfLists_tuple_tuple;\n" +
+        "    }\n" +
+        "  }\n" +
+        "}");
+  }
+
+  @Test
+  public void testUnknownTwoLevelListOfLists() throws Exception {
+    // This tests the case where we don't detect a 2-level list by the repeated
+    // group's name, but it must be 2-level because the repeated group doesn't
+    // contain an optional or repeated element as required for 3-level lists
+    Schema listOfLists = optional(Schema.createArray(Schema.createArray(
+        Schema.create(Schema.Type.INT))));
+    Schema schema = Schema.createRecord("UnknownTwoLevelListInList", null, null, false);
+    schema.setFields(Lists.newArrayList(
+        new Schema.Field("listOfLists", listOfLists, null, NullNode.getInstance())
+    ));
+    System.err.println("Avro schema: " + schema.toString(true));
+
+    // Cannot use round-trip assertion because repeated group names differ
+    testParquetToAvroConversion(schema,
+        "message UnknownTwoLevelListInList {\n" +
+            "  optional group listOfLists (LIST) {\n" +
+            "    repeated group mylist (LIST) {\n" +
+            "      repeated int32 innerlist;\n" +
+            "    }\n" +
+            "  }\n" +
+            "}");
+    // Cannot use round-trip assertion because 3-level representation is used
+    testParquetToAvroConversion(NEW_BEHAVIOR, schema,
+        "message UnknownTwoLevelListInList {\n" +
+            "  optional group listOfLists (LIST) {\n" +
+            "    repeated group mylist (LIST) {\n" +
+            "      repeated int32 innerlist;\n" +
+            "    }\n" +
+            "  }\n" +
+            "}");
+  }
+
+  @Test
   public void testParquetMapWithoutMapKeyValueAnnotation() throws Exception {
     Schema schema = Schema.createRecord("myrecord", null, null, false);
     Schema map = Schema.createMap(Schema.create(Schema.Type.INT));


### PR DESCRIPTION
This fixes lists of lists that have been written with Avro's 2-level
representation. The conversion setup logic missed the case where the
inner field is repeated and cannot be the element in a 3-level list.

This also fixes the schema conversion for cases where an unknown
writer used a 2-level list of lists.

This is based on @liancheng's #264 but fixes the problem in a slightly different way.