### PR TITLE
try to use class loader from Hadoop Configuration

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/SerializationUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/SerializationUtil.java
@@ -27,6 +27,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.input.ClassLoaderObjectInputStream;
 import org.apache.hadoop.conf.Configuration;
 
 import org.apache.parquet.Closeables;
@@ -97,7 +98,12 @@ public final class SerializationUtil {
       bais = new ByteArrayInputStream(bytes);
       gis = new GZIPInputStream(bais);
       ois = new ObjectInputStream(gis);
-      return (T) ois.readObject();
+      try {
+        return (T) ois.readObject();
+      } catch (ClassNotFoundException e) {
+        ClassLoaderObjectInputStream clois = new ClassLoaderObjectInputStream(conf.getClassLoader(), gis);
+        return (T) clois.readObject();
+      }
     } catch (ClassNotFoundException e) {
       throw new IOException("Could not read object from config with key " + key, e);
     } catch (ClassCastException e) {


### PR DESCRIPTION
 (thread local clas loader) if system class loader fails to find the class.

Apache Spark uploads jars to after Java executor process starts, so they are not available in system class loader.

This PR solves the problem described in this post - allows to use User Defined Predicate classes and objects.