### PR TITLE
PARQUET-398: Updates dev/COMMITTERS.md

### DIFF
--- a/dev/COMMITTERS.md
+++ b/dev/COMMITTERS.md
@@ -23,6 +23,7 @@
 |--------------------|------------|----------------|-------------|
 | Aniket Mokashi     | aniket486  | aniket486      |             |
 | Brock Noland       | brock      | brockn         |             |
+| Cheng Lian         | lian       | liancheng      | lian cheng  |
 | Chris Aniszczyk    | caniszczyk |                |             |
 | Dmitriy Ryaboy     | dvryaboy   | dvryaboy       |             |
 | Jake Farrell       | jfarrell   |                |             |


### PR DESCRIPTION
Updates `dev/COMMITTERS.md` to test committership.