### PR TITLE
PARQUET-509: Fix args passed to string format calls

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectCodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectCodecFactory.java
@@ -389,7 +389,7 @@ class DirectCodecFactory extends CodecFactory implements AutoCloseable {
             decompressorPool.returnObject(decom);
           } else {
             if (Log.DEBUG) {
-              LOG.debug(String.format(BYTE_BUF_IMPL_NOT_FOUND_MSG, "decompressor" + codec.getClass().getName()));
+              LOG.debug(String.format(BYTE_BUF_IMPL_NOT_FOUND_MSG, "decompressor", codec.getClass().getName()));
             }
           }
 
@@ -409,7 +409,7 @@ class DirectCodecFactory extends CodecFactory implements AutoCloseable {
             } else {
               supportDirectDecompressor = false;
               if (Log.DEBUG) {
-                LOG.debug(String.format(BYTE_BUF_IMPL_NOT_FOUND_MSG, "compressor" + codec.getClass().getName()));
+                LOG.debug(String.format(BYTE_BUF_IMPL_NOT_FOUND_MSG, "compressor", codec.getClass().getName()));
               }
             }
 


### PR DESCRIPTION
This PR fixes the args passed to the `String.format()` call.