### PR TITLE
PARQUET-429: Enables predicates collecting their referred columns

### DIFF
--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectInputOutputFormat.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectInputOutputFormat.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import org.apache.avro.Schema;
 import org.apache.avro.reflect.Nullable;
 import org.apache.avro.reflect.ReflectData;
@@ -43,6 +45,7 @@ import org.apache.parquet.filter.ColumnPredicates;
 import org.apache.parquet.filter.ColumnRecordFilter;
 import org.apache.parquet.filter.RecordFilter;
 import org.apache.parquet.filter.UnboundRecordFilter;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -325,6 +328,11 @@ public class TestReflectInputOutputFormat {
     @Override
     public RecordFilter bind(Iterable<ColumnReader> readers) {
       return filter.bind(readers);
+    }
+
+    @Override
+    public void collectColumnPaths(Set<ColumnPath> columnPathSet) {
+      // do nothing
     }
   }
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificInputOutputFormat.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificInputOutputFormat.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.fail;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
+
 import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -36,6 +38,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -124,6 +127,11 @@ public class TestSpecificInputOutputFormat {
     @Override
     public RecordFilter bind(Iterable<ColumnReader> readers) {
       return filter.bind(readers);
+    }
+
+    @Override
+    public void collectColumnPaths(Set<ColumnPath> columnPathSet) {
+      // do nothing
     }
   }
 

--- a/parquet-column/src/main/java/org/apache/parquet/filter/AndRecordFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter/AndRecordFilter.java
@@ -20,6 +20,9 @@ package org.apache.parquet.filter;
 
 import org.apache.parquet.Preconditions;
 import org.apache.parquet.column.ColumnReader;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+import java.util.Set;
 
 /**
  * Provides ability to chain two filters together. Bear in mind that the first one will
@@ -45,6 +48,12 @@ public final class AndRecordFilter implements RecordFilter {
       @Override
       public RecordFilter bind(Iterable<ColumnReader> readers) {
         return new AndRecordFilter( filter1.bind(readers), filter2.bind( readers) );
+      }
+
+      @Override
+      public void collectColumnPaths(Set<ColumnPath> columnPathSet) {
+        filter1.collectColumnPaths(columnPathSet);
+        filter2.collectColumnPaths(columnPathSet);
       }
     };
   }

--- a/parquet-column/src/main/java/org/apache/parquet/filter/ColumnRecordFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter/ColumnRecordFilter.java
@@ -19,7 +19,11 @@
 package org.apache.parquet.filter;
 
 import org.apache.parquet.column.ColumnReader;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
 import java.util.Arrays;
+import java.util.Set;
+
 import static org.apache.parquet.Preconditions.checkNotNull;
 
 /**
@@ -52,6 +56,11 @@ public final class ColumnRecordFilter implements RecordFilter {
           }
         }
         throw new IllegalArgumentException( "Column " + columnPath + " does not exist.");
+      }
+
+      @Override
+      public void collectColumnPaths(Set<ColumnPath> columnPathSet) {
+        columnPathSet.add(ColumnPath.get(filterPath));
       }
     };
   }

--- a/parquet-column/src/main/java/org/apache/parquet/filter/NotRecordFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter/NotRecordFilter.java
@@ -20,6 +20,9 @@ package org.apache.parquet.filter;
 
 import org.apache.parquet.Preconditions;
 import org.apache.parquet.column.ColumnReader;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+import java.util.Set;
 
 /**
  * Provides ability to negate the result of a filter.
@@ -40,6 +43,11 @@ public final class NotRecordFilter implements RecordFilter {
       @Override
       public RecordFilter bind(Iterable<ColumnReader> readers) {
         return new NotRecordFilter( filter.bind(readers) );
+      }
+
+      @Override
+      public void collectColumnPaths(Set<ColumnPath> columnPathSet) {
+        filter.collectColumnPaths(columnPathSet);
       }
     };
   }

--- a/parquet-column/src/main/java/org/apache/parquet/filter/OrRecordFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter/OrRecordFilter.java
@@ -20,6 +20,9 @@ package org.apache.parquet.filter;
 
 import org.apache.parquet.Preconditions;
 import org.apache.parquet.column.ColumnReader;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+import java.util.Set;
 
 /**
  * Provides ability to chain two filters together.
@@ -43,6 +46,12 @@ public final class OrRecordFilter implements RecordFilter {
       @Override
       public RecordFilter bind(Iterable<ColumnReader> readers) {
         return new OrRecordFilter( filter1.bind(readers), filter2.bind( readers) );
+      }
+
+      @Override
+      public void collectColumnPaths(Set<ColumnPath> columnPathSet) {
+        filter1.collectColumnPaths(columnPathSet);
+        filter2.collectColumnPaths(columnPathSet);
       }
     };
   }

--- a/parquet-column/src/main/java/org/apache/parquet/filter/PagedRecordFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter/PagedRecordFilter.java
@@ -19,6 +19,9 @@
 package org.apache.parquet.filter;
 
 import org.apache.parquet.column.ColumnReader;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+import java.util.Set;
 
 /**
  * Filter which will only materialize a page worth of results.
@@ -39,6 +42,11 @@ public final class PagedRecordFilter implements RecordFilter {
       @Override
       public RecordFilter bind(Iterable<ColumnReader> readers) {
         return new PagedRecordFilter( startPos, pageSize );
+      }
+
+      @Override
+      public void collectColumnPaths(Set<ColumnPath> columnPathSet) {
+        // do nothing here
       }
     };
   }

--- a/parquet-column/src/main/java/org/apache/parquet/filter/UnboundRecordFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter/UnboundRecordFilter.java
@@ -19,6 +19,9 @@
 package org.apache.parquet.filter;
 
 import org.apache.parquet.column.ColumnReader;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+import java.util.Set;
 
 /**
  * Builder for a record filter. Idea is that each filter provides a create function
@@ -32,5 +35,10 @@ public interface UnboundRecordFilter {
   /**
    * Call to bind to actual columns and create filter.
    */
-  RecordFilter bind( Iterable<ColumnReader> readers);
+  RecordFilter bind(Iterable<ColumnReader> readers);
+
+  /**
+   * Call to collect column paths into the set
+   */
+  void collectColumnPaths(Set<ColumnPath> columnPathSet);
 }

--- a/parquet-column/src/main/java/org/apache/parquet/filter2/compat/FilterCompatColumnCollector.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter2/compat/FilterCompatColumnCollector.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.filter2.compat;
+
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.filter2.predicate.Operators;
+import org.apache.parquet.filter2.predicate.UserDefinedPredicate;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class FilterCompatColumnCollector implements FilterCompat.Visitor<Set<ColumnPath>> {
+
+  public static final FilterCompatColumnCollector INSTANCE = new FilterCompatColumnCollector();
+
+  private FilterCompatColumnCollector() {
+  }
+
+  @Override
+  public Set<ColumnPath> visit(FilterCompat.FilterPredicateCompat filterPredicateCompat) {
+    FilterPredicateColumnCollector collector = new FilterPredicateColumnCollector();
+    filterPredicateCompat.getFilterPredicate().accept(collector);
+    return collector.getColumnSet();
+  }
+
+  @Override
+  public Set<ColumnPath> visit(FilterCompat.UnboundRecordFilterCompat unboundRecordFilterCompat) {
+    final HashSet<ColumnPath> columnSet = new HashSet<ColumnPath>();
+    unboundRecordFilterCompat.getUnboundRecordFilter().collectColumnPaths(columnSet);
+    return columnSet;
+  }
+
+  @Override
+  public Set<ColumnPath> visit(FilterCompat.NoOpFilter noOpFilter) {
+    return null;
+  }
+
+  /**
+   * This class is stateful, and not thread-safe
+   * So create an instance every time this is used
+   */
+  private static class FilterPredicateColumnCollector implements FilterPredicate.Visitor<Boolean> {
+
+    private final HashSet<ColumnPath> columnSet = new HashSet<ColumnPath>();
+
+    @Override
+    public <T extends Comparable<T>> Boolean visit(Operators.Eq<T> eq) {
+      return columnSet.add(eq.getColumn().getColumnPath());
+    }
+
+    @Override
+    public <T extends Comparable<T>> Boolean visit(Operators.NotEq<T> notEq) {
+      return columnSet.add(notEq.getColumn().getColumnPath());
+    }
+
+    @Override
+    public <T extends Comparable<T>> Boolean visit(Operators.Lt<T> lt) {
+      return columnSet.add(lt.getColumn().getColumnPath());
+    }
+
+    @Override
+    public <T extends Comparable<T>> Boolean visit(Operators.LtEq<T> ltEq) {
+      return columnSet.add(ltEq.getColumn().getColumnPath());
+    }
+
+    @Override
+    public <T extends Comparable<T>> Boolean visit(Operators.Gt<T> gt) {
+      return columnSet.add(gt.getColumn().getColumnPath());
+    }
+
+    @Override
+    public <T extends Comparable<T>> Boolean visit(Operators.GtEq<T> gtEq) {
+      return columnSet.add(gtEq.getColumn().getColumnPath());
+    }
+
+    @Override
+    public Boolean visit(Operators.And and) {
+      and.getLeft().accept(this);
+      return and.getRight().accept(this);
+    }
+
+    @Override
+    public Boolean visit(Operators.Or or) {
+      or.getLeft().accept(this);
+      return or.getRight().accept(this);
+    }
+
+    @Override
+    public Boolean visit(Operators.Not not) {
+      return not.getPredicate().accept(this);
+    }
+
+    @Override
+    public <T extends Comparable<T>, U extends UserDefinedPredicate<T>> Boolean visit(
+        Operators.UserDefined<T, U> udp) {
+      return columnSet.add(udp.getColumn().getColumnPath());
+    }
+
+    @Override
+    public <T extends Comparable<T>, U extends UserDefinedPredicate<T>> Boolean visit(
+        Operators.LogicalNotUserDefined<T, U> udp) {
+
+      return udp.getUserDefined().accept(this);
+    }
+
+    public HashSet<ColumnPath> getColumnSet() {
+      return columnSet;
+    }
+  }
+}

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/compat/TestFilterCompatColumnCollector.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/compat/TestFilterCompatColumnCollector.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.filter2.compat;
+
+import org.apache.parquet.column.ColumnReader;
+import org.apache.parquet.filter.AndRecordFilter;
+import org.apache.parquet.filter.ColumnPredicates;
+import org.apache.parquet.filter.ColumnRecordFilter;
+import org.apache.parquet.filter.NotRecordFilter;
+import org.apache.parquet.filter.OrRecordFilter;
+import org.apache.parquet.filter.PagedRecordFilter;
+import org.apache.parquet.filter.UnboundRecordFilter;
+import org.apache.parquet.filter2.predicate.DummyUdp;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.parquet.filter2.predicate.FilterApi.and;
+import static org.apache.parquet.filter2.predicate.FilterApi.eq;
+import static org.apache.parquet.filter2.predicate.FilterApi.gt;
+import static org.apache.parquet.filter2.predicate.FilterApi.gtEq;
+import static org.apache.parquet.filter2.predicate.FilterApi.intColumn;
+import static org.apache.parquet.filter2.predicate.FilterApi.lt;
+import static org.apache.parquet.filter2.predicate.FilterApi.ltEq;
+import static org.apache.parquet.filter2.predicate.FilterApi.not;
+import static org.apache.parquet.filter2.predicate.FilterApi.notEq;
+import static org.apache.parquet.filter2.predicate.FilterApi.or;
+import static org.apache.parquet.filter2.predicate.FilterApi.userDefined;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class TestFilterCompatColumnCollector {
+
+  @Test
+  public void testVisitFilterPredicateCompat() {
+    FilterPredicate f1 = or(eq(intColumn("a"), 1),
+                            notEq(intColumn("a"), 2));
+    FilterPredicate f2 = and(gt(intColumn("b.b"), 1),
+                             gtEq(intColumn("b.b"), 2));
+    FilterPredicate f3 = not(lt(intColumn("c.c1"), 1));
+    FilterPredicate f4 = not(ltEq(intColumn("c.c2"), 2));
+    FilterPredicate f5 = userDefined(intColumn("d.d.d1"), DummyUdp.class);
+    FilterPredicate f6 = not(userDefined(intColumn("d.d.d2"), DummyUdp.class));
+    FilterPredicate f = and(f1, and(f2, and(f3, and(f4, and(f5, f6)))));
+
+    Set<ColumnPath> resultSet =
+        FilterCompatColumnCollector.INSTANCE.visit((FilterCompat.FilterPredicateCompat) (FilterCompat.get(f)));
+
+    Set<ColumnPath> expectSet = new HashSet<ColumnPath>();
+    expectSet.add(ColumnPath.get("a"));
+    expectSet.add(ColumnPath.get("b", "b"));
+    expectSet.add(ColumnPath.get("c", "c1"));
+    expectSet.add(ColumnPath.get("c", "c2"));
+    expectSet.add(ColumnPath.get("d", "d", "d1"));
+    expectSet.add(ColumnPath.get("d", "d", "d2"));
+
+    assertEquals(expectSet, resultSet);
+  }
+
+  private static class DummyColumnPredicate implements ColumnPredicates.Predicate {
+
+    @Override
+    public boolean apply(ColumnReader input) {
+      return false;
+    }
+  }
+
+  @Test
+  public void testVisitUnboundRecordFilterCompat() {
+    UnboundRecordFilter f1 = ColumnRecordFilter.column("a", new DummyColumnPredicate());
+    UnboundRecordFilter f2 = ColumnRecordFilter.column("a", new DummyColumnPredicate());
+    UnboundRecordFilter f3 = ColumnRecordFilter.column("b.b", new DummyColumnPredicate());
+    UnboundRecordFilter f4 = ColumnRecordFilter.column("b.b", new DummyColumnPredicate());
+    UnboundRecordFilter f5 = ColumnRecordFilter.column("c.c1", new DummyColumnPredicate());
+    UnboundRecordFilter f6 = ColumnRecordFilter.column("c.c2", new DummyColumnPredicate());
+    UnboundRecordFilter f7 = ColumnRecordFilter.column("d.d.d1", new DummyColumnPredicate());
+    UnboundRecordFilter f8 = ColumnRecordFilter.column("d.d.d2", new DummyColumnPredicate());
+
+    UnboundRecordFilter f9 = OrRecordFilter.or(f1, OrRecordFilter.or(f2, OrRecordFilter.or(f3, f4)));
+    UnboundRecordFilter f10 =
+        NotRecordFilter.not(OrRecordFilter.or(f5, OrRecordFilter.or(f6, OrRecordFilter.or(f7, f8))));
+    UnboundRecordFilter f = AndRecordFilter.and(AndRecordFilter.and(f9, f10), PagedRecordFilter.page(0, 100));
+
+    Set<ColumnPath> resultSet =
+        FilterCompatColumnCollector.INSTANCE.visit((FilterCompat.UnboundRecordFilterCompat) (FilterCompat.get(f)));
+
+    Set<ColumnPath> expectSet = new HashSet<ColumnPath>();
+    expectSet.add(ColumnPath.get("a"));
+    expectSet.add(ColumnPath.get("b", "b"));
+    expectSet.add(ColumnPath.get("c", "c1"));
+    expectSet.add(ColumnPath.get("c", "c2"));
+    expectSet.add(ColumnPath.get("d", "d", "d1"));
+    expectSet.add(ColumnPath.get("d", "d", "d2"));
+
+    assertEquals(expectSet, resultSet);
+  }
+
+  @Test
+  public void testVisitNoOpFilter() {
+    assertNull(FilterCompatColumnCollector.INSTANCE.visit((FilterCompat.NoOpFilter) FilterCompat.NOOP));
+  }
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputFormat.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputFormat.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
@@ -300,6 +301,11 @@ public class TestInputFormat {
     @Override
     public RecordFilter bind(Iterable<ColumnReader> readers) {
       return null;
+    }
+
+    @Override
+    public void collectColumnPaths(Set<ColumnPath> columnPathSet) {
+      // do nothing here
     }
   }
 


### PR DESCRIPTION
This PR enables all 3 FilterCompats to collect their referred columns.

Unit tests for the changed codes are also added.

@julienledem @rdblue @isnotinvain @liancheng Could you please take a look at this? Cheers.