### PR TITLE
PARQUET-380: Fix build when using thrift 0.9.0.

### DIFF
--- a/parquet-cascading/pom.xml
+++ b/parquet-cascading/pom.xml
@@ -51,9 +51,15 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-        <groupId>org.apache.parquet</groupId>
-        <artifactId>parquet-thrift</artifactId>
-        <version>${project.version}</version>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-thrift</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${thrift.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -81,10 +87,22 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-       <groupId>cascading</groupId>
-       <artifactId>cascading-hadoop</artifactId>
-       <version>${cascading.version}</version>
-       <scope>provided</scope>
+      <groupId>cascading</groupId>
+      <artifactId>cascading-hadoop</artifactId>
+      <version>${cascading.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -85,6 +85,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${thrift.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-cascading</artifactId>
       <version>${project.version}</version>
@@ -111,6 +117,18 @@
       <artifactId>cascading-hadoop</artifactId>
       <version>${cascading.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <thrift.version>0.7.0</thrift.version>
     <fastutil.version>6.5.7</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>
+    <slf4j.version>1.7.5</slf4j.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
This adds the correct version of libthrift as a dependency for
parquet-cascading and parquet-scrooge, which overrides the 0.7.0
dependency that elephantbird uses.