### PR TITLE
PARQUET-384: Add dictionary filtering.

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/page/DictionaryPageReadStore.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/DictionaryPageReadStore.java
@@ -1,0 +1,36 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.page;
+
+import org.apache.parquet.column.ColumnDescriptor;
+
+/**
+ * Interface to read dictionary pages for all the columns of a row group
+ */
+public interface DictionaryPageReadStore {
+
+  /**
+   * Returns a {@link DictionaryPage} for the given column descriptor.
+   * The dictionary page bytes are uncompressed.
+   *
+   * @param descriptor the descriptor of the column
+   * @return the DictionaryPage for that column, or null if there isn't one
+   */
+  DictionaryPage readDictionaryPage(ColumnDescriptor descriptor);
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/compat/RowGroupFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/compat/RowGroupFilter.java
@@ -56,25 +56,24 @@ public class RowGroupFilter implements Visitor<List<BlockMetaData>> {
     return filter.accept(new RowGroupFilter(blocks, schema));
   }
 
-  public static List<BlockMetaData> filterRowGroups(List<FilterLevel> levels, Filter filter, List<BlockMetaData> blocks, MessageType schema, ParquetFileReader reader) {
+  public static List<BlockMetaData> filterRowGroups(List<FilterLevel> levels, Filter filter, List<BlockMetaData> blocks, ParquetFileReader reader) {
     checkNotNull(filter, "filter");
-    return filter.accept(new RowGroupFilter(levels, blocks, schema, reader));
+    return filter.accept(new RowGroupFilter(levels, blocks, reader));
   }
 
   @Deprecated
   private RowGroupFilter(List<BlockMetaData> blocks, MessageType schema) {
-    this(Collections.singletonList(FilterLevel.STATISTICS), blocks, schema, null);
-  }
-
-  private RowGroupFilter(List<FilterLevel> levels, List<BlockMetaData> blocks, MessageType schema, ParquetFileReader reader) {
     this.blocks = checkNotNull(blocks, "blocks");
     this.schema = checkNotNull(schema, "schema");
+    this.levels = Collections.singletonList(FilterLevel.STATISTICS);
+    this.reader = null;
+  }
+
+  private RowGroupFilter(List<FilterLevel> levels, List<BlockMetaData> blocks, ParquetFileReader reader) {
+    this.blocks = checkNotNull(blocks, "blocks");
+    this.reader = checkNotNull(reader, "reader");
+    this.schema = reader.getFileMetaData().getSchema();
     this.levels = levels;
-    this.reader = reader;
-    if (reader == null && levels.contains(FilterLevel.DICTIONARY)) {
-      throw new NullPointerException(
-          "Cannot filter by dictionaries with a null ParquetFileReader");
-    }
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/compat/RowGroupFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/compat/RowGroupFilter.java
@@ -19,14 +19,17 @@
 package org.apache.parquet.filter2.compat;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.parquet.filter2.compat.FilterCompat.Filter;
 import org.apache.parquet.filter2.compat.FilterCompat.NoOpFilter;
 import org.apache.parquet.filter2.compat.FilterCompat.Visitor;
+import org.apache.parquet.filter2.dictionarylevel.DictionaryFilter;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.filter2.predicate.SchemaCompatibilityValidator;
 import org.apache.parquet.filter2.statisticslevel.StatisticsFilter;
+import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.schema.MessageType;
 
@@ -40,15 +43,38 @@ import static org.apache.parquet.Preconditions.checkNotNull;
 public class RowGroupFilter implements Visitor<List<BlockMetaData>> {
   private final List<BlockMetaData> blocks;
   private final MessageType schema;
+  private final List<FilterLevel> levels;
+  private final ParquetFileReader reader;
+
+  public enum FilterLevel {
+    STATISTICS,
+    DICTIONARY
+  }
 
   public static List<BlockMetaData> filterRowGroups(Filter filter, List<BlockMetaData> blocks, MessageType schema) {
     checkNotNull(filter, "filter");
     return filter.accept(new RowGroupFilter(blocks, schema));
   }
 
+  public static List<BlockMetaData> filterRowGroups(List<FilterLevel> levels, Filter filter, List<BlockMetaData> blocks, MessageType schema, ParquetFileReader reader) {
+    checkNotNull(filter, "filter");
+    return filter.accept(new RowGroupFilter(levels, blocks, schema, reader));
+  }
+
+  @Deprecated
   private RowGroupFilter(List<BlockMetaData> blocks, MessageType schema) {
+    this(Collections.singletonList(FilterLevel.STATISTICS), blocks, schema, null);
+  }
+
+  private RowGroupFilter(List<FilterLevel> levels, List<BlockMetaData> blocks, MessageType schema, ParquetFileReader reader) {
     this.blocks = checkNotNull(blocks, "blocks");
     this.schema = checkNotNull(schema, "schema");
+    this.levels = levels;
+    this.reader = reader;
+    if (reader == null && levels.contains(FilterLevel.DICTIONARY)) {
+      throw new NullPointerException(
+          "Cannot filter by dictionaries with a null ParquetFileReader");
+    }
   }
 
   @Override
@@ -61,7 +87,17 @@ public class RowGroupFilter implements Visitor<List<BlockMetaData>> {
     List<BlockMetaData> filteredBlocks = new ArrayList<BlockMetaData>();
 
     for (BlockMetaData block : blocks) {
-      if (!StatisticsFilter.canDrop(filterPredicate, block.getColumns())) {
+      boolean drop = false;
+
+      if(levels.contains(FilterLevel.STATISTICS)) {
+        drop = StatisticsFilter.canDrop(filterPredicate, block.getColumns());
+      }
+
+      if(!drop && levels.contains(FilterLevel.DICTIONARY)) {
+        drop = DictionaryFilter.canDrop(filterPredicate, block.getColumns(), reader.getDictionaryReader(block));
+      }
+
+      if(!drop) {
         filteredBlocks.add(block);
       }
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilter.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.filter2.dictionarylevel;
+
+import org.apache.parquet.Log;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.page.DictionaryPageReadStore;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.filter2.predicate.Operators.*;
+import org.apache.parquet.filter2.predicate.UserDefinedPredicate;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.apache.parquet.Preconditions.checkArgument;
+import static org.apache.parquet.Preconditions.checkNotNull;
+
+
+/**
+ * Applies filters based on the contents of column dictionaries.
+ */
+public class DictionaryFilter implements FilterPredicate.Visitor<Boolean> {
+
+  private static final Log LOG = Log.getLog(DictionaryFilter.class);
+
+  public static boolean canDrop(FilterPredicate pred, List<ColumnChunkMetaData> columns, DictionaryPageReadStore dictionaries) {
+    checkNotNull(pred, "pred");
+    checkNotNull(columns, "columns");
+    return pred.accept(new DictionaryFilter(columns, dictionaries));
+  }
+
+  private final Map<ColumnPath, ColumnChunkMetaData> columns = new HashMap<ColumnPath, ColumnChunkMetaData>();
+  private final DictionaryPageReadStore dictionaries;
+
+  private DictionaryFilter(List<ColumnChunkMetaData> columnsList, DictionaryPageReadStore dictionaries) {
+    for (ColumnChunkMetaData chunk : columnsList) {
+      columns.put(chunk.getPath(), chunk);
+    }
+
+    this.dictionaries = dictionaries;
+  }
+
+  private ColumnChunkMetaData getColumnChunk(ColumnPath columnPath) {
+    ColumnChunkMetaData c = columns.get(columnPath);
+    checkArgument(c != null, "Column " + columnPath.toDotString() + " not found in schema!");
+    return c;
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends Comparable<T>> Set<T> expandDictionary(ColumnChunkMetaData meta) throws IOException {
+    ColumnDescriptor col = new ColumnDescriptor(meta.getPath().toArray(), meta.getType(), -1, -1);
+    DictionaryPage page = dictionaries.readDictionaryPage(col);
+
+    // the chunk may not be dictionary-encoded
+    if (page == null) {
+      return null;
+    }
+
+    Dictionary dict = page.getEncoding().initDictionary(col, page);
+
+    Set dictSet = new HashSet<T>();
+
+    for (int i=0; i<=dict.getMaxId(); i++) {
+      switch(meta.getType()) {
+        case BINARY: dictSet.add(dict.decodeToBinary(i));
+          break;
+        case INT32: dictSet.add(dict.decodeToInt(i));
+          break;
+        case INT64: dictSet.add(dict.decodeToLong(i));
+          break;
+        case FLOAT: dictSet.add(dict.decodeToFloat(i));
+          break;
+        case DOUBLE: dictSet.add(dict.decodeToDouble(i));
+          break;
+        default:
+          LOG.warn("Unknown dictionary type" + meta.getType());
+      }
+    }
+
+    return (Set<T>) dictSet;
+  }
+
+  @Override
+  public <T extends Comparable<T>> Boolean visit(Eq<T> eq) {
+    Column<T> filterColumn = eq.getColumn();
+    ColumnChunkMetaData meta = getColumnChunk(filterColumn.getColumnPath());
+    T value = eq.getValue();
+
+    filterColumn.getColumnPath();
+
+    try {
+      Set<T> dictSet = expandDictionary(meta);
+      if (dictSet != null) {
+        return !dictSet.contains(value);
+      }
+    } catch (IOException e) {
+      LOG.warn("Failed to process dictionary for filter evaluation.", e);
+    }
+
+    return false; // cannot drop the row group based on this dictionary
+  }
+
+  @Override
+  public <T extends Comparable<T>> Boolean visit(NotEq<T> notEq) {
+    Column<T> filterColumn = notEq.getColumn();
+    ColumnChunkMetaData meta = getColumnChunk(filterColumn.getColumnPath());
+    T value = notEq.getValue();
+
+    filterColumn.getColumnPath();
+
+    try {
+      Set<T> dictSet = expandDictionary(meta);
+      if (dictSet != null) {
+        return dictSet.size() == 1 && dictSet.contains(value);
+      }
+    } catch (IOException e) {
+      LOG.warn("Failed to process dictionary for filter evaluation.", e);
+    }
+
+    return false;
+  }
+
+  @Override
+  public <T extends Comparable<T>> Boolean visit(Lt<T> lt) {
+    Column<T> filterColumn = lt.getColumn();
+    ColumnChunkMetaData meta = getColumnChunk(filterColumn.getColumnPath());
+    T value = lt.getValue();
+
+    filterColumn.getColumnPath();
+
+    try {
+      Set<T> dictSet = expandDictionary(meta);
+      if (dictSet == null) {
+        return false;
+      }
+
+      for(T entry : dictSet) {
+        if(value.compareTo(entry) > 0) {
+          return false;
+        }
+      }
+
+      return true;
+    } catch (IOException e) {
+      LOG.warn("Failed to process dictionary for filter evaluation.", e);
+    }
+
+    return false;
+  }
+
+  @Override
+  public <T extends Comparable<T>> Boolean visit(LtEq<T> ltEq) {
+    Column<T> filterColumn = ltEq.getColumn();
+    ColumnChunkMetaData meta = getColumnChunk(filterColumn.getColumnPath());
+    T value = ltEq.getValue();
+
+    filterColumn.getColumnPath();
+
+    try {
+      Set<T> dictSet = expandDictionary(meta);
+      if (dictSet == null) {
+        return false;
+      }
+
+      for(T entry : dictSet) {
+        if(value.compareTo(entry) >= 0) {
+          return false;
+        }
+      }
+
+      return true;
+    } catch (IOException e) {
+      LOG.warn("Failed to process dictionary for filter evaluation.", e);
+    }
+
+    return false;
+  }
+
+  @Override
+  public <T extends Comparable<T>> Boolean visit(Gt<T> gt) {
+    Column<T> filterColumn = gt.getColumn();
+    ColumnChunkMetaData meta = getColumnChunk(filterColumn.getColumnPath());
+    T value = gt.getValue();
+
+    filterColumn.getColumnPath();
+
+    try {
+      Set<T> dictSet = expandDictionary(meta);
+      if (dictSet == null) {
+        return false;
+      }
+
+      for(T entry : dictSet) {
+        if(value.compareTo(entry) < 0) {
+          return false;
+        }
+      }
+
+      return true;
+    } catch (IOException e) {
+      LOG.warn("Failed to process dictionary for filter evaluation.", e);
+    }
+
+    return false;
+  }
+
+  @Override
+  public <T extends Comparable<T>> Boolean visit(GtEq<T> gtEq) {
+    Column<T> filterColumn = gtEq.getColumn();
+    ColumnChunkMetaData meta = getColumnChunk(filterColumn.getColumnPath());
+    T value = gtEq.getValue();
+
+    filterColumn.getColumnPath();
+
+    try {
+      Set<T> dictSet = expandDictionary(meta);
+      if (dictSet == null) {
+        return false;
+      }
+
+      for(T entry : dictSet) {
+        if(value.compareTo(entry) <= 0) {
+          return false;
+        }
+      }
+
+      return true;
+    } catch (IOException e) {
+      LOG.warn("Failed to process dictionary for filter evaluation.", e);
+    }
+
+    return false;
+  }
+
+  @Override
+  public Boolean visit(And and) {
+    return and.getLeft().accept(this) || and.getRight().accept(this);
+  }
+
+  @Override
+  public Boolean visit(Or or) {
+    return or.getLeft().accept(this) && or.getRight().accept(this);
+  }
+
+  @Override
+  public Boolean visit(Not not) {
+    throw new IllegalArgumentException(
+        "This predicate contains a not! Did you forget to run this predicate through LogicalInverseRewriter? " + not);
+  }
+
+  @Override
+  public <T extends Comparable<T>, U extends UserDefinedPredicate<T>> Boolean visit(UserDefined<T, U> udp) {
+    throw new UnsupportedOperationException("UDP not supported with dictionary evaluation.");
+  }
+
+  @Override
+  public <T extends Comparable<T>, U extends UserDefinedPredicate<T>> Boolean visit(LogicalNotUserDefined<T, U> udp) {
+    throw new UnsupportedOperationException("UDP not supported with dictionary evaluation.");
+  }
+
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -429,13 +429,14 @@ public class ParquetMetadataConverter {
   private static interface MetadataFilterVisitor<T, E extends Throwable> {
     T visit(NoFilter filter) throws E;
     T visit(SkipMetadataFilter filter) throws E;
-    T visit(RangeMetadataFilter filter) throws E;
+    T visit(OffsetMetadataFilter filter) throws E;
   }
 
   public abstract static class MetadataFilter {
     private MetadataFilter() {}
     abstract <T, E extends Throwable> T accept(MetadataFilterVisitor<T, E> visitor) throws E;
   }
+
   /**
    * [ startOffset, endOffset )
    * @param startOffset
@@ -445,6 +446,15 @@ public class ParquetMetadataConverter {
   public static MetadataFilter range(long startOffset, long endOffset) {
     return new RangeMetadataFilter(startOffset, endOffset);
   }
+
+  public static MetadataFilter offsets(long... offsets) {
+    Set<Long> set = new HashSet<Long>();
+    for (long offset : offsets) {
+      set.add(offset);
+    }
+    return new OffsetListMetadataFilter(set);
+  }
+
   private static final class NoFilter extends MetadataFilter {
     private NoFilter() {}
     @Override
@@ -467,29 +477,56 @@ public class ParquetMetadataConverter {
       return "SKIP_ROW_GROUPS";
     }
   }
+
+  interface OffsetMetadataFilter {
+    boolean contains(long offset);
+  }
+
   /**
    * [ startOffset, endOffset )
    * @author Julien Le Dem
    */
   // Visible for testing
-  static final class RangeMetadataFilter extends MetadataFilter {
+  static final class RangeMetadataFilter extends MetadataFilter implements OffsetMetadataFilter {
     final long startOffset;
     final long endOffset;
+
     RangeMetadataFilter(long startOffset, long endOffset) {
       super();
       this.startOffset = startOffset;
       this.endOffset = endOffset;
     }
+
     @Override
     <T, E extends Throwable> T accept(MetadataFilterVisitor<T, E> visitor) throws E {
       return visitor.visit(this);
     }
-    boolean contains(long offset) {
+
+    @Override
+    public boolean contains(long offset) {
       return offset >= this.startOffset && offset < this.endOffset;
     }
+
     @Override
     public String toString() {
       return "range(s:" + startOffset + ", e:" + endOffset + ")";
+    }
+  }
+
+  static final class OffsetListMetadataFilter extends MetadataFilter implements OffsetMetadataFilter {
+    private final Set<Long> offsets;
+
+    public OffsetListMetadataFilter(Set<Long> offsets) {
+      this.offsets = offsets;
+    }
+
+    public boolean contains(long offset) {
+      return offsets.contains(offset);
+    }
+
+    @Override
+    <T, E extends Throwable> T accept(MetadataFilterVisitor<T, E> visitor) throws E {
+      return visitor.visit(this);
     }
   }
 
@@ -499,7 +536,7 @@ public class ParquetMetadataConverter {
   }
 
   // Visible for testing
-  static FileMetaData filterFileMetaData(FileMetaData metaData, RangeMetadataFilter filter) {
+  static FileMetaData filterFileMetaData(FileMetaData metaData, OffsetMetadataFilter filter) {
     List<RowGroup> rowGroups = metaData.getRow_groups();
     List<RowGroup> newRowGroups = new ArrayList<RowGroup>();
     for (RowGroup rowGroup : rowGroups) {
@@ -544,7 +581,7 @@ public class ParquetMetadataConverter {
       }
 
       @Override
-      public FileMetaData visit(RangeMetadataFilter filter) throws IOException {
+      public FileMetaData visit(OffsetMetadataFilter filter) throws IOException {
         return filterFileMetaData(readFileMetaData(from), filter);
       }
     });

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DictionaryPageReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DictionaryPageReader.java
@@ -1,0 +1,89 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import org.apache.parquet.Strings;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.page.DictionaryPageReadStore;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.io.ParquetDecodingException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A {@link DictionaryPageReadStore} implementation that reads dictionaries from
+ * an open {@link ParquetFileReader}.
+ *
+ * This implementation will delegate dictionary reads to a
+ * {@link ColumnChunkPageReadStore} to avoid extra reads after a row group has
+ * been loaded into memory.
+ */
+class DictionaryPageReader implements DictionaryPageReadStore {
+
+  private final ParquetFileReader reader;
+  private final Map<String, ColumnChunkMetaData> columns;
+  private ColumnChunkPageReadStore rowGroup = null;
+
+  DictionaryPageReader(ParquetFileReader reader, BlockMetaData block) {
+    this.reader = reader;
+    this.columns = new HashMap<String, ColumnChunkMetaData>();
+    for (ColumnChunkMetaData column : block.getColumns()) {
+      columns.put(column.getPath().toDotString(), column);
+    }
+  }
+
+  /**
+   * Sets this reader's row group's page store. When a row group is set, this
+   * reader will delegate to that row group to return dictionary pages. This
+   * avoids seeking and re-reading dictionary bytes after this reader's row
+   * group is loaded into memory.
+   *
+   * @param rowGroup a ColumnChunkPageReadStore for this reader's row group
+   */
+  void setRowGroup(ColumnChunkPageReadStore rowGroup) {
+    this.rowGroup = rowGroup;
+  }
+
+  @Override
+  public DictionaryPage readDictionaryPage(ColumnDescriptor descriptor) {
+    if (rowGroup != null) {
+      // if the row group has already been read, use that dictionary
+      return rowGroup.readDictionaryPage(descriptor);
+    }
+
+    String dotPath = Strings.join(descriptor.getPath(), ".");
+    ColumnChunkMetaData column = columns.get(dotPath);
+    if (column == null) {
+      throw new ParquetDecodingException(
+          "Cannot load dictionary, unknown column: " + dotPath);
+    }
+
+    try {
+      // TODO: cache dictionary pages. filters may call this multiple times
+      return reader.readDictionary(column);
+    } catch (IOException e) {
+      throw new ParquetDecodingException(
+          "Failed to read dictionary", e);
+    }
+  }
+
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
@@ -22,22 +22,18 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 
 import org.apache.parquet.Log;
-import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.filter.UnboundRecordFilter;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.compat.FilterCompat.Filter;
 import org.apache.parquet.hadoop.api.InitContext;
 import org.apache.parquet.hadoop.api.ReadSupport;
-import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.hadoop.util.counters.BenchmarkCounter;
 import org.apache.parquet.io.ColumnIOFactory;
@@ -45,9 +41,7 @@ import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.api.RecordMaterializer;
 import org.apache.parquet.io.api.RecordMaterializer.RecordMaterializationException;
-import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
 
 import static java.lang.String.format;
 import static org.apache.parquet.Log.DEBUG;
@@ -81,7 +75,6 @@ class InternalParquetRecordReader<T> {
 
   private long totalCountLoadedSoFar = 0;
 
-  private Path file;
   private UnmaterializableRecordCounter unmaterializableRecordCounter;
 
   /**
@@ -163,27 +156,22 @@ class InternalParquetRecordReader<T> {
     return (float) current / total;
   }
 
-  public void initialize(MessageType fileSchema,
-      FileMetaData parquetFileMetadata,
-      Path file, List<BlockMetaData> blocks, Configuration configuration)
+  public void initialize(ParquetFileReader reader, Configuration configuration)
       throws IOException {
     // initialize a ReadContext for this file
+    this.reader = reader;
+    FileMetaData parquetFileMetadata = reader.getFooter().getFileMetaData();
+    this.fileSchema = parquetFileMetadata.getSchema();
     Map<String, String> fileMetadata = parquetFileMetadata.getKeyValueMetaData();
     ReadSupport.ReadContext readContext = readSupport.init(new InitContext(
         configuration, toSetMultiMap(fileMetadata), fileSchema));
     this.columnIOFactory = new ColumnIOFactory(parquetFileMetadata.getCreatedBy());
     this.requestedSchema = readContext.getRequestedSchema();
-    this.fileSchema = fileSchema;
-    this.file = file;
     this.columnCount = requestedSchema.getPaths().size();
     this.recordConverter = readSupport.prepareForRead(
         configuration, fileMetadata, fileSchema, readContext);
     this.strictTypeChecking = configuration.getBoolean(STRICT_TYPE_CHECKING, true);
-    List<ColumnDescriptor> columns = requestedSchema.getColumns();
-    reader = new ParquetFileReader(configuration, parquetFileMetadata, file, blocks, columns);
-    for (BlockMetaData block : blocks) {
-      total += block.getRowCount();
-    }
+    this.total = reader.getRecordCount();
     this.unmaterializableRecordCounter = new UnmaterializableRecordCounter(configuration, total);
     LOG.info("RecordReader initialized will read a total of " + total + " records.");
   }
@@ -225,7 +213,7 @@ class InternalParquetRecordReader<T> {
 
         if (DEBUG) LOG.debug("read value: " + currentValue);
       } catch (RuntimeException e) {
-        throw new ParquetDecodingException(format("Can not read value at %d in block %d in file %s", current, currentBlock, file), e);
+        throw new ParquetDecodingException(format("Can not read value at %d in block %d in file %s", current, currentBlock, reader.getPath()), e);
       }
     }
     return true;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
@@ -188,21 +188,6 @@ class InternalParquetRecordReader<T> {
     LOG.info("RecordReader initialized will read a total of " + total + " records.");
   }
 
-  private boolean contains(GroupType group, String[] path, int index) {
-    if (index == path.length) {
-      return false;
-    }
-    if (group.containsField(path[index])) {
-      Type type = group.getType(path[index]);
-      if (type.isPrimitive()) {
-        return index + 1 == path.length;
-      } else {
-        return contains(type.asGroupType(), path, index + 1);
-      }
-    }
-    return false;
-  }
-
   public boolean nextKeyValue() throws IOException, InterruptedException {
     boolean recordFound = false;
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
@@ -22,24 +22,36 @@ package org.apache.parquet.filter2.dictionarylevel;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DictionaryPageReadStore;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.filter2.predicate.Operators.BinaryColumn;
+import org.apache.parquet.filter2.predicate.Operators.DoubleColumn;
+import org.apache.parquet.filter2.predicate.Operators.FloatColumn;
 import org.apache.parquet.filter2.predicate.Operators.IntColumn;
-import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.filter2.predicate.Operators.LongColumn;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.example.GroupWriteSupport;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
 import static org.apache.parquet.filter2.dictionarylevel.DictionaryFilter.canDrop;
@@ -48,6 +60,8 @@ import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESS
 import static org.apache.parquet.schema.MessageTypeParser.parseMessageType;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class DictionaryFilterTest {
 
@@ -57,32 +71,39 @@ public class DictionaryFilterTest {
   private static final MessageType schema = parseMessageType(
       "message test { "
           + "required binary binary_field; "
+          + "required binary single_value_field; "
           + "required int32 int32_field; "
           + "required int64 int64_field; "
           + "required double double_field; "
           + "required float float_field; "
+          + "required int32 plain_int32_field; "
+          + "required binary fallback_binary_field; "
           + "} ");
 
-  private static final int ENGLISH_CHARACTER_NUMBER = 26;
-  private static final int[] intValues = new int[] {-100, 302, 3333333, 7654321, 1234567, -2000, -77775, 0, 75, 22223,
+  private static final String ALPHABET = "abcdefghijklmnopqrstuvwxyz";
+  private static final int[] intValues = new int[] {
+      -100, 302, 3333333, 7654321, 1234567, -2000, -77775, 0, 75, 22223,
       77, 22221, -444443, 205, 12, 44444, 889, 66665, -777889, -7,
       52, 33, -257, 1111, 775, 26};
-  private static final long[] longValues = new long[] {-100L, 302L, 3333333L, 7654321L, 1234567L, -2000L, -77775L, 0L,
+  private static final long[] longValues = new long[] {
+      -100L, 302L, 3333333L, 7654321L, 1234567L, -2000L, -77775L, 0L,
       75L, 22223L, 77L, 22221L, -444443L, 205L, 12L, 44444L, 889L, 66665L,
       -777889L, -7L, 52L, 33L, -257L, 1111L, 775L, 26L};
 
   private static void writeData(SimpleGroupFactory f, ParquetWriter<Group> writer) throws IOException {
     for (int i = 0; i < nElements; i++) {
-      int index = i % ENGLISH_CHARACTER_NUMBER;
-      char c  = (char) ((index) + 'a');
-      String b = String.valueOf(c);
+      int index = i % ALPHABET.length();
 
       Group group = f.newGroup()
-          .append("binary_field", b)
-          .append("int32_field", intValues[index])
-          .append("int64_field", longValues[index])
-          .append("double_field", intValues[index] * 1.0)
-          .append("float_field", ((float) (intValues[index] * 2.0)));
+          .append("binary_field", ALPHABET.substring(index, index+1))
+          .append("single_value_field", "sharp")
+          .append("int32_field", intValues[i % intValues.length])
+          .append("int64_field", longValues[i % longValues.length])
+          .append("double_field", toDouble(intValues[i % intValues.length]))
+          .append("float_field", toFloat(intValues[i % intValues.length]))
+          .append("plain_int32_field", i)
+          .append("fallback_binary_field", i < (nElements / 2) ?
+              ALPHABET.substring(index, index+1) : UUID.randomUUID().toString());
 
       writer.write(group);
     }
@@ -93,15 +114,17 @@ public class DictionaryFilterTest {
   public static void prepareFile() throws IOException {
     cleanup();
 
-    boolean dictionaryEnabled = true;
-    boolean validating = false;
     GroupWriteSupport.setSchema(schema, conf);
     SimpleGroupFactory f = new SimpleGroupFactory(schema);
-    ParquetWriter<Group> writer = new ParquetWriter<Group>(
-        file,
-        new GroupWriteSupport(),
-        UNCOMPRESSED, 1024*1024, 1024, 1024*1024,
-        dictionaryEnabled, validating, PARQUET_1_0, conf);
+    ParquetWriter<Group> writer = ExampleParquetWriter.builder(file)
+        .withWriterVersion(PARQUET_1_0)
+        .withCompressionCodec(UNCOMPRESSED)
+        .withRowGroupSize(1024*1024)
+        .withPageSize(1024)
+        .enableDictionaryEncoding()
+        .withDictionaryPageSize(2*1024)
+        .withConf(conf)
+        .build();
     writeData(f, writer);
   }
 
@@ -120,11 +143,9 @@ public class DictionaryFilterTest {
 
   @Before
   public void setUp() throws Exception {
-    FileSystem fs = FileSystem.getLocal(conf);
-    ParquetMetadata meta = ParquetFileReader.readFooter(conf, fs.getFileStatus(file), ParquetMetadataConverter.NO_FILTER);
-
-    ccmd = meta.getBlocks().get(0).getColumns();
     reader = ParquetFileReader.open(conf, file);
+    ParquetMetadata meta = reader.getFooter();
+    ccmd = meta.getBlocks().get(0).getColumns();
     dictionaries = reader.getDictionaryReader(meta.getBlocks().get(0));
   }
 
@@ -134,39 +155,233 @@ public class DictionaryFilterTest {
   }
 
   @Test
-  public void testCanDropEq() throws Exception {
+  @SuppressWarnings("deprecation")
+  public void testDictionaryEncodedColumns() throws Exception {
+    Set<String> dictionaryEncodedColumns = new HashSet<String>(Arrays.asList(
+        "binary_field", "single_value_field", "int32_field", "int64_field",
+        "double_field", "float_field"));
+    for (ColumnChunkMetaData column : ccmd) {
+      String name = column.getPath().toDotString();
+      if (dictionaryEncodedColumns.contains(name)) {
+        assertTrue("Column should be dictionary encoded: " + name,
+            column.getEncodings().contains(Encoding.PLAIN_DICTIONARY));
+        assertFalse("Column should not have plain data pages" + name,
+            column.getEncodings().contains(Encoding.PLAIN));
+
+      } else {
+        assertTrue("Column should have plain encoding: " + name,
+            column.getEncodings().contains(Encoding.PLAIN));
+
+        if (name.startsWith("fallback")) {
+          assertTrue("Column should be have some dictionary encoding: " + name,
+              column.getEncodings().contains(Encoding.PLAIN_DICTIONARY));
+        } else {
+          assertFalse("Column should have no dictionary encoding: " + name,
+              column.getEncodings().contains(Encoding.PLAIN_DICTIONARY));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testEqBinary() throws Exception {
     BinaryColumn b = binaryColumn("binary_field");
     FilterPredicate pred = eq(b, Binary.fromString("c"));
 
-    assertFalse(canDrop(pred, ccmd, dictionaries));
+    assertFalse("Should not drop block for lower case letters",
+        canDrop(pred, ccmd, dictionaries));
+
+    assertTrue("Should drop block for upper case letters",
+        canDrop(eq(b, Binary.fromString("A")), ccmd, dictionaries));
   }
 
   @Test
-  public void testCanDropLt() throws Exception {
-    IntColumn i32 = intColumn("int32_field");
-    FilterPredicate predDrop = lt(i32, -777889);
-    assertTrue(canDrop(predDrop, ccmd, dictionaries));
+  public void testNotEqBinary() throws Exception {
+    BinaryColumn sharp = binaryColumn("single_value_field");
+    BinaryColumn b = binaryColumn("binary_field");
 
-    FilterPredicate predKeep = lt(i32, -1);
-    assertFalse(canDrop(predKeep, ccmd, dictionaries));
+    assertTrue("Should drop block with only the excluded value",
+        canDrop(notEq(sharp, Binary.fromString("sharp")), ccmd, dictionaries));
+
+    assertFalse("Should not drop block with any other value",
+        canDrop(notEq(sharp, Binary.fromString("applause")), ccmd, dictionaries));
+
+    assertFalse("Should not drop block with a known value",
+        canDrop(notEq(b, Binary.fromString("x")), ccmd, dictionaries));
+
+    assertFalse("Should not drop block with a known value",
+        canDrop(notEq(b, Binary.fromString("B")), ccmd, dictionaries));
   }
 
   @Test
-  public void testCanDropLtEq() throws Exception {
+  public void testLtInt() throws Exception {
     IntColumn i32 = intColumn("int32_field");
-    FilterPredicate pred = ltEq(i32, -777890);
+    int lowest = Integer.MAX_VALUE;
+    for (int value : intValues) {
+      lowest = Math.min(lowest, value);
+    }
 
-    assertTrue(canDrop(pred, ccmd, dictionaries));
+    assertTrue("Should drop: < lowest value",
+        canDrop(lt(i32, lowest), ccmd, dictionaries));
+    assertFalse("Should not drop: < (lowest value + 1)",
+        canDrop(lt(i32, lowest + 1), ccmd, dictionaries));
+
+    assertFalse("Should not drop: contains matching values",
+        canDrop(lt(i32, Integer.MAX_VALUE), ccmd, dictionaries));
   }
 
   @Test
-  public void testCanDropAnd() throws Exception {
-    IntColumn i32 = intColumn("int32_field");
-    FilterPredicate pred = and(lt(i32, -777889), gt(i32, 3333332));
+  public void testLtEqLong() throws Exception {
+    LongColumn i64 = longColumn("int64_field");
+    long lowest = Long.MAX_VALUE;
+    for (long value : longValues) {
+      lowest = Math.min(lowest, value);
+    }
 
-    assertTrue(canDrop(pred, ccmd, dictionaries));
+    assertTrue("Should drop: <= lowest - 1",
+        canDrop(ltEq(i64, lowest - 1), ccmd, dictionaries));
+    assertFalse("Should not drop: <= lowest",
+        canDrop(ltEq(i64, lowest), ccmd, dictionaries));
+
+    assertFalse("Should not drop: contains matching values",
+        canDrop(ltEq(i64, Long.MAX_VALUE), ccmd, dictionaries));
   }
 
-  // TODO: negative tests, columns without dictionaries, columns with fallback
+  @Test
+  public void testGtFloat() throws Exception {
+    FloatColumn f = floatColumn("float_field");
+    float highest = Float.MIN_VALUE;
+    for (int value : intValues) {
+      highest = Math.max(highest, toFloat(value));
+    }
 
+    assertTrue("Should drop: > highest value",
+        canDrop(gt(f, highest), ccmd, dictionaries));
+    assertFalse("Should not drop: > (highest value - 1.0)",
+        canDrop(gt(f, highest - 1.0f), ccmd, dictionaries));
+
+    assertFalse("Should not drop: contains matching values",
+        canDrop(gt(f, Float.MIN_VALUE), ccmd, dictionaries));
+  }
+
+  @Test
+  public void testGtEqDouble() throws Exception {
+    DoubleColumn d = doubleColumn("double_field");
+    double highest = Double.MIN_VALUE;
+    for (int value : intValues) {
+      highest = Math.max(highest, toDouble(value));
+    }
+
+    assertTrue("Should drop: >= highest + 0.00000001",
+        canDrop(gtEq(d, highest + 0.00000001), ccmd, dictionaries));
+    assertFalse("Should not drop: >= highest",
+        canDrop(gtEq(d, highest), ccmd, dictionaries));
+
+    assertFalse("Should not drop: contains matching values",
+        canDrop(gtEq(d, Double.MIN_VALUE), ccmd, dictionaries));
+  }
+
+  @Test
+  public void testAnd() throws Exception {
+    BinaryColumn col = binaryColumn("binary_field");
+
+    // both evaluate to false (no upper-case letters are in the dictionary)
+    FilterPredicate B = eq(col, Binary.fromString("B"));
+    FilterPredicate C = eq(col, Binary.fromString("C"));
+
+    // both evaluate to true (all lower-case letters are in the dictionary)
+    FilterPredicate x = eq(col, Binary.fromString("x"));
+    FilterPredicate y = eq(col, Binary.fromString("y"));
+
+    assertTrue("Should drop when either predicate must be false",
+        canDrop(and(B, y), ccmd, dictionaries));
+    assertTrue("Should drop when either predicate must be false",
+        canDrop(and(x, C), ccmd, dictionaries));
+    assertTrue("Should drop when either predicate must be false",
+        canDrop(and(B, C), ccmd, dictionaries));
+    assertFalse("Should not drop when either predicate could be true",
+        canDrop(and(x, y), ccmd, dictionaries));
+  }
+
+  @Test
+  public void testOr() throws Exception {
+    BinaryColumn col = binaryColumn("binary_field");
+
+    // both evaluate to false (no upper-case letters are in the dictionary)
+    FilterPredicate B = eq(col, Binary.fromString("B"));
+    FilterPredicate C = eq(col, Binary.fromString("C"));
+
+    // both evaluate to true (all lower-case letters are in the dictionary)
+    FilterPredicate x = eq(col, Binary.fromString("x"));
+    FilterPredicate y = eq(col, Binary.fromString("y"));
+
+    assertFalse("Should not drop when one predicate could be true",
+        canDrop(or(B, y), ccmd, dictionaries));
+    assertFalse("Should not drop when one predicate could be true",
+        canDrop(or(x, C), ccmd, dictionaries));
+    assertTrue("Should drop when both predicates must be false",
+        canDrop(or(B, C), ccmd, dictionaries));
+    assertFalse("Should not drop when one predicate could be true",
+        canDrop(or(x, y), ccmd, dictionaries));
+  }
+
+  @Test
+  public void testColumnWithoutDictionary() throws Exception {
+    IntColumn plain = intColumn("plain_int32_field");
+    DictionaryPageReadStore dictionaryStore = mock(DictionaryPageReadStore.class);
+
+    assertFalse("Should never drop block using plain encoding",
+        canDrop(eq(plain, -10), ccmd, dictionaryStore));
+
+    assertFalse("Should never drop block using plain encoding",
+        canDrop(lt(plain, -10), ccmd, dictionaryStore));
+
+    assertFalse("Should never drop block using plain encoding",
+        canDrop(ltEq(plain, -10), ccmd, dictionaryStore));
+
+    assertFalse("Should never drop block using plain encoding",
+        canDrop(gt(plain, nElements + 10), ccmd, dictionaryStore));
+
+    assertFalse("Should never drop block using plain encoding",
+        canDrop(gtEq(plain, nElements + 10), ccmd, dictionaryStore));
+
+    assertFalse("Should never drop block using plain encoding",
+        canDrop(notEq(plain, nElements + 10), ccmd, dictionaryStore));
+
+    verifyZeroInteractions(dictionaryStore);
+  }
+
+  @Test
+  public void testColumnWithDictionaryAndPlainEncodings() throws Exception {
+    IntColumn plain = intColumn("fallback_binary_field");
+    DictionaryPageReadStore dictionaryStore = mock(DictionaryPageReadStore.class);
+
+    assertFalse("Should never drop block using plain encoding",
+        canDrop(eq(plain, -10), ccmd, dictionaryStore));
+
+    assertFalse("Should never drop block using plain encoding",
+        canDrop(lt(plain, -10), ccmd, dictionaryStore));
+
+    assertFalse("Should never drop block using plain encoding",
+        canDrop(ltEq(plain, -10), ccmd, dictionaryStore));
+
+    assertFalse("Should never drop block using plain encoding",
+        canDrop(gt(plain, nElements + 10), ccmd, dictionaryStore));
+
+    assertFalse("Should never drop block using plain encoding",
+        canDrop(gtEq(plain, nElements + 10), ccmd, dictionaryStore));
+
+    assertFalse("Should never drop block using plain encoding",
+        canDrop(notEq(plain, nElements + 10), ccmd, dictionaryStore));
+
+    verifyZeroInteractions(dictionaryStore);
+  }
+
+  private static double toDouble(int value) {
+    return (value * 1.0);
+  }
+
+  private static float toFloat(int value) {
+    return (float) (value * 2.0);
+  }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.filter2.dictionarylevel;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.page.DictionaryPageReadStore;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.filter2.predicate.Operators.BinaryColumn;
+import org.apache.parquet.filter2.predicate.Operators.IntColumn;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.MessageType;
+import org.junit.*;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
+import static org.apache.parquet.filter2.dictionarylevel.DictionaryFilter.canDrop;
+import static org.apache.parquet.filter2.predicate.FilterApi.*;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
+import static org.apache.parquet.schema.MessageTypeParser.parseMessageType;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DictionaryFilterTest {
+
+  private static final int nElements = 1000;
+  private static final Configuration conf = new Configuration();
+  private static  Path file = new Path("target/test/TestDictionaryFilter/testParquetFile");
+  private static final MessageType schema = parseMessageType(
+      "message test { "
+          + "required binary binary_field; "
+          + "required int32 int32_field; "
+          + "required int64 int64_field; "
+          + "required double double_field; "
+          + "required float float_field; "
+          + "} ");
+
+  private static final int ENGLISH_CHARACTER_NUMBER = 26;
+  private static final int[] intValues = new int[] {-100, 302, 3333333, 7654321, 1234567, -2000, -77775, 0, 75, 22223,
+      77, 22221, -444443, 205, 12, 44444, 889, 66665, -777889, -7,
+      52, 33, -257, 1111, 775, 26};
+  private static final long[] longValues = new long[] {-100L, 302L, 3333333L, 7654321L, 1234567L, -2000L, -77775L, 0L,
+      75L, 22223L, 77L, 22221L, -444443L, 205L, 12L, 44444L, 889L, 66665L,
+      -777889L, -7L, 52L, 33L, -257L, 1111L, 775L, 26L};
+
+  private static void writeData(SimpleGroupFactory f, ParquetWriter<Group> writer) throws IOException {
+    for (int i = 0; i < nElements; i++) {
+      int index = i % ENGLISH_CHARACTER_NUMBER;
+      char c  = (char) ((index) + 'a');
+      String b = String.valueOf(c);
+
+      Group group = f.newGroup()
+          .append("binary_field", b)
+          .append("int32_field", intValues[index])
+          .append("int64_field", longValues[index])
+          .append("double_field", intValues[index] * 1.0)
+          .append("float_field", ((float) (intValues[index] * 2.0)));
+
+      writer.write(group);
+    }
+    writer.close();
+  }
+
+  @BeforeClass
+  public static void prepareFile() throws IOException {
+    cleanup();
+
+    boolean dictionaryEnabled = true;
+    boolean validating = false;
+    GroupWriteSupport.setSchema(schema, conf);
+    SimpleGroupFactory f = new SimpleGroupFactory(schema);
+    ParquetWriter<Group> writer = new ParquetWriter<Group>(
+        file,
+        new GroupWriteSupport(),
+        UNCOMPRESSED, 1024*1024, 1024, 1024*1024,
+        dictionaryEnabled, validating, PARQUET_1_0, conf);
+    writeData(f, writer);
+  }
+
+  @AfterClass
+  public static void cleanup() throws IOException {
+    FileSystem fs = file.getFileSystem(conf);
+    if (fs.exists(file)) {
+      fs.delete(file, true);
+    }
+  }
+
+
+  List<ColumnChunkMetaData> ccmd;
+  ParquetFileReader reader;
+  DictionaryPageReadStore dictionaries;
+
+  @Before
+  public void setUp() throws Exception {
+    FileSystem fs = FileSystem.getLocal(conf);
+    ParquetMetadata meta = ParquetFileReader.readFooter(conf, fs.getFileStatus(file), ParquetMetadataConverter.NO_FILTER);
+
+    ccmd = meta.getBlocks().get(0).getColumns();
+    reader = ParquetFileReader.open(conf, file);
+    dictionaries = reader.getDictionaryReader(meta.getBlocks().get(0));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    reader.close();
+  }
+
+  @Test
+  public void testCanDropEq() throws Exception {
+    BinaryColumn b = binaryColumn("binary_field");
+    FilterPredicate pred = eq(b, Binary.fromString("c"));
+
+    assertFalse(canDrop(pred, ccmd, dictionaries));
+  }
+
+  @Test
+  public void testCanDropLt() throws Exception {
+    IntColumn i32 = intColumn("int32_field");
+    FilterPredicate predDrop = lt(i32, -777889);
+    assertTrue(canDrop(predDrop, ccmd, dictionaries));
+
+    FilterPredicate predKeep = lt(i32, -1);
+    assertFalse(canDrop(predKeep, ccmd, dictionaries));
+  }
+
+  @Test
+  public void testCanDropLtEq() throws Exception {
+    IntColumn i32 = intColumn("int32_field");
+    FilterPredicate pred = ltEq(i32, -777890);
+
+    assertTrue(canDrop(pred, ccmd, dictionaries));
+  }
+
+  @Test
+  public void testCanDropAnd() throws Exception {
+    IntColumn i32 = intColumn("int32_field");
+    FilterPredicate pred = and(lt(i32, -777889), gt(i32, 3333332));
+
+    assertTrue(canDrop(pred, ccmd, dictionaries));
+  }
+
+  // TODO: negative tests, columns without dictionaries, columns with fallback
+
+}


### PR DESCRIPTION
This builds on #286 from @danielcweeks and cleans up some of the interfaces. It introduces `DictionaryPageReadStore` to expose dictionary pages to the filters and cleans up some internal calls by passing `ParquetFileReader`.

When committed, this closes #286.