### PR TITLE
PARQUET-352: Add object model property to file footers.

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
@@ -92,6 +92,11 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
     this.model = model;
   }
 
+  @Override
+  public String getName() {
+    return "avro";
+  }
+
   /**
    * @see org.apache.parquet.avro.AvroParquetOutputFormat#setSchema(org.apache.hadoop.mapreduce.Job, org.apache.avro.Schema)
    */

--- a/parquet-cascading/src/main/java/org/apache/parquet/cascading/TupleWriteSupport.java
+++ b/parquet-cascading/src/main/java/org/apache/parquet/cascading/TupleWriteSupport.java
@@ -42,6 +42,11 @@ public class TupleWriteSupport extends WriteSupport<TupleEntry> {
   public static final String PARQUET_CASCADING_SCHEMA = "parquet.cascading.schema";
 
   @Override
+  public String getName() {
+    return "cascading";
+  }
+
+  @Override
   public WriteContext init(Configuration configuration) {
     String schema = configuration.get(PARQUET_CASCADING_SCHEMA);
     rootSchema = MessageTypeParser.parseMessageType(schema);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
@@ -119,6 +119,10 @@ class InternalParquetRecordWriter<T> {
     flushRowGroupToStore();
     FinalizedWriteContext finalWriteContext = writeSupport.finalizeWrite();
     Map<String, String> finalMetadata = new HashMap<String, String>(extraMetaData);
+    String modelName = writeSupport.getName();
+    if (modelName != null) {
+      finalMetadata.put(ParquetWriter.OBJECT_MODEL_NAME_PROP, modelName);
+    }
     finalMetadata.putAll(finalWriteContext.getExtraMetaData());
     parquetFileWriter.end(finalMetadata);
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -45,6 +45,8 @@ public class ParquetWriter<T> implements Closeable {
   public static final WriterVersion DEFAULT_WRITER_VERSION =
       WriterVersion.PARQUET_1_0;
 
+  public static final String OBJECT_MODEL_NAME_PROP = "writer.model.name";
+
   // max size (bytes) to write as padding and the min size of a row group
   public static final int MAX_PADDING_SIZE_DEFAULT = 0;
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/DelegatingWriteSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/DelegatingWriteSupport.java
@@ -55,6 +55,11 @@ public class DelegatingWriteSupport<T> extends WriteSupport<T> {
   }
 
   @Override
+  public String getName() {
+    return delegate.getName();
+  }
+
+  @Override
   public WriteSupport.FinalizedWriteContext finalizeWrite() {
     return delegate.finalizeWrite();
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/WriteSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/WriteSupport.java
@@ -121,6 +121,18 @@ abstract public class WriteSupport<T> {
   public abstract void write(T record);
 
   /**
+   * Called to get a name to identify the WriteSupport object model.
+   * If not null, this is added to the file footer metadata.
+   * <p>
+   * Defining this method will be required in a future API version.
+   *
+   * @return a String name for file metadata.
+   */
+  public String getName() {
+    return null;
+  }
+
+  /**
    * called once in the end after the last record was written
    * @return information to be added in the file
    */

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/example/GroupWriteSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/example/GroupWriteSupport.java
@@ -64,6 +64,11 @@ public class GroupWriteSupport extends WriteSupport<Group> {
   }
 
   @Override
+  public String getName() {
+    return "example";
+  }
+
+  @Override
   public org.apache.parquet.hadoop.api.WriteSupport.WriteContext init(Configuration configuration) {
     // if present, prefer the schema passed to the constructor
     if (schema == null) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
@@ -135,6 +135,9 @@ public class TestParquetWriter {
             }
           }
         }
+        assertEquals("Object model property should be example",
+            "example", footer.getFileMetaData().getKeyValueMetaData()
+                .get(ParquetWriter.OBJECT_MODEL_NAME_PROP));
       }
     }
   }

--- a/parquet-pig/src/main/java/org/apache/parquet/pig/TupleWriteSupport.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/TupleWriteSupport.java
@@ -67,6 +67,11 @@ public class TupleWriteSupport extends WriteSupport<Tuple> {
     this.rootPigSchema = pigSchema;
   }
 
+  @Override
+  public String getName() {
+    return "pig";
+  }
+
   public Schema getPigSchema() {
     return rootPigSchema;
   }

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -62,6 +62,11 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
     this.protoMessage = protobufClass;
   }
 
+  @Override
+  public String getName() {
+    return "protobuf";
+  }
+
   public static void setSchema(Configuration configuration, Class<? extends Message> protoClass) {
     configuration.setClass(PB_CLASS_WRITE, protoClass, Message.class);
   }

--- a/parquet-scrooge/src/main/java/org/apache/parquet/scrooge/ScroogeWriteSupport.java
+++ b/parquet-scrooge/src/main/java/org/apache/parquet/scrooge/ScroogeWriteSupport.java
@@ -49,6 +49,11 @@ public class ScroogeWriteSupport<T extends ThriftStruct> extends AbstractThriftW
   }
 
   @Override
+  public String getName() {
+    return "scrooge";
+  }
+
+  @Override
   protected StructType getThriftStruct() {
     ScroogeStructConverter schemaConverter = new ScroogeStructConverter();
     return schemaConverter.convert(thriftClass);

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/TBaseWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/TBaseWriteSupport.java
@@ -46,6 +46,11 @@ public class TBaseWriteSupport<T extends TBase<?, ?>> extends AbstractThriftWrit
   }
 
   @Override
+  public String getName() {
+    return "thrift";
+  }
+
+  @Override
   protected StructType getThriftStruct() {
     return ThriftSchemaConverter.toStructType(thriftClass);
   }

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
@@ -93,6 +93,11 @@ public class ThriftBytesWriteSupport extends WriteSupport<BytesWritable> {
   }
 
   @Override
+  public String getName() {
+    return "thrift";
+  }
+
+  @Override
   public WriteContext init(Configuration configuration) {
     if (this.protocolFactory == null) {
       try {

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftWriteSupport.java
@@ -59,6 +59,11 @@ public class ThriftWriteSupport<T extends TBase<?,?>> extends WriteSupport<T> {
   }
 
   @Override
+  public String getName() {
+    return writeSupport.getName();
+  }
+
+  @Override
   public WriteContext init(Configuration configuration) {
     return this.writeSupport.init(configuration);
   }

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/pig/TupleToThriftWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/pig/TupleToThriftWriteSupport.java
@@ -49,6 +49,11 @@ public class TupleToThriftWriteSupport extends WriteSupport<Tuple> {
     this.className = className;
   }
 
+  @Override
+  public String getName() {
+    return "thrift";
+  }
+
   @SuppressWarnings({"rawtypes", "unchecked"})
   @Override
   public WriteContext init(Configuration configuration) {


### PR DESCRIPTION
WriteSupport now has a getName getter method that is added to the footer
if it returns a non-null string as writer.model.name. This is intended
to help identify files written by object models incorrectly.