### PR TITLE
PARQUET-404: Replace git@github.com.apache for HTTPS URL on dev/README.md to avoid permission issues

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -26,7 +26,7 @@ Merging a pull request requires being a committer on the project.
 * How to merge a Pull request:
 have an apache and apache-github remote setup
 ```
-git remote add apache-github git@github.com:apache/parquet-mr.git
+git remote add apache-github https://github.com/apache/parquet-mr.git
 git remote add apache https://git-wip-us.apache.org/repos/asf/parquet-mr.git
 ```
 run the following command


### PR DESCRIPTION
…lic key on committer github account is needed

@julienledem @rdblue @liancheng Could you help me review this trivial patch for dev/README.md?