### PR TITLE
PARQUET-349: VersionParser does not handle versions missing 'build' section

### DIFF
--- a/parquet-common/src/main/java/org/apache/parquet/VersionParser.java
+++ b/parquet-common/src/main/java/org/apache/parquet/VersionParser.java
@@ -31,7 +31,7 @@ import static org.apache.parquet.Preconditions.checkArgument;
  */
 public class VersionParser {
   // example: parquet-mr version 1.8.0rc2-SNAPSHOT (build ddb469afac70404ea63b72ed2f07a911a8592ff7)
-  public static final String FORMAT = "(.+) version ((.*) )?\\(build ?(.*)\\)";
+  public static final String FORMAT = "(.*?)\\s+version\\s*(?:([^(]*?)\\s*(?:\\(\\s*build\\s*([^)]*?)\\s*\\))?)?";
   public static final Pattern PATTERN = Pattern.compile(FORMAT);
 
   public static class ParsedVersion {
@@ -113,8 +113,8 @@ public class VersionParser {
     }
 
     String application = matcher.group(1);
-    String semver = matcher.group(3);
-    String appBuildHash = matcher.group(4);
+    String semver = matcher.group(2);
+    String appBuildHash = matcher.group(3);
 
     if (Strings.isNullOrEmpty(application)) {
       throw new VersionParseException("application cannot be null or empty");

--- a/parquet-common/src/test/java/org/apache/parquet/VersionTest.java
+++ b/parquet-common/src/test/java/org/apache/parquet/VersionTest.java
@@ -79,5 +79,22 @@ public class VersionTest {
     assertEquals(new ParsedVersion("parquet-mr", "1.6.0", null), VersionParser.parse("parquet-mr version 1.6.0 (build)"));
     assertEquals(new ParsedVersion("parquet-mr", null, null), VersionParser.parse("parquet-mr version (build)"));
     assertEquals(new ParsedVersion("parquet-mr", null, null), VersionParser.parse("parquet-mr version (build )"));
+
+    // Missing entire build section
+    assertEquals(new ParsedVersion("parquet-mr", "1.6.0", null), VersionParser.parse("parquet-mr version 1.6.0"));
+    assertEquals(new ParsedVersion("parquet-mr", "1.8.0rc4", null), VersionParser.parse("parquet-mr version 1.8.0rc4"));
+    assertEquals(new ParsedVersion("parquet-mr", "1.8.0rc4-SNAPSHOT", null), VersionParser.parse("parquet-mr version 1.8.0rc4-SNAPSHOT"));
+    assertEquals(new ParsedVersion("parquet-mr", null, null), VersionParser.parse("parquet-mr version"));
+
+
+    // Various spaces
+    assertEquals(new ParsedVersion("parquet-mr", "1.6.0", null), VersionParser.parse("parquet-mr     version    1.6.0"));
+    assertEquals(new ParsedVersion("parquet-mr", "1.8.0rc4", null), VersionParser.parse("parquet-mr     version    1.8.0rc4"));
+    assertEquals(new ParsedVersion("parquet-mr", "1.8.0rc4-SNAPSHOT", null), VersionParser.parse("parquet-mr      version    1.8.0rc4-SNAPSHOT  "));
+    assertEquals(new ParsedVersion("parquet-mr", null, null), VersionParser.parse("parquet-mr      version"));
+    assertEquals(new ParsedVersion("parquet-mr", "1.6.0", null), VersionParser.parse("parquet-mr version 1.6.0 (  build )"));
+    assertEquals(new ParsedVersion("parquet-mr", "1.6.0", null), VersionParser.parse("parquet-mr     version 1.6.0 (    build)"));
+    assertEquals(new ParsedVersion("parquet-mr", null, null), VersionParser.parse("parquet-mr     version (    build)"));
+    assertEquals(new ParsedVersion("parquet-mr", null, null), VersionParser.parse("parquet-mr    version    (build    )"));
   }
 }


### PR DESCRIPTION
This change reworks the regular expression in VersionParser.java to allow for missing 'version' and 'build' sections.