### PR TITLE
PARQUET-484: Warn when Decimal is stored as INT64 while could be stored as INT32

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.parquet.Preconditions;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type.ID;
+import org.slf4j.Logger;
 
 /**
  * This class provides fluent builders that produce Parquet schema Types.
@@ -305,6 +306,7 @@ public class Types {
   public abstract static class
       BasePrimitiveBuilder<P, THIS extends BasePrimitiveBuilder<P, THIS>>
       extends Builder<THIS, P> {
+    private final Logger log = org.slf4j.LoggerFactory.getLogger(BasePrimitiveBuilder.class);
     private static final long MAX_PRECISION_INT32 = maxPrecision(4);
     private static final long MAX_PRECISION_INT64 = maxPrecision(8);
     private final PrimitiveTypeName primitiveType;
@@ -406,6 +408,11 @@ public class Types {
                   meta.getPrecision() <= MAX_PRECISION_INT64,
                   "INT64 cannot store " + meta.getPrecision() + " digits " +
                   "(max " + MAX_PRECISION_INT64 + ")");
+              if (meta.getPrecision() <= MAX_PRECISION_INT32) {
+                String msg = String.format("Consider use INT32 instead of INT64 for storing %d digits; see %s for details.",
+                    precision, "https://github.com/Parquet/parquet-format/blob/master/LogicalTypes.md");
+                log.warn(msg);
+              }
             } else if (primitiveType == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
               Preconditions.checkState(
                   meta.getPrecision() <= maxPrecision(length),

--- a/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
@@ -26,6 +26,7 @@ import org.apache.parquet.Preconditions;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type.ID;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class provides fluent builders that produce Parquet schema Types.
@@ -306,9 +307,11 @@ public class Types {
   public abstract static class
       BasePrimitiveBuilder<P, THIS extends BasePrimitiveBuilder<P, THIS>>
       extends Builder<THIS, P> {
-    private final Logger log = org.slf4j.LoggerFactory.getLogger(BasePrimitiveBuilder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BasePrimitiveBuilder.class);
     private static final long MAX_PRECISION_INT32 = maxPrecision(4);
     private static final long MAX_PRECISION_INT64 = maxPrecision(8);
+    private static final String LOGICAL_TYPES_DOC_URL =
+        "https://github.com/apache/parquet-format/blob/master/LogicalTypes.md";
     private final PrimitiveTypeName primitiveType;
     private int length = NOT_SET;
     private int precision = NOT_SET;
@@ -409,9 +412,8 @@ public class Types {
                   "INT64 cannot store " + meta.getPrecision() + " digits " +
                   "(max " + MAX_PRECISION_INT64 + ")");
               if (meta.getPrecision() <= MAX_PRECISION_INT32) {
-                String msg = String.format("Consider use INT32 instead of INT64 for storing %d digits; see %s for details.",
-                    precision, "https://github.com/Parquet/parquet-format/blob/master/LogicalTypes.md");
-                log.warn(msg);
+                LOGGER.warn("Decimal with {} digits is stored in an INT64, but fits in an INT32. See {}.",
+                            precision, LOGICAL_TYPES_DOC_URL);
               }
             } else if (primitiveType == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
               Preconditions.checkState(


### PR DESCRIPTION
Below is documented in [LogicalTypes.md](https://github.com/Parquet/parquet-format/blob/master/LogicalTypes.md#decimal):

> int32: for 1 <= precision <= 9
> int64: for 1 <= precision <= 18; precision < 10 will produce a warning

This PR implements the `precision < 10 will produce a warning` part.

@rdblue @liancheng would mind taking a look at this when you have time? It's a fairly small addition; cheers.