### PR TITLE
PARQUET-560: Synchronize writes to the finishCalled variable

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyCompressor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyCompressor.java
@@ -113,7 +113,7 @@ public class SnappyCompressor implements Compressor {
   }
 
   @Override
-  public void finish() {
+  public synchronized void finish() {
     finishCalled = true;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,7 @@
                      <exclude>org/apache/parquet/avro/SpecificDataSupplier</exclude> <!-- made public -->
                      <exclude>org/apache/parquet/io/ColumnIOFactory$ColumnIOCreatorVisitor</exclude> <!-- removed non-API class -->
                      <exclude>org/apache/parquet/io/ColumnIOFactory/**</exclude> <!-- removed non-API class and methods-->
+		     <exclude>org/apache/parquet/hadoop/codec/SnappyCompressor</exclude> <!-- added synchronized modifier -->
                    </excludes>
                  </requireBackwardCompatibility>
                </rules>


### PR DESCRIPTION
Reads of the `finishCalled` variable are properly synchronized, but writes are not -- so there's some sort of inconsistent synch. going on here. This PR fixes that.

/cc @rdblue can you please take a look?