### PR TITLE
PARQUET-391: Add thrift dependency for generated sources in parquet-cascading, parquet-scrooge modules

### DIFF
--- a/parquet-cascading/pom.xml
+++ b/parquet-cascading/pom.xml
@@ -86,6 +86,12 @@
        <version>${cascading.version}</version>
        <scope>provided</scope>
     </dependency>
+    <dependency>
+       <groupId>org.apache.thrift</groupId>
+       <artifactId>libthrift</artifactId>
+       <version>${thrift.version}</version>
+       <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -112,6 +112,12 @@
       <version>${cascading.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${thrift.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
When compiling with -Pthrift9  , parquet build fails in parquet-cascading module since we have not specified the thrift dependency ; and compilation breaks for the generated sources from thrift 0.9