### PR TITLE
PARQUET-431: Make ParquetOutputFormat.memoryManager volatile

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -394,9 +394,12 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
         MemoryManager.DEFAULT_MEMORY_POOL_RATIO);
     long minAllocation = conf.getLong(ParquetOutputFormat.MIN_MEMORY_ALLOCATION,
         MemoryManager.DEFAULT_MIN_MEMORY_ALLOCATION);
-    if (memoryManager == null) {
-      memoryManager = new MemoryManager(maxLoad, minAllocation);
-    } else if (memoryManager.getMemoryPoolRatio() != maxLoad) {
+    synchronized (ParquetOutputFormat.class) {
+      if (memoryManager == null) {
+        memoryManager = new MemoryManager(maxLoad, minAllocation);
+      }
+    }
+    if (memoryManager.getMemoryPoolRatio() != maxLoad) {
       LOG.warn("The configuration " + MEMORY_POOL_RATIO + " has been set. It should not " +
           "be reset by the new value: " + maxLoad);
     }
@@ -447,7 +450,11 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
    */
   private static volatile MemoryManager memoryManager;
 
-  public static MemoryManager getMemoryManager() {
+  /**
+   * This method is intended to ONLY be used in test codes
+   * */
+  @Deprecated
+  public synchronized static MemoryManager getMemoryManager() {
     return memoryManager;
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -445,7 +445,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   /**
    * This memory manager is for all the real writers (InternalParquetRecordWriter) in one task.
    */
-  private static MemoryManager memoryManager;
+  private static volatile MemoryManager memoryManager;
 
   public static MemoryManager getMemoryManager() {
     return memoryManager;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -450,10 +450,6 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
    */
   private static volatile MemoryManager memoryManager;
 
-  /**
-   * This method is intended to ONLY be used in test codes
-   * */
-  @Deprecated
   public synchronized static MemoryManager getMemoryManager() {
     return memoryManager;
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -444,7 +444,6 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
     return committer;
   }
 
-
   /**
    * This memory manager is for all the real writers (InternalParquetRecordWriter) in one task.
    */

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -448,7 +448,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   /**
    * This memory manager is for all the real writers (InternalParquetRecordWriter) in one task.
    */
-  private static volatile MemoryManager memoryManager;
+  private static MemoryManager memoryManager;
 
   public synchronized static MemoryManager getMemoryManager() {
     return memoryManager;


### PR DESCRIPTION
Currently ParquetOutputFormat.getRecordWriter() contains an unsynchronized lazy initialization of the non-volatile static field *memoryManager*.

Because the compiler or processor may reorder instructions, threads are not guaranteed to see a completely initialized object, when ParquetOutputFormat.getRecordWriter() is called by multiple threads.

This PR makes *memoryManager* volatile to correct the problem.