### PR TITLE
PARQUET-660: Ignore extension fields in protobuf messages.

### DIFF
--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoSchemaConverter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoSchemaConverter.java
@@ -86,21 +86,21 @@ public class ProtoSchemaConverter {
     Type.Repetition repetition = getRepetition(descriptor);
     JavaType javaType = descriptor.getJavaType();
     switch (javaType) {
-    case BOOLEAN : return builder.primitive(BOOLEAN, repetition);
-    case INT : return builder.primitive(INT32, repetition);
-    case LONG : return builder.primitive(INT64, repetition);
-    case FLOAT : return builder.primitive(FLOAT, repetition);
-    case DOUBLE: return builder.primitive(DOUBLE, repetition);
-    case BYTE_STRING: return builder.primitive(BINARY, repetition);
-    case STRING: return builder.primitive(BINARY, repetition).as(UTF8);
-    case MESSAGE: {
-      GroupBuilder<GroupBuilder<T>> group = builder.group(repetition);
-      convertFields(group, descriptor.getMessageType().getFields());
-      return group;
-    }
-    case ENUM: return builder.primitive(BINARY, repetition).as(ENUM);
-    default:
-      throw new UnsupportedOperationException("Cannot convert Protocol Buffer: unknown type " + javaType);
+      case BOOLEAN: return builder.primitive(BOOLEAN, repetition);
+      case INT: return builder.primitive(INT32, repetition);
+      case LONG: return builder.primitive(INT64, repetition);
+      case FLOAT: return builder.primitive(FLOAT, repetition);
+      case DOUBLE: return builder.primitive(DOUBLE, repetition);
+      case BYTE_STRING: return builder.primitive(BINARY, repetition);
+      case STRING: return builder.primitive(BINARY, repetition).as(UTF8);
+      case MESSAGE: {
+        GroupBuilder<GroupBuilder<T>> group = builder.group(repetition);
+        convertFields(group, descriptor.getMessageType().getFields());
+        return group;
+      }
+      case ENUM: return builder.primitive(BINARY, repetition).as(ENUM);
+      default:
+        throw new UnsupportedOperationException("Cannot convert Protocol Buffer: unknown type " + javaType);
     }
   }
 

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -156,7 +156,6 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
       List<Descriptors.FieldDescriptor> fields = descriptor.getFields();
       fieldWriters = (FieldWriter[]) Array.newInstance(FieldWriter.class, fields.size());
 
-      int i = 0;
       for (Descriptors.FieldDescriptor fieldDescriptor: fields) {
         String name = fieldDescriptor.getName();
         Type type = schema.getType(name);
@@ -169,8 +168,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
         writer.setFieldName(name);
         writer.setIndex(schema.getFieldIndex(name));
 
-        fieldWriters[i] = writer;
-        i++;
+        fieldWriters[fieldDescriptor.getIndex()] = writer;
       }
     }
 

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -276,7 +276,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
   }
 
   class IntWriter extends FieldWriter {
-  @Override
+    @Override
     final void writeRawValue(Object value) {
       recordConsumer.addInteger((Integer) value);
     }

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -218,6 +218,13 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
 
       for (Map.Entry<Descriptors.FieldDescriptor, Object> entry : changedPbFields.entrySet()) {
         Descriptors.FieldDescriptor fieldDescriptor = entry.getKey();
+
+        if(fieldDescriptor.isExtension()) {
+          // Field index of an extension field might overlap with a base field.
+          throw new UnsupportedOperationException(
+                  "Cannot convert Protobuf message with extension field(s)");
+        }
+
         int fieldIndex = fieldDescriptor.getIndex();
         fieldWriters[fieldIndex].writeField(entry.getValue());
       }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
@@ -165,4 +165,19 @@ public class ProtoWriteSupportTest {
     inOrder.verify(readConsumerMock).endMessage();
     Mockito.verifyNoMoreInteractions(readConsumerMock);
   }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testMessageWithExtensions() throws Exception {
+    RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
+    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.Vehicle.class, readConsumerMock);
+
+    TestProtobuf.Vehicle.Builder msg = TestProtobuf.Vehicle.newBuilder();
+    msg.setHorsePower(300);
+    // Currently there's no support for extension fields. This test tests that the extension field
+    // will cause an exception.
+    msg.setExtension(TestProtobuf.Airplane.wingSpan, 50);
+
+    instance.write(msg.build());
+  }
+
 }

--- a/parquet-protobuf/src/test/resources/TestProtobuf.proto
+++ b/parquet-protobuf/src/test/resources/TestProtobuf.proto
@@ -137,3 +137,14 @@ message SecondCustomClassMessage {
 }
 
 //please place your unit test Protocol Buffer definitions here.
+
+message Vehicle {
+    optional int32 horsePower = 1;
+    extensions 100 to 199;
+}
+
+message Airplane {
+    extend Vehicle {
+        optional int32 wingSpan = 101;
+    }
+}


### PR DESCRIPTION
Currently, converting protobuf messages with extension can result in an uninformative error or a data corruption. A more detailed explanation in the corresponding [jira](https://issues.apache.org/jira/browse/PARQUET-660).

This patch simply ignores extension fields in protobuf messages. 

In the longer run, I'd like to add a proper support for Protobuf extensions. This might take a little longer though, so I've decided to improve the current situation with this patch.