### PR TITLE
PARQUET-540: Fix Cascading 3 build thrift and SLF4J.

### DIFF
--- a/parquet-cascading/pom.xml
+++ b/parquet-cascading/pom.xml
@@ -157,7 +157,7 @@
       <plugin>
         <groupId>org.apache.thrift.tools</groupId>
         <artifactId>maven-thrift-plugin</artifactId>
-        <version>0.1.10</version>
+        <version>0.1.11</version>
         <configuration>
           <thriftExecutable>${thrift.executable}</thriftExecutable>
           <thriftSourceRoot>../parquet-cascading-common23/src/main/thrift</thriftSourceRoot>

--- a/parquet-cascading/pom.xml
+++ b/parquet-cascading/pom.xml
@@ -157,7 +157,7 @@
       <plugin>
         <groupId>org.apache.thrift.tools</groupId>
         <artifactId>maven-thrift-plugin</artifactId>
-        <version>0.1.11</version>
+        <version>${maven-thrift-plugin.version}</version>
         <configuration>
           <thriftExecutable>${thrift.executable}</thriftExecutable>
           <thriftSourceRoot>../parquet-cascading-common23/src/main/thrift</thriftSourceRoot>

--- a/parquet-cascading3/pom.xml
+++ b/parquet-cascading3/pom.xml
@@ -51,15 +51,32 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-        <groupId>org.apache.parquet</groupId>
-        <artifactId>parquet-thrift</artifactId>
-        <version>${project.version}</version>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-thrift</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${thrift.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+       <groupId>cascading</groupId>
+       <artifactId>cascading-hadoop</artifactId> <!-- building against cascading-hadoop for Hadoop1, but will use against any backend -->
+       <version>${cascading3.version}</version>
+       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
@@ -75,10 +92,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-       <groupId>cascading</groupId>
-       <artifactId>cascading-hadoop</artifactId> <!-- building against cascading-hadoop for Hadoop1, but will use against any backend -->
-       <version>${cascading3.version}</version>
-       <scope>provided</scope>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -157,7 +174,7 @@
       <plugin>
         <groupId>org.apache.thrift.tools</groupId>
         <artifactId>maven-thrift-plugin</artifactId>
-        <version>0.1.10</version>
+        <version>0.1.11</version>
         <configuration>
           <thriftExecutable>${thrift.executable}</thriftExecutable>
           <thriftSourceRoot>../parquet-cascading-common23/src/main/thrift</thriftSourceRoot>

--- a/parquet-cascading3/pom.xml
+++ b/parquet-cascading3/pom.xml
@@ -174,7 +174,7 @@
       <plugin>
         <groupId>org.apache.thrift.tools</groupId>
         <artifactId>maven-thrift-plugin</artifactId>
-        <version>0.1.11</version>
+        <version>${maven-thrift-plugin.version}</version>
         <configuration>
           <thriftExecutable>${thrift.executable}</thriftExecutable>
           <thriftSourceRoot>../parquet-cascading-common23/src/main/thrift</thriftSourceRoot>

--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -140,7 +140,7 @@
         <plugin>
             <groupId>org.apache.thrift.tools</groupId>
             <artifactId>maven-thrift-plugin</artifactId>
-            <version>0.1.11</version>
+            <version>${maven-thrift-plugin.version}</version>
             <configuration>
                 <thriftExecutable>${thrift.executable}</thriftExecutable>
             </configuration>

--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -140,7 +140,7 @@
         <plugin>
             <groupId>org.apache.thrift.tools</groupId>
             <artifactId>maven-thrift-plugin</artifactId>
-            <version>0.1.10</version>
+            <version>0.1.11</version>
             <configuration>
                 <thriftExecutable>${thrift.executable}</thriftExecutable>
             </configuration>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -144,7 +144,7 @@
       <plugin>
         <groupId>org.apache.thrift.tools</groupId>
         <artifactId>maven-thrift-plugin</artifactId>
-        <version>0.1.11</version>
+        <version>${maven-thrift-plugin.version}</version>
         <configuration>
           <thriftExecutable>${thrift.executable}</thriftExecutable>
         </configuration>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -144,7 +144,7 @@
       <plugin>
         <groupId>org.apache.thrift.tools</groupId>
         <artifactId>maven-thrift-plugin</artifactId>
-        <version>0.1.10</version>
+        <version>0.1.11</version>
         <configuration>
           <thriftExecutable>${thrift.executable}</thriftExecutable>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <github.global.server>github</github.global.server>
     <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
+    <maven-thrift-plugin.version>0.1.11</maven-thrift-plugin.version>
     <jackson.groupId>org.codehaus.jackson</jackson.groupId>
     <jackson.version>1.9.11</jackson.version>
     <jackson.package>org.codehaus.jackson</jackson.package>

--- a/pom.xml
+++ b/pom.xml
@@ -57,15 +57,6 @@
     </developer>
   </developers>
 
-  <!-- this is needed for maven-thrift-plugin, would like to remove this.
-   see: https://issues.apache.org/jira/browse/THRIFT-1536  -->
-  <pluginRepositories>
-    <pluginRepository>
-      <id>Twitter public Maven repo</id>
-      <url>http://maven.twttr.com</url>
-    </pluginRepository>
-  </pluginRepositories>
-
   <properties>
     <targetJavaVersion>1.6</targetJavaVersion>
     <maven.compiler.source>1.6</maven.compiler.source>


### PR DESCRIPTION
This fixes:
* parquet-cascading3 should have a libthrift dependency that uses thrift.version
* parquet-cascading3 should have the standard SLF4J dependencies
* Twitter's maven repo is no longer necessary because Parquet uses the Apache maven-thrift-plugin