### PR TITLE
Parquet-400: Fixed issue reading some files from HDFS and S3 when usi…

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -833,7 +833,7 @@ public class ParquetFileReader implements Closeable {
       } else {
         chunksByteBuffer = allocator.allocate(length);
         while (chunksByteBuffer.hasRemaining()) {
-          CompatibilityUtil.getBuf(f, chunksByteBuffer, chunksByteBuffer.remaining());
+          CompatibilityUtil.getBuf(f, chunksByteBuffer);
         }
       }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/CompatibilityUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/CompatibilityUtil.java
@@ -66,16 +66,6 @@ public class CompatibilityUtil {
     }
   }
 
-  private static Object invoke(Method method, String errorMsg, Object instance, Object... args) {
-    try {
-      return method.invoke(instance, args);
-    } catch (IllegalAccessException e) {
-      throw new IllegalArgumentException(errorMsg, e);
-    } catch (InvocationTargetException e) {
-      throw new IllegalArgumentException(errorMsg, e);
-    }
-  }
-
   public static int getBuf(FSDataInputStream f, ByteBuffer readBuf) throws IOException {
     int res;
     if (useV21) {
@@ -105,9 +95,13 @@ public class CompatibilityUtil {
         throw new ShouldNeverHappenException(e);
       }
     } else {
-      byte[] buf = new byte[readBuf.remaining()];
-      res = f.read(buf);
-      readBuf.put(buf, 0, res);
+      if (readBuf.hasArray()) {
+        res = f.read(readBuf.array(), readBuf.arrayOffset(), readBuf.remaining());
+      } else {
+        byte[] buf = new byte[readBuf.remaining()];
+        res = f.read(buf);
+        readBuf.put(buf, 0, res);
+      }
     }
     return res;
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/CompatibilityUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/CompatibilityUtil.java
@@ -96,7 +96,9 @@ public class CompatibilityUtil {
       }
     } else {
       if (readBuf.hasArray()) {
+        int initPos = readBuf.position();
         res = f.read(readBuf.array(), readBuf.arrayOffset(), readBuf.remaining());
+        readBuf.position(initPos + res);
       } else {
         byte[] buf = new byte[readBuf.remaining()];
         res = f.read(buf);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/CompatibilityUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/CompatibilityUtil.java
@@ -76,7 +76,7 @@ public class CompatibilityUtil {
     }
   }
 
-  public static int getBuf(FSDataInputStream f, ByteBuffer readBuf, int maxSize) throws IOException {
+  public static int getBuf(FSDataInputStream f, ByteBuffer readBuf) throws IOException {
     int res;
     if (useV21) {
       try {
@@ -88,7 +88,7 @@ public class CompatibilityUtil {
           // be a reasonable check to make to see if the interface is
           // present but not implemented and we should be falling back
           useV21 = false;
-          return getBuf(f, readBuf, maxSize);
+          return getBuf(f, readBuf);
         } else if (e.getCause() instanceof IOException) {
           throw (IOException) e.getCause();
         } else {
@@ -105,7 +105,7 @@ public class CompatibilityUtil {
         throw new ShouldNeverHappenException(e);
       }
     } else {
-      byte[] buf = new byte[maxSize];
+      byte[] buf = new byte[readBuf.remaining()];
       res = f.read(buf);
       readBuf.put(buf, 0, res);
     }


### PR DESCRIPTION
…ng Hadoop 2.x

The problem was not handling the case where a read request returns less
than the requested number of bytes. The FSDataInputStream lacks an
API equivalent for readFully when using ByteBuffers, which used to solve
this problem when using byte arrays as the destination. This has been
fixed by including a loop to manually request the remaining bytes until
everything has been read.