### PR TITLE
PARQUET-585: Slowly ramp up sizes of int[]s in IntList to keep sizes small when data sets are small

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/IntList.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/IntList.java
@@ -31,8 +31,8 @@ import java.util.List;
  */
 public class IntList {
 
-  private static final int MAX_SLAB_SIZE = 64 * 1024;
-  private static final int INITIAL_SLAB_SIZE = 4 * 1024;
+  public static final int MAX_SLAB_SIZE = 64 * 1024;
+  public static final int INITIAL_SLAB_SIZE = 4 * 1024;
 
   //Double slab size till we reach the max slab size. At that point we just add slabs of size
   //MAX_SLAB_SIZE. This ensures we don't allocate very large slabs from the start if we don't have

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/IntList.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/IntList.java
@@ -58,7 +58,7 @@ public class IntList {
     }
 
     /**
-     * @return wether there is a next value
+     * @return whether there is a next value
      */
     public boolean hasNext() {
       return current < count;
@@ -80,11 +80,11 @@ public class IntList {
   private int currentSlabPos;
 
   /**
-   * construct an empty list
+   * Construct an empty list
+   * Lazy initialize currentSlab only when needed to save on memory in cases where items might
+   * not be added
    */
-  public IntList() {
-    initSlab();
-  }
+  public IntList() {}
 
   private void initSlab() {
     currentSlab = new int[SLAB_SIZE];
@@ -95,10 +95,13 @@ public class IntList {
    * @param i value to append to the end of the list
    */
   public void add(int i) {
-    if (currentSlabPos == currentSlab.length) {
+    if (currentSlab == null) {
+      initSlab();
+    } else if (currentSlabPos == currentSlab.length) {
       slabs.add(currentSlab);
       initSlab();
     }
+
     currentSlab[currentSlabPos] = i;
     ++ currentSlabPos;
   }
@@ -108,6 +111,10 @@ public class IntList {
    * @return an IntIterator on the content
    */
   public IntIterator iterator() {
+    if (currentSlab == null) {
+      initSlab();
+    }
+
     int[][] itSlabs = slabs.toArray(new int[slabs.size() + 1][]);
     itSlabs[slabs.size()] = currentSlab;
     return new IntIterator(itSlabs, SLAB_SIZE * slabs.size() + currentSlabPos);

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/IntList.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/IntList.java
@@ -76,15 +76,11 @@ public class IntList {
   }
 
   private List<int[]> slabs = new ArrayList<int[]>();
+
+  // Lazy initialize currentSlab only when needed to save on memory in cases where items might
+  // not be added
   private int[] currentSlab;
   private int currentSlabPos;
-
-  /**
-   * Construct an empty list
-   * Lazy initialize currentSlab only when needed to save on memory in cases where items might
-   * not be added
-   */
-  public IntList() {}
 
   private void initSlab() {
     currentSlab = new int[SLAB_SIZE];

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/IntListTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/IntListTest.java
@@ -30,7 +30,7 @@ public class IntListTest {
   @Test
   public void testSmallList() {
     int testSize = IntList.INITIAL_SLAB_SIZE - 100;
-    doTestIntList(testSize);
+    doTestIntList(testSize, IntList.INITIAL_SLAB_SIZE);
   }
 
   /**
@@ -39,7 +39,7 @@ public class IntListTest {
   @Test
   public void testListGreaterThanInitialSlabSize() {
     int testSize = IntList.INITIAL_SLAB_SIZE + 100;
-    doTestIntList(testSize);
+    doTestIntList(testSize, IntList.INITIAL_SLAB_SIZE * 2);
   }
 
   /**
@@ -49,14 +49,17 @@ public class IntListTest {
   @Test
   public void testListGreaterThanMaxSlabSize() {
     int testSize = IntList.MAX_SLAB_SIZE * 4 + 100;
-    doTestIntList(testSize);
+    doTestIntList(testSize, IntList.MAX_SLAB_SIZE);
   }
 
-  private void doTestIntList(int testSize) {
+  private void doTestIntList(int testSize, int expectedSlabSize) {
     IntList testList = new IntList();
     populateList(testList, testSize);
 
     verifyIteratorResults(testSize, testList);
+
+    // confirm the size of the current slab
+    Assert.assertEquals(expectedSlabSize, testList.getCurrentSlabSize());
   }
 
   private void populateList(IntList testList, int size) {
@@ -75,7 +78,7 @@ public class IntListTest {
       expected++;
     }
 
-    //ensure we have the correct final value of expected
+    // ensure we have the correct final value of expected
     Assert.assertEquals(testSize, expected);
   }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/IntListTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/IntListTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.dictionary;
+
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+public class IntListTest {
+
+  /**
+   * Test IntList of fairly small size (< 4K), this tests a single slab being created
+   */
+  @Test
+  public void testSmallList() {
+    int testSize = 100;
+    doTestIntList(testSize);
+  }
+
+  /**
+   * Test IntList > 4K so that we have multiple slabs being created
+   */
+  @Test
+  public void testListGreaterThan4K() {
+    int testSize = 6000;
+    doTestIntList(testSize);
+  }
+
+  /**
+   * Test IntList of a fairly large size (> 300K) so that we have multiple slabs
+   * created of varying sizes
+   */
+  @Test
+  public void testListGreaterThan300K() {
+    int testSize = 310000;
+    doTestIntList(testSize);
+  }
+
+  private void doTestIntList(int testSize) {
+    IntList testList = new IntList();
+    populateList(testList, testSize);
+
+    verifyIteratorResults(testSize, testList);
+  }
+
+  private void populateList(IntList testList, int size) {
+    for(int i = 0; i < size; i++) {
+      testList.add(i);
+    }
+  }
+
+  private void verifyIteratorResults(int testSize, IntList testList) {
+    IntList.IntIterator iterator = testList.iterator();
+    int expected = 0;
+
+    while (iterator.hasNext()) {
+      int val = iterator.next();
+      Assert.assertEquals(expected, val);
+      expected++;
+    }
+
+    //ensure we have the correct final value of expected
+    Assert.assertEquals(testSize, expected);
+  }
+}

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/IntListTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/IntListTest.java
@@ -25,30 +25,30 @@ import junit.framework.Assert;
 public class IntListTest {
 
   /**
-   * Test IntList of fairly small size (< 4K), this tests a single slab being created
+   * Test IntList of fairly small size (< INITIAL_SLAB_SIZE), this tests a single slab being created
    */
   @Test
   public void testSmallList() {
-    int testSize = 100;
+    int testSize = IntList.INITIAL_SLAB_SIZE - 100;
     doTestIntList(testSize);
   }
 
   /**
-   * Test IntList > 4K so that we have multiple slabs being created
+   * Test IntList > INITIAL_SLAB_SIZE so that we have multiple slabs being created
    */
   @Test
-  public void testListGreaterThan4K() {
-    int testSize = 6000;
+  public void testListGreaterThanInitialSlabSize() {
+    int testSize = IntList.INITIAL_SLAB_SIZE + 100;
     doTestIntList(testSize);
   }
 
   /**
-   * Test IntList of a fairly large size (> 300K) so that we have multiple slabs
+   * Test IntList of a fairly large size (> MAX_SLAB_SIZE) so that we have multiple slabs
    * created of varying sizes
    */
   @Test
-  public void testListGreaterThan300K() {
-    int testSize = 310000;
+  public void testListGreaterThanMaxSlabSize() {
+    int testSize = IntList.MAX_SLAB_SIZE * 4 + 100;
     doTestIntList(testSize);
   }
 


### PR DESCRIPTION
One of the follow up items from PR - https://github.com/apache/parquet-mr/pull/339 was to slowly ramp up the size of the int[] created in IntList to ensure we don't allocate 64K arrays right off the bat. This PR updates the code to start with a 4K array then keeps doubling till 64K (and stays at 64K after that). 