### PR TITLE
PARQUET-571: Fix potential leak in ParquetFileReader.close()

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -776,11 +776,14 @@ public class ParquetFileReader implements Closeable {
 
   @Override
   public void close() throws IOException {
-    if (f != null) {
-      f.close();
-    }
-    if (codecFactory != null) {
-      codecFactory.release();
+    try {
+      if (f != null) {
+        f.close();
+      }
+    } finally {
+      if (codecFactory != null) {
+        codecFactory.release();
+      }
     }
   }
 


### PR DESCRIPTION
If an exception occurs when closing the input stream `f`, the codecs
will not be released. This may cause native memory leaks for some codecs. \cc @rdblue 