### PR TITLE
PARQUET-521: Add Brotli compression codec.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_install:
   - cd ..
 
 env:
-  - HADOOP_PROFILE=default
-  - HADOOP_PROFILE=hadoop-2
+  - HADOOP_PROFILE=default TEST_CODECS=uncompressed
+  - HADOOP_PROFILE=hadoop-2 TEST_CODECS=gzip,snappy
 
 install: mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true > mvn_install.log || mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true > mvn_install.log || (cat mvn_install.log && false)
 script: mvn test -P $HADOOP_PROFILE

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_install:
   - cd ..
 
 env:
-  - HADOOP_PROFILE=default TEST_CODECS=uncompressed
-  - HADOOP_PROFILE=hadoop-2 TEST_CODECS=gzip,snappy
+  - HADOOP_PROFILE=default TEST_CODECS=uncompressed,gzip
+  - HADOOP_PROFILE=hadoop-2 TEST_CODECS=snappy,brotli
 
 install: mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true > mvn_install.log || mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true > mvn_install.log || (cat mvn_install.log && false)
 script: mvn test -P $HADOOP_PROFILE

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -75,6 +75,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.meteogroup.jbrotli</groupId>
+      <artifactId>jbrotli</artifactId>
+      <version>${brotli.version}</version>
+    </dependency>
+    <dependency>
       <groupId>commons-pool</groupId>
       <artifactId>commons-pool</artifactId>
       <version>1.5.4</version>

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.util.ReflectionUtils;
 
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.hadoop.codec.NonBlockingDecompressor;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 public class CodecFactory {
@@ -104,6 +105,9 @@ public class CodecFactory {
       final BytesInput decompressed;
       if (codec != null) {
         decompressor.reset();
+        if (decompressor instanceof NonBlockingDecompressor) {
+          ((NonBlockingDecompressor) decompressor).setOutputBufferSize(uncompressedSize);
+        }
         InputStream is = codec.createInputStream(bytes.toInputStream(), decompressor);
         decompressed = BytesInput.from(is, uncompressedSize);
       } else {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/BrotliCompressor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/BrotliCompressor.java
@@ -1,0 +1,98 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.hadoop.codec;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.Preconditions;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.meteogroup.jbrotli.Brotli;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.parquet.schema.OriginalType.JSON;
+import static org.apache.parquet.schema.OriginalType.UTF8;
+
+public class BrotliCompressor extends NonBlockingCompressor {
+  private static final Set<OriginalType> TEXT_ANNOTATIONS = new HashSet<OriginalType>();
+  static {
+    TEXT_ANNOTATIONS.add(UTF8);
+    TEXT_ANNOTATIONS.add(JSON);
+  }
+
+  private final org.meteogroup.jbrotli.BrotliCompressor compressor =
+      new org.meteogroup.jbrotli.BrotliCompressor();
+  private Brotli.Parameter parameter;
+
+  private static boolean isText(PrimitiveType primitiveType) {
+    return (primitiveType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.BINARY) &&
+        TEXT_ANNOTATIONS.contains(primitiveType.getOriginalType());
+  }
+
+  public BrotliCompressor(Configuration conf) {
+    this.parameter = makeParameter(conf);
+  }
+
+  public BrotliCompressor(PrimitiveType primitive, int quality) {
+    Preconditions.checkArgument(quality >= 1 && quality <= 11,
+        "Invalid Brotli quality: %s", quality);
+    this.parameter = new Brotli.Parameter();
+    parameter.setMode(isText(primitive) ? Brotli.Mode.TEXT : Brotli.Mode.GENERIC);
+    parameter.setQuality(quality);
+  }
+
+  @Override
+  protected int getMaxCompressedLength(int numInputBytes) {
+    // this is based on https://github.com/google/brotli/issues/274
+    // that page is not very clear, so this is much more conservative
+    return numInputBytes * 2;
+  }
+
+  @Override
+  public int compress(ByteBuffer inputBuffer, ByteBuffer outputBuffer) throws IOException {
+    return compressor.compress(parameter, inputBuffer, outputBuffer);
+  }
+
+  @Override
+  public void reinit(Configuration conf) {
+    super.reinit(conf);
+    this.parameter = makeParameter(conf);
+  }
+
+  private static Brotli.Parameter makeParameter(Configuration conf) {
+    if (conf != null) {
+      int quality = conf.getInt(BrotliNonBlockingCodec.QUALITY_LEVEL_PROP, 1);
+      Preconditions.checkArgument(quality >= 1 && quality <= 11,
+          "Invalid Brotli quality: %s", quality);
+
+      boolean isText = conf.getBoolean(BrotliNonBlockingCodec.IS_TEXT_PROP, false);
+
+      Brotli.Parameter parameter = new Brotli.Parameter();
+      parameter.setMode(isText ? Brotli.Mode.TEXT : Brotli.Mode.GENERIC);
+      parameter.setQuality(quality);
+
+      return parameter;
+    }
+
+    return new Brotli.Parameter();
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/BrotliDecompressor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/BrotliDecompressor.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.hadoop.codec;
+
+import org.apache.hadoop.conf.Configuration;
+import org.meteogroup.jbrotli.BrotliDeCompressor;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class BrotliDecompressor extends NonBlockingDecompressor {
+  private final BrotliDeCompressor decompressor = new BrotliDeCompressor();
+  private int outputBufferSize = -1;
+
+  public void setOutputBufferSize(int size) {
+    this.outputBufferSize = size;
+  }
+
+  @Override
+  protected int getUncompressedLength(ByteBuffer inputBuffer) throws IOException {
+    if (outputBufferSize > 0) {
+      return outputBufferSize;
+    }
+    return inputBuffer.remaining() * 4;
+  }
+
+  @Override
+  protected int decompress(ByteBuffer inputBuffer, ByteBuffer outputBuffer) throws IOException {
+    return decompressor.deCompress(inputBuffer, outputBuffer);
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/BrotliNonBlockingCodec.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/BrotliNonBlockingCodec.java
@@ -1,0 +1,56 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.hadoop.codec;
+
+import org.meteogroup.jbrotli.libloader.BrotliLibraryLoader;
+
+public class BrotliNonBlockingCodec extends NonBlockingCodec {
+  public static final String IS_TEXT_PROP = "parquet.compression.brotli.is-text";
+  public static final String QUALITY_LEVEL_PROP = "parquet.compression.brotli.quality";
+
+  static {
+    BrotliLibraryLoader.loadBrotli();
+  }
+
+  @Override
+  public org.apache.hadoop.io.compress.Compressor createCompressor() {
+    return new BrotliCompressor(getConf());
+  }
+
+  @Override
+  public org.apache.hadoop.io.compress.Decompressor createDecompressor() {
+    return new BrotliDecompressor();
+  }
+
+  @Override
+  public Class<? extends org.apache.hadoop.io.compress.Compressor> getCompressorType() {
+    return BrotliCompressor.class;
+  }
+
+  @Override
+  public Class<? extends org.apache.hadoop.io.compress.Decompressor> getDecompressorType() {
+    return BrotliDecompressor.class;
+  }
+
+  @Override
+  public String getDefaultExtension() {
+    return "br";
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/NonBlockingCodec.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/NonBlockingCodec.java
@@ -1,0 +1,82 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.parquet.hadoop.codec;
+
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionInputStream;
+import org.apache.hadoop.io.compress.CompressionOutputStream;
+import org.apache.hadoop.io.compress.Compressor;
+import org.apache.hadoop.io.compress.Decompressor;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Non-blocking compression codec for Parquet.  We do not use the default hadoop
+ * one since that codec adds a blocking structure around the base snappy compression
+ * algorithm.  This is useful for hadoop to minimize the size of compression blocks
+ * for their file formats (e.g. SequenceFile) but is undesirable for Parquet since
+ * we already have the data page which provides that.
+ */
+public abstract class NonBlockingCodec extends Configured implements CompressionCodec {
+  // Hadoop config for how big to make intermediate buffers.
+  private final String BUFFER_SIZE_CONFIG = "io.file.buffer.size";
+
+  @Override
+  public abstract Compressor createCompressor();
+
+  @Override
+  public abstract Decompressor createDecompressor();
+
+  @Override
+  public abstract Class<? extends Compressor> getCompressorType();
+
+  @Override
+  public abstract Class<? extends Decompressor> getDecompressorType();
+
+  @Override
+  public abstract String getDefaultExtension();
+
+  @Override
+  public CompressionInputStream createInputStream(InputStream stream)
+      throws IOException {
+    return createInputStream(stream, createDecompressor());
+  }
+
+  @Override
+  public CompressionInputStream createInputStream(InputStream stream,
+      Decompressor decompressor) throws IOException {
+    return new NonBlockedDecompressorStream(stream, decompressor,
+        getConf().getInt(BUFFER_SIZE_CONFIG, 4*1024));
+  }
+
+  @Override
+  public CompressionOutputStream createOutputStream(OutputStream stream)
+      throws IOException {
+    return createOutputStream(stream, createCompressor());
+  }
+
+  @Override
+  public CompressionOutputStream createOutputStream(OutputStream stream,
+      Compressor compressor) throws IOException {
+    return new NonBlockedCompressorStream(stream, compressor,
+        getConf().getInt(BUFFER_SIZE_CONFIG, 4*1024));
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/NonBlockingCompressor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/NonBlockingCompressor.java
@@ -1,0 +1,166 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.hadoop.codec;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.Compressor;
+import org.apache.parquet.Preconditions;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * This class is a wrapper around the a compressor. It always consumes the
+ * entire input in setInput and compresses it as one compressed block.
+ */
+abstract class NonBlockingCompressor implements Compressor {
+
+  protected abstract int getMaxCompressedLength(int numInputBytes);
+
+  protected abstract int compress(ByteBuffer inputBuffer, ByteBuffer outputBuffer)
+      throws IOException;
+
+
+  // Buffer for compressed output. This buffer grows as necessary.
+  private ByteBuffer outputBuffer = ByteBuffer.allocateDirect(0);
+
+  // Buffer for uncompressed input. This buffer grows as necessary.
+  private ByteBuffer inputBuffer = ByteBuffer.allocateDirect(8192);
+
+  private long bytesRead = 0L;
+  private long bytesWritten = 0L;
+  private boolean finishCalled = false;
+
+  /**
+   * Fills specified buffer with compressed data. Returns actual number
+   * of bytes of compressed data. A return value of 0 indicates that
+   * needsInput() should be called in order to determine if more input
+   * data is required.
+   *
+   * @param buffer Buffer for the compressed data
+   * @param off    Start offset of the data
+   * @param len    Size of the buffer
+   * @return The actual number of bytes of compressed data.
+   */
+  @Override
+  public synchronized int compress(byte[] buffer, int off, int len) throws IOException {
+    SnappyUtil.validateBuffer(buffer, off, len);
+
+    if (needsInput()) {
+      // No buffered output bytes and no input to consume, need more input
+      return 0;
+    }
+
+    if (!outputBuffer.hasRemaining()) {
+      // There is uncompressed input, compress it now
+      int maxOutputSize = getMaxCompressedLength(inputBuffer.position());
+      if (maxOutputSize > outputBuffer.capacity()) {
+        outputBuffer = ByteBuffer.allocateDirect(maxOutputSize);
+      }
+      // Reset the previous outputBuffer
+      outputBuffer.clear();
+      inputBuffer.limit(inputBuffer.position());
+      inputBuffer.position(0);
+
+      int size = compress(inputBuffer, outputBuffer);
+      outputBuffer.limit(size);
+      inputBuffer.limit(0);
+      inputBuffer.rewind();
+    }
+
+    // Return compressed output up to 'len'
+    int numBytes = Math.min(len, outputBuffer.remaining());
+    outputBuffer.get(buffer, off, numBytes);
+    bytesWritten += numBytes;
+    return numBytes;
+  }
+
+  @Override
+  public synchronized void setInput(byte[] buffer, int off, int len) {
+    SnappyUtil.validateBuffer(buffer, off, len);
+
+    Preconditions.checkArgument(!outputBuffer.hasRemaining(),
+        "Output buffer should be empty. Caller must call compress()");
+
+    if (inputBuffer.capacity() - inputBuffer.position() < len) {
+      ByteBuffer tmp = ByteBuffer.allocateDirect(
+          Math.max(inputBuffer.position() * 2, inputBuffer.position() + len));
+      inputBuffer.rewind();
+      tmp.put(inputBuffer);
+      inputBuffer = tmp;
+    }
+    inputBuffer.limit(inputBuffer.position() + len);
+
+    // Append the current bytes to the input buffer
+    inputBuffer.put(buffer, off, len);
+    bytesRead += len;
+  }
+
+  @Override
+  public void end() {
+    // No-op
+  }
+
+  @Override
+  public synchronized void finish() {
+    finishCalled = true;
+  }
+
+  @Override
+  public synchronized boolean finished() {
+    return finishCalled && inputBuffer.position() == 0 && !outputBuffer.hasRemaining();
+  }
+
+  @Override
+  public long getBytesRead() {
+    return bytesRead;
+  }
+
+  @Override
+  public long getBytesWritten() {
+    return bytesWritten;
+  }
+
+  @Override
+  // We want to compress all the input in one go so we always need input until it is
+  // all consumed.
+  public synchronized boolean needsInput() {
+    return !finishCalled;
+  }
+
+  @Override
+  public void reinit(Configuration c) {
+    reset();
+  }
+
+  @Override
+  public synchronized void reset() {
+    finishCalled = false;
+    bytesRead = bytesWritten = 0;
+    inputBuffer.rewind();
+    outputBuffer.rewind();
+    inputBuffer.limit(0);
+    outputBuffer.limit(0);
+  }
+
+  @Override
+  public void setDictionary(byte[] dictionary, int off, int len) {
+    // No-op
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/NonBlockingDecompressor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/NonBlockingDecompressor.java
@@ -1,0 +1,156 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.hadoop.codec;
+
+import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.parquet.Preconditions;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+abstract public class NonBlockingDecompressor implements Decompressor {
+
+  public abstract void setOutputBufferSize(int size);
+
+  protected abstract int getUncompressedLength(ByteBuffer inputBuffer) throws IOException;
+
+  protected abstract int decompress(ByteBuffer inputBuffer, ByteBuffer outputBuffer)
+      throws IOException;
+
+  // Buffer for uncompressed output. This buffer grows as necessary.
+  private ByteBuffer outputBuffer = ByteBuffer.allocateDirect(0);
+
+  // Buffer for compressed input. This buffer grows as necessary.
+  private ByteBuffer inputBuffer = ByteBuffer.allocateDirect(0);
+
+  private boolean finished;
+
+  /**
+   * Fills specified buffer with uncompressed data. Returns actual number
+   * of bytes of uncompressed data. A return value of 0 indicates that
+   * {@link #needsInput()} should be called in order to determine if more
+   * input data is required.
+   *
+   * @param buffer   Buffer for the compressed data
+   * @param off Start offset of the data
+   * @param len Size of the buffer
+   * @return The actual number of bytes of uncompressed data.
+   * @throws IOException
+   */
+  @Override
+  public synchronized int decompress(byte[] buffer, int off, int len) throws IOException {
+    SnappyUtil.validateBuffer(buffer, off, len);
+    if (inputBuffer.position() == 0 && !outputBuffer.hasRemaining()) {
+      return 0;
+    }
+
+    if (!outputBuffer.hasRemaining()) {
+      inputBuffer.rewind();
+      Preconditions.checkArgument(inputBuffer.position() == 0, "Invalid position of 0.");
+      Preconditions.checkArgument(outputBuffer.position() == 0, "Invalid position of 0.");
+      // There is compressed input, decompress it now.
+      int decompressedSize = getUncompressedLength(inputBuffer);
+      if (decompressedSize > outputBuffer.capacity()) {
+        outputBuffer = ByteBuffer.allocateDirect(decompressedSize);
+      }
+
+      // Reset the previous outputBuffer (i.e. set position to 0)
+      outputBuffer.clear();
+      int size = decompress(inputBuffer, outputBuffer);
+      outputBuffer.limit(size);
+      // We've decompressed the entire input, reset the input now
+      inputBuffer.clear();
+      inputBuffer.limit(0);
+      finished = true;
+    }
+
+    // Return compressed output up to 'len'
+    int numBytes = Math.min(len, outputBuffer.remaining());
+    outputBuffer.get(buffer, off, numBytes);
+    return numBytes;
+  }
+
+  /**
+   * Sets input data for decompression.
+   * This should be called if and only if {@link #needsInput()} returns
+   * <code>true</code> indicating that more input data is required.
+   * (Both native and non-native versions of various Decompressors require
+   * that the data passed in via <code>b[]</code> remain unmodified until
+   * the caller is explicitly notified--via {@link #needsInput()}--that the
+   * buffer may be safely modified.  With this requirement, an extra
+   * buffer-copy can be avoided.)
+   *
+   * @param buffer   Input data
+   * @param off Start offset
+   * @param len Length
+   */
+  @Override
+  public synchronized void setInput(byte[] buffer, int off, int len) {
+    SnappyUtil.validateBuffer(buffer, off, len);
+
+    if (inputBuffer.capacity() - inputBuffer.position() < len) {
+      ByteBuffer newBuffer = ByteBuffer.allocateDirect(inputBuffer.position() + len);
+      inputBuffer.rewind();
+      newBuffer.put(inputBuffer);
+      inputBuffer = newBuffer;
+    } else {
+      inputBuffer.limit(inputBuffer.position() + len);
+    }
+    inputBuffer.put(buffer, off, len);
+  }
+
+  @Override
+  public void end() {
+    // No-op
+  }
+
+  @Override
+  public synchronized boolean finished() {
+    return finished && !outputBuffer.hasRemaining();
+  }
+
+  @Override
+  public int getRemaining() {
+    return 0;
+  }
+
+  @Override
+  public synchronized boolean needsInput() {
+    return !inputBuffer.hasRemaining() && !outputBuffer.hasRemaining();
+  }
+
+  @Override
+  public synchronized void reset() {
+    finished = false;
+    inputBuffer.rewind();
+    outputBuffer.rewind();
+    inputBuffer.limit(0);
+    outputBuffer.limit(0);
+  }
+
+  @Override
+  public boolean needsDictionary() {
+    return false;
+  }
+
+  @Override
+  public void setDictionary(byte[] b, int off, int len) {
+    // No-op
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyCodec.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyCodec.java
@@ -18,40 +18,10 @@
  */
 package org.apache.parquet.hadoop.codec;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
-import org.apache.hadoop.conf.Configurable;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.compress.CompressionInputStream;
-import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
 
-/**
- * Snappy compression codec for Parquet.  We do not use the default hadoop
- * one since that codec adds a blocking structure around the base snappy compression
- * algorithm.  This is useful for hadoop to minimize the size of compression blocks
- * for their file formats (e.g. SequenceFile) but is undesirable for Parquet since
- * we already have the data page which provides that.
- */
-public class SnappyCodec implements Configurable, CompressionCodec {
-  private Configuration conf;
-  // Hadoop config for how big to make intermediate buffers.
-  private final String BUFFER_SIZE_CONFIG = "io.file.buffer.size";
-
-  @Override
-  public void setConf(Configuration conf) {
-    this.conf = conf;
-  }
-
-  @Override
-  public Configuration getConf() {
-    return conf;
-  }
-
+public class SnappyCodec extends NonBlockingCodec {
   @Override
   public Compressor createCompressor() {
     return new SnappyCompressor();
@@ -60,32 +30,6 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   @Override
   public Decompressor createDecompressor() {
     return new SnappyDecompressor();
-  }
-
-  @Override
-  public CompressionInputStream createInputStream(InputStream stream)
-      throws IOException {
-    return createInputStream(stream, createDecompressor());
-  }
-
-  @Override
-  public CompressionInputStream createInputStream(InputStream stream,
-      Decompressor decompressor) throws IOException {
-    return new NonBlockedDecompressorStream(stream, decompressor,
-        conf.getInt(BUFFER_SIZE_CONFIG, 4*1024));
-  }
-
-  @Override
-  public CompressionOutputStream createOutputStream(OutputStream stream)
-      throws IOException {
-    return createOutputStream(stream, createCompressor());
-  }
-
-  @Override
-  public CompressionOutputStream createOutputStream(OutputStream stream,
-      Compressor compressor) throws IOException {
-    return new NonBlockedCompressorStream(stream, compressor, 
-        conf.getInt(BUFFER_SIZE_CONFIG, 4*1024));
   }
 
   @Override
@@ -101,5 +45,5 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   @Override
   public String getDefaultExtension() {
     return ".snappy";
-  }  
+  }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyCompressor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyCompressor.java
@@ -18,144 +18,22 @@
  */
 package org.apache.parquet.hadoop.codec;
 
+import org.xerial.snappy.Snappy;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.compress.Compressor;
-import org.xerial.snappy.Snappy;
-
-import org.apache.parquet.Preconditions;
 
 /**
  * This class is a wrapper around the snappy compressor. It always consumes the
  * entire input in setInput and compresses it as one compressed block.
  */
-public class SnappyCompressor implements Compressor {
-  // Buffer for compressed output. This buffer grows as necessary.
-  private ByteBuffer outputBuffer = ByteBuffer.allocateDirect(0);
-
-  // Buffer for uncompressed input. This buffer grows as necessary.
-  private ByteBuffer inputBuffer = ByteBuffer.allocateDirect(0);
-
-  private long bytesRead = 0L;
-  private long bytesWritten = 0L;
-  private boolean finishCalled = false;
-
-  /**
-   * Fills specified buffer with compressed data. Returns actual number
-   * of bytes of compressed data. A return value of 0 indicates that
-   * needsInput() should be called in order to determine if more input
-   * data is required.
-   *
-   * @param buffer   Buffer for the compressed data
-   * @param off Start offset of the data
-   * @param len Size of the buffer
-   * @return The actual number of bytes of compressed data.
-   */
+public class SnappyCompressor extends NonBlockingCompressor {
   @Override
-  public synchronized int compress(byte[] buffer, int off, int len) throws IOException {
-    SnappyUtil.validateBuffer(buffer, off, len);
-
-    if (needsInput()) {
-      // No buffered output bytes and no input to consume, need more input
-      return 0;
-    }
-
-    if (!outputBuffer.hasRemaining()) {
-      // There is uncompressed input, compress it now
-      int maxOutputSize = Snappy.maxCompressedLength(inputBuffer.position());
-      if (maxOutputSize > outputBuffer.capacity()) {
-        outputBuffer = ByteBuffer.allocateDirect(maxOutputSize);
-      }
-      // Reset the previous outputBuffer
-      outputBuffer.clear();
-      inputBuffer.limit(inputBuffer.position());
-      inputBuffer.position(0);
-
-      int size = Snappy.compress(inputBuffer, outputBuffer);
-      outputBuffer.limit(size);
-      inputBuffer.limit(0);
-      inputBuffer.rewind();
-    }
-
-    // Return compressed output up to 'len'
-    int numBytes = Math.min(len, outputBuffer.remaining());
-    outputBuffer.get(buffer, off, numBytes);    
-    bytesWritten += numBytes;
-    return numBytes;	    
+  protected int getMaxCompressedLength(int numInputBytes) {
+    return Snappy.maxCompressedLength(numInputBytes);
   }
 
   @Override
-  public synchronized void setInput(byte[] buffer, int off, int len) {  
-    SnappyUtil.validateBuffer(buffer, off, len);
-    
-    Preconditions.checkArgument(!outputBuffer.hasRemaining(), 
-        "Output buffer should be empty. Caller must call compress()");
-
-    if (inputBuffer.capacity() - inputBuffer.position() < len) {
-      ByteBuffer tmp = ByteBuffer.allocateDirect(inputBuffer.position() + len);
-      inputBuffer.rewind();
-      tmp.put(inputBuffer);
-      inputBuffer = tmp;
-    } else {
-      inputBuffer.limit(inputBuffer.position() + len);
-    }
-
-    // Append the current bytes to the input buffer
-    inputBuffer.put(buffer, off, len);
-    bytesRead += len;
-  }
-
-  @Override
-  public void end() {
-    // No-op		
-  }
-
-  @Override
-  public synchronized void finish() {
-    finishCalled = true;
-  }
-
-  @Override
-  public synchronized boolean finished() {
-    return finishCalled && inputBuffer.position() == 0 && !outputBuffer.hasRemaining();
-  }
-
-  @Override
-  public long getBytesRead() {
-    return bytesRead;
-  }
-
-  @Override
-  public long getBytesWritten() {
-    return bytesWritten;
-  }
-
-  @Override
-  // We want to compress all the input in one go so we always need input until it is
-  // all consumed.
-  public synchronized boolean needsInput() {
-    return !finishCalled;
-  }
-
-  @Override
-  public void reinit(Configuration c) {
-    reset();		
-  }
-
-  @Override
-  public synchronized void reset() {
-    finishCalled = false;
-    bytesRead = bytesWritten = 0;
-    inputBuffer.rewind();
-    outputBuffer.rewind();
-    inputBuffer.limit(0);
-    outputBuffer.limit(0);
-  }
-
-  @Override
-  public void setDictionary(byte[] dictionary, int off, int len) {
-    // No-op		
+  protected int compress(ByteBuffer inputBuffer, ByteBuffer outputBuffer) throws IOException {
+    return Snappy.compress(inputBuffer, outputBuffer);
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyDecompressor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyDecompressor.java
@@ -18,134 +18,26 @@
  */
 package org.apache.parquet.hadoop.codec;
 
+import org.xerial.snappy.Snappy;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.apache.hadoop.io.compress.Decompressor;
-import org.xerial.snappy.Snappy;
+public class SnappyDecompressor extends NonBlockingDecompressor {
+  private int outputBufferSize = -1;
 
-import org.apache.parquet.Preconditions;
-
-public class SnappyDecompressor implements Decompressor {
-  // Buffer for uncompressed output. This buffer grows as necessary.
-  private ByteBuffer outputBuffer = ByteBuffer.allocateDirect(0);
-
-  // Buffer for compressed input. This buffer grows as necessary.
-  private ByteBuffer inputBuffer = ByteBuffer.allocateDirect(0);
-
-  private boolean finished;
-  
-  /**
-   * Fills specified buffer with uncompressed data. Returns actual number
-   * of bytes of uncompressed data. A return value of 0 indicates that
-   * {@link #needsInput()} should be called in order to determine if more
-   * input data is required.
-   *
-   * @param buffer   Buffer for the compressed data
-   * @param off Start offset of the data
-   * @param len Size of the buffer
-   * @return The actual number of bytes of uncompressed data.
-   * @throws IOException
-   */
   @Override
-  public synchronized int decompress(byte[] buffer, int off, int len) throws IOException {
-    SnappyUtil.validateBuffer(buffer, off, len);
-	if (inputBuffer.position() == 0 && !outputBuffer.hasRemaining()) {
-      return 0;
-    }
-    
-    if (!outputBuffer.hasRemaining()) {
-      inputBuffer.rewind();
-      Preconditions.checkArgument(inputBuffer.position() == 0, "Invalid position of 0.");
-      Preconditions.checkArgument(outputBuffer.position() == 0, "Invalid position of 0.");
-      // There is compressed input, decompress it now.
-      int decompressedSize = Snappy.uncompressedLength(inputBuffer);
-      if (decompressedSize > outputBuffer.capacity()) {
-        outputBuffer = ByteBuffer.allocateDirect(decompressedSize);
-      }
-
-      // Reset the previous outputBuffer (i.e. set position to 0)
-      outputBuffer.clear();
-      int size = Snappy.uncompress(inputBuffer, outputBuffer);
-      outputBuffer.limit(size);
-      // We've decompressed the entire input, reset the input now
-      inputBuffer.clear();
-      inputBuffer.limit(0);
-      finished = true;
-    }
-
-    // Return compressed output up to 'len'
-    int numBytes = Math.min(len, outputBuffer.remaining());
-    outputBuffer.get(buffer, off, numBytes);
-    return numBytes;	    
-  }
-
-  /**
-   * Sets input data for decompression.
-   * This should be called if and only if {@link #needsInput()} returns
-   * <code>true</code> indicating that more input data is required.
-   * (Both native and non-native versions of various Decompressors require
-   * that the data passed in via <code>b[]</code> remain unmodified until
-   * the caller is explicitly notified--via {@link #needsInput()}--that the
-   * buffer may be safely modified.  With this requirement, an extra
-   * buffer-copy can be avoided.)
-   *
-   * @param buffer   Input data
-   * @param off Start offset
-   * @param len Length
-   */
-  @Override
-  public synchronized void setInput(byte[] buffer, int off, int len) {
-    SnappyUtil.validateBuffer(buffer, off, len);
-
-    if (inputBuffer.capacity() - inputBuffer.position() < len) {
-      ByteBuffer newBuffer = ByteBuffer.allocateDirect(inputBuffer.position() + len);
-      inputBuffer.rewind();
-      newBuffer.put(inputBuffer);
-      inputBuffer = newBuffer;      
-    } else {
-      inputBuffer.limit(inputBuffer.position() + len);
-    }
-    inputBuffer.put(buffer, off, len);
+  public void setOutputBufferSize(int size) {
+    this.outputBufferSize = size;
   }
 
   @Override
-  public void end() {
-    // No-op		
+  protected int getUncompressedLength(ByteBuffer inputBuffer) throws IOException {
+    return outputBufferSize < 0 ? Snappy.uncompressedLength(inputBuffer) : outputBufferSize;
   }
 
   @Override
-  public synchronized boolean finished() {
-    return finished && !outputBuffer.hasRemaining();
-  }
-
-  @Override
-  public int getRemaining() {
-    return 0;
-  }
-
-  @Override
-  public synchronized boolean needsInput() {
-    return !inputBuffer.hasRemaining() && !outputBuffer.hasRemaining();
-  }
-
-  @Override
-  public synchronized void reset() {
-    finished = false;
-    inputBuffer.rewind();
-    outputBuffer.rewind();
-    inputBuffer.limit(0);
-    outputBuffer.limit(0);
-  }
-
-  @Override
-  public boolean needsDictionary() {
-    return false;
-  }
-
-  @Override
-  public void setDictionary(byte[] b, int off, int len) {
-    // No-op		
+  protected int decompress(ByteBuffer inputBuffer, ByteBuffer outputBuffer) throws IOException {
+    return Snappy.uncompress(inputBuffer, outputBuffer);
   }
 
 } //class SnappyDecompressor

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/CompressionCodecName.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/CompressionCodecName.java
@@ -27,7 +27,8 @@ public enum CompressionCodecName {
   UNCOMPRESSED(null, CompressionCodec.UNCOMPRESSED, ""),
   SNAPPY("org.apache.parquet.hadoop.codec.SnappyCodec", CompressionCodec.SNAPPY, ".snappy"),
   GZIP("org.apache.hadoop.io.compress.GzipCodec", CompressionCodec.GZIP, ".gz"),
-  LZO("com.hadoop.compression.lzo.LzoCodec", CompressionCodec.LZO, ".lzo");
+  LZO("com.hadoop.compression.lzo.LzoCodec", CompressionCodec.LZO, ".lzo"),
+  BROTLI("org.apache.parquet.hadoop.codec.BrotliNonBlockingCodec", CompressionCodec.BROTLI, ".br");
 
   public static CompressionCodecName fromConf(String name) {
      if (name == null) {

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
   </developers>
 
   <!-- this is needed for maven-thrift-plugin, would like to remove this.
-   see: https://issues.apache.org/jira/browse/THRIFT-1536  -->
+    see: https://issues.apache.org/jira/browse/THRIFT-1536  -->
   <pluginRepositories>
     <pluginRepository>
       <id>Twitter public Maven repo</id>
@@ -66,7 +66,16 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <repositories>
+    <repository>
+      <id>bintray-nitram509-jbrotli</id>
+      <name>bintray</name>
+      <url>http://dl.bintray.com/nitram509/jbrotli</url>
+    </repository>
+  </repositories>
+
   <properties>
+    <brotli.version>0.4.0</brotli.version>
     <targetJavaVersion>1.6</targetJavaVersion>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>${targetJavaVersion}</maven.compiler.target>
@@ -80,7 +89,7 @@
     <hadoop.version>1.1.0</hadoop.version>
     <cascading.version>2.5.3</cascading.version>
     <cascading3.version>3.0.3</cascading3.version>
-    <parquet.format.version>2.3.1</parquet.format.version>
+    <parquet.format.version>2.3.2-SNAPSHOT</parquet.format.version>
     <previous.version>1.7.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <scala.version>2.10.4</scala.version>
@@ -245,7 +254,10 @@
                      <exclude>org/apache/parquet/avro/SpecificDataSupplier</exclude> <!-- made public -->
                      <exclude>org/apache/parquet/io/ColumnIOFactory$ColumnIOCreatorVisitor</exclude> <!-- removed non-API class -->
                      <exclude>org/apache/parquet/io/ColumnIOFactory/**</exclude> <!-- removed non-API class and methods-->
-		     <exclude>org/apache/parquet/hadoop/codec/SnappyCompressor</exclude> <!-- added synchronized modifier -->
+                     <exclude>org/apache/parquet/hadoop/codec/SnappyCompressor</exclude> <!-- added synchronized modifier -->
+                     <exclude>org/apache/parquet/hadoop/codec/SnappyDecompressor</exclude> <!-- now a subclass of NonBlockingDecompressor -->
+                     <exclude>org/apache/parquet/hadoop/codec/SnappyCodec</exclude> <!-- now a subclass of NonBlockingCodec -->
+                     <exclude>org/apache/parquet/hadoop/codec/SnappyCodec/**</exclude> <!-- getConf/setConf moved to superclass -->
                    </excludes>
                  </requireBackwardCompatibility>
                </rules>


### PR DESCRIPTION
This adds a Brotli codec that shares code with the Snappy codec. Snappy
is "non-blocking", meaning that it always accepts more data and buffers
it without blocking. The first reads is blocking, while the compression
is done off-heap. This strategy doesn't appear to have a noticable
performance impact, but does get better compression for Brotli than
streaming buffers.

The non-blocking part of Parquet's Snappy codec has been refactored so
it can be used for both Brotli and Snappy, which both use direct byte
buffers and compress outside the JVM.

This currently depends on a snapshot release of parquet-format with
[PARQUET-609](https://issues.apache.org/jira/browse/PARQUET-609).
