### PR TITLE
PARQUET-421: Fix mismatch of javadoc names and method parameters in m...

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/page/DataPageV1.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/DataPageV1.java
@@ -41,10 +41,10 @@ public class DataPageV1 extends DataPage {
    * @param valuesEncoding the values encoding for this page
    * @param dlEncoding
    */
-  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, Statistics<?> stats, Encoding rlEncoding, Encoding dlEncoding, Encoding valuesEncoding) {
+  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding, Encoding valuesEncoding) {
     super(Ints.checkedCast(bytes.size()), uncompressedSize, valueCount);
     this.bytes = bytes;
-    this.statistics = stats;
+    this.statistics = statistics;
     this.rlEncoding = rlEncoding;
     this.dlEncoding = dlEncoding;
     this.valuesEncoding = valuesEncoding;

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/ValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/ValuesWriter.java
@@ -80,7 +80,7 @@ public abstract class ValuesWriter {
   }
 
   /**
-   * ( > {@link #getBufferedMemorySize} )
+   * ( > {@link #getBufferedSize} )
    * @return the allocated size of the buffer
    */
   abstract public long getAllocatedSize();
@@ -93,42 +93,42 @@ public abstract class ValuesWriter {
   }
 
   /**
-   * @param value the value to encode
+   * @param v the value to encode
    */
   public void writeBoolean(boolean v) {
     throw new UnsupportedOperationException(getClass().getName());
   }
 
   /**
-   * @param value the value to encode
+   * @param v the value to encode
    */
   public void writeBytes(Binary v) {
     throw new UnsupportedOperationException(getClass().getName());
   }
 
   /**
-   * @param value the value to encode
+   * @param v the value to encode
    */
   public void writeInteger(int v) {
     throw new UnsupportedOperationException(getClass().getName());
   }
 
   /**
-   * @param value the value to encode
+   * @param v the value to encode
    */
   public void writeLong(long v) {
     throw new UnsupportedOperationException(getClass().getName());
   }
 
   /**
-   * @param value the value to encode
+   * @param v the value to encode
    */
   public void writeDouble(double v) {
     throw new UnsupportedOperationException(getClass().getName());
   }
 
   /**
-   * @param value the value to encode
+   * @param v the value to encode
    */
   public void writeFloat(float v) {
     throw new UnsupportedOperationException(getClass().getName());

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/plain/BooleanPlainValuesReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/plain/BooleanPlainValuesReader.java
@@ -51,7 +51,7 @@ public class BooleanPlainValuesReader extends ValuesReader {
 
   /**
    * {@inheritDoc}
-   * @see org.apache.parquet.column.values.ValuesReader#skipBoolean()
+   * @see org.apache.parquet.column.values.ValuesReader#skip()
    */
   @Override
   public void skip() {
@@ -60,7 +60,7 @@ public class BooleanPlainValuesReader extends ValuesReader {
 
   /**
    * {@inheritDoc}
-   * @see org.apache.parquet.column.values.ValuesReader#initFromPage(byte[], int)
+   * @see org.apache.parquet.column.values.ValuesReader#initFromPage(int valueCount, ByteBuffer page, int offset)
    */
   @Override
   public void initFromPage(int valueCount, ByteBuffer in, int offset) throws IOException {

--- a/parquet-column/src/main/java/org/apache/parquet/schema/TypeConverter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/TypeConverter.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 /**
  * to convert a MessageType tree
- * @see Type#convert(TypeConverter)
+ * @see Type#convert(List, TypeConverter)
  *
  * @author Julien Le Dem
  *

--- a/parquet-encoding/src/main/java/org/apache/parquet/column/values/bitpacking/BitPacking.java
+++ b/parquet-encoding/src/main/java/org/apache/parquet/column/values/bitpacking/BitPacking.java
@@ -109,7 +109,7 @@ public class BitPacking {
   /**
    *
    * @param bitLength the width in bits of the integers to read
-   * @param inthe stream to read the bytes from
+   * @param in the stream to read the bytes from
    * @return the correct implementation for the width
    */
   public static BitPackingReader createBitPackingReader(int bitLength, InputStream in, long valueCount) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/example/ExampleOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/example/ExampleOutputFormat.java
@@ -30,7 +30,7 @@ import org.apache.parquet.schema.MessageType;
  * An example output format
  *
  * must be provided the schema up front
- * @see ExampleOutputFormat#setSchema(Configuration, MessageType)
+ * @see ExampleOutputFormat#setSchema(Job, MessageType)
  * @see GroupWriteSupport#PARQUET_EXAMPLE_SCHEMA
  *
  * @author Julien Le Dem
@@ -40,8 +40,8 @@ public class ExampleOutputFormat extends ParquetOutputFormat<Group> {
 
   /**
    * set the schema being written to the job conf
+   * @param job
    * @param schema the schema of the data
-   * @param configuration the job configuration
    */
   public static void setSchema(Job job, MessageType schema) {
     GroupWriteSupport.setSchema(schema, ContextUtil.getConfiguration(job));
@@ -49,7 +49,7 @@ public class ExampleOutputFormat extends ParquetOutputFormat<Group> {
 
   /**
    * retrieve the schema from the conf
-   * @param configuration the job conf
+   * @param job
    * @return the schema
    */
   public static MessageType getSchema(Job job) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ParquetMetadata.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ParquetMetadata.java
@@ -101,7 +101,6 @@ public class ParquetMetadata {
    *
    * @param fileMetaData file level metadata
    * @param blocks block level metadata
-   * @param keyValueMetaData
    */
   public ParquetMetadata(FileMetaData fileMetaData, List<BlockMetaData> blocks) {
     this.fileMetaData = fileMetaData;


### PR DESCRIPTION
…odule encoding, column, and hadoop




Codes change now and then, but some corresponding doc comments are left out.

This PR fixes only the doc comments that should have been changed. It should be OK, since none codes are touched.

@rdblue could you take a look please? Cheers.