### PR TITLE
PARQUET-305: Update logging to SLF4J.

### DIFF
--- a/parquet-avro/pom.xml
+++ b/parquet-avro/pom.xml
@@ -81,6 +81,12 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parquet-benchmarks/pom.xml
+++ b/parquet-benchmarks/pom.xml
@@ -63,6 +63,12 @@
         <version>${jmh.version}</version>
         <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parquet-cascading/pom.xml
+++ b/parquet-cascading/pom.xml
@@ -68,12 +68,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
       <version>${project.version}</version>

--- a/parquet-column/pom.xml
+++ b/parquet-column/pom.xml
@@ -77,6 +77,12 @@
       <version>1.3.149</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parquet-common/pom.xml
+++ b/parquet-common/pom.xml
@@ -37,10 +37,23 @@
 
   <dependencies>
     <dependency>
-        <groupId>org.semver</groupId>
-        <artifactId>api</artifactId>
-        <version>${semver.api.version}</version>
-        <scope>test</scope>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.semver</groupId>
+      <artifactId>api</artifactId>
+      <version>${semver.api.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/parquet-common/src/main/java/org/apache/parquet/Log.java
+++ b/parquet-common/src/main/java/org/apache/parquet/Log.java
@@ -34,7 +34,6 @@ import java.util.logging.Level;
  * @author Julien Le Dem
  *
  */
-@Deprecated
 public class Log {
 
   /**
@@ -53,7 +52,6 @@ public class Log {
    * @return the corresponding logger
    * @deprecated will be removed in 2.0.0; use org.slf4j.LoggerFactory instead.
    */
-  @Deprecated
   public static Log getLog(Class<?> c) {
     return new Log(c);
   }

--- a/parquet-common/src/main/java/org/apache/parquet/Log.java
+++ b/parquet-common/src/main/java/org/apache/parquet/Log.java
@@ -18,16 +18,9 @@
  */
 package org.apache.parquet;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.text.MessageFormat;
-import java.util.Date;
-import java.util.logging.Formatter;
-import java.util.logging.Handler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
-import java.util.logging.StreamHandler;
 
 /**
  * Simple wrapper around java.util.logging
@@ -41,6 +34,7 @@ import java.util.logging.StreamHandler;
  * @author Julien Le Dem
  *
  */
+@Deprecated
 public class Log {
 
   /**
@@ -53,62 +47,13 @@ public class Log {
   public static final boolean WARN = (LEVEL.intValue() <= Level.WARNING.intValue());
   public static final boolean ERROR = (LEVEL.intValue() <= Level.SEVERE.intValue());
 
-  static {
-    // add a default handler in case there is none
-    Logger logger = Logger.getLogger(Log.class.getPackage().getName());
-    Handler[] handlers = logger.getHandlers();
-    if (handlers == null || handlers.length == 0) {
-      logger.setUseParentHandlers(false);
-      StreamHandler handler = new StreamHandler(System.out, new Formatter() {
-        Date dat = new Date();
-        private final static String format = "{0,date} {0,time}";
-        private MessageFormat formatter = new MessageFormat(format);
-
-        private Object args[] = new Object[1];
-
-        /**
-         * Format the given LogRecord.
-         * @param record the log record to be formatted.
-         * @return a formatted log record
-         */
-        public synchronized String format(LogRecord record) {
-          StringBuffer sb = new StringBuffer();
-          // Minimize memory allocations here.
-          dat.setTime(record.getMillis());
-          args[0] = dat;
-          formatter.format(args, sb, null);
-          sb.append(" ");
-          sb.append(record.getLevel().getLocalizedName());
-          sb.append(": ");
-          sb.append(record.getLoggerName());
-
-          sb.append(": ");
-          sb.append(formatMessage(record));
-          sb.append("\n");
-          if (record.getThrown() != null) {
-            try {
-              StringWriter sw = new StringWriter();
-              PrintWriter pw = new PrintWriter(sw);
-              record.getThrown().printStackTrace(pw);
-              pw.close();
-              sb.append(sw.toString());
-            } catch (Exception ex) {
-            }
-          }
-          return sb.toString();
-        }
-      });
-      handler.setLevel(LEVEL);
-      logger.addHandler(handler);
-    }
-    logger.setLevel(LEVEL);
-  }
-
   /**
    *
    * @param c the current class
    * @return the corresponding logger
+   * @deprecated will be removed in 2.0.0; use org.slf4j.LoggerFactory instead.
    */
+  @Deprecated
   public static Log getLog(Class<?> c) {
     return new Log(c);
   }
@@ -116,7 +61,7 @@ public class Log {
   private Logger logger;
 
   public Log(Class<?> c) {
-    this.logger = Logger.getLogger(c.getName());
+    this.logger = LoggerFactory.getLogger(c);
   }
 
   /**
@@ -125,9 +70,9 @@ public class Log {
    */
   public void debug(Object m) {
     if (m instanceof Throwable) {
-      logger.log(Level.FINE, "", (Throwable)m);
+      logger.debug("", (Throwable) m);
     } else {
-      logger.fine(String.valueOf(m));
+      logger.debug(String.valueOf(m));
     }
   }
 
@@ -137,7 +82,7 @@ public class Log {
    * @param t
    */
   public void debug(Object m, Throwable t) {
-    logger.log(Level.FINE, String.valueOf(m), t);
+    logger.debug(String.valueOf(m), t);
   }
 
   /**
@@ -146,7 +91,7 @@ public class Log {
    */
   public void info(Object m) {
     if (m instanceof Throwable) {
-      logger.log(Level.INFO, "", (Throwable)m);
+      logger.info("", (Throwable) m);
     } else {
       logger.info(String.valueOf(m));
     }
@@ -158,7 +103,7 @@ public class Log {
    * @param t
    */
   public void info(Object m, Throwable t) {
-    logger.log(Level.INFO, String.valueOf(m), t);
+    logger.info(String.valueOf(m), t);
   }
 
   /**
@@ -167,9 +112,9 @@ public class Log {
    */
   public void warn(Object m) {
     if (m instanceof Throwable) {
-      logger.log(Level.WARNING, "", (Throwable)m);
+      logger.warn("", (Throwable) m);
     } else {
-      logger.warning(String.valueOf(m));
+      logger.warn(String.valueOf(m));
     }
   }
 
@@ -179,7 +124,7 @@ public class Log {
    * @param t
    */
   public void warn(Object m, Throwable t) {
-    logger.log(Level.WARNING, String.valueOf(m), t);
+    logger.warn(String.valueOf(m), t);
   }
 
   /**
@@ -188,9 +133,9 @@ public class Log {
    */
   public void error(Object m) {
     if (m instanceof Throwable) {
-      logger.log(Level.SEVERE, "", (Throwable)m);
+      logger.error("", (Throwable) m);
     } else {
-      logger.warning(String.valueOf(m));
+      logger.error(String.valueOf(m));
     }
   }
 
@@ -200,7 +145,7 @@ public class Log {
    * @param t
    */
   public void error(Object m, Throwable t) {
-    logger.log(Level.SEVERE, String.valueOf(m), t);
+    logger.error(String.valueOf(m), t);
   }
 
 }

--- a/parquet-encoding/pom.xml
+++ b/parquet-encoding/pom.xml
@@ -47,6 +47,13 @@
       <version>1.5</version>
       <scope>compile</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -53,12 +53,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-jackson</artifactId>
       <version>${project.version}</version>
@@ -74,17 +68,23 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>11.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
       <version>1.1.1.6</version>
       <type>jar</type>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-pool</groupId>
+      <artifactId>commons-pool</artifactId>
+      <version>1.5.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>11.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -93,9 +93,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>commons-pool</groupId>
-      <artifactId>commons-pool</artifactId>
-      <version>1.5.4</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/parquet-pig/pom.xml
+++ b/parquet-pig/pom.xml
@@ -80,12 +80,6 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
       <version>${project.version}</version>
@@ -108,6 +102,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -76,6 +76,12 @@
       <version>${hadoop.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <developers>

--- a/parquet-scala/pom.xml
+++ b/parquet-scala/pom.xml
@@ -64,6 +64,12 @@
       <version>2.2.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -67,12 +67,6 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
       <version>${project.version}</version>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -79,12 +79,6 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
       <version>${project.version}</version>
@@ -120,6 +114,12 @@
       <artifactId>libthrift</artifactId>
       <version>${thrift.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/parquet-tools/pom.xml
+++ b/parquet-tools/pom.xml
@@ -72,6 +72,11 @@
       <artifactId>guava</artifactId>
       <version>11.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
     <hadoop.version>1.1.0</hadoop.version>
     <cascading.version>2.5.3</cascading.version>
     <parquet.format.version>2.3.0-incubating</parquet.format.version>
-    <log4j.version>1.2.17</log4j.version>
     <previous.version>1.7.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <scala.version>2.10.4</scala.version>
@@ -352,6 +351,16 @@
         <version>2.10</version>
         <configuration>
           <argLine>-Xmx512m</argLine>
+          <systemPropertyVariables>
+            <!-- Configure Parquet logging during tests
+                 See http://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html
+                 -->
+            <org.slf4j.simpleLogger.defaultLogLevel>info</org.slf4j.simpleLogger.defaultLogLevel>
+            <org.slf4j.simpleLogger.showDateTime>true</org.slf4j.simpleLogger.showDateTime>
+            <org.slf4j.simpleLogger.dateTimeFormat>YYYY-MM-dd HH:mm:ss</org.slf4j.simpleLogger.dateTimeFormat>
+            <org.slf4j.simpleLogger.showThreadName>false</org.slf4j.simpleLogger.showThreadName>
+            <org.slf4j.simpleLogger.showShortLogName>true</org.slf4j.simpleLogger.showShortLogName>
+          </systemPropertyVariables>
           <excludes>
             <exclude>**/benchmark/*.java</exclude>
           </excludes>


### PR DESCRIPTION
This removes the Log implementation based on java.util.logging and
replaces it with SLF4J. The compiler removal of debug log messages still
works because Log.DEBUG and similar final constants are unchanged.

This commit adds slf4j-simple as the test logger implementation.
Configuration for slf4j-simple is in the root pom. Two modules can't use
slf4j-simple, parquet-pig and parquet-thrift, and use slf4j-log4j12
instead because pig depends on log4j and tests die without it.