### PR TITLE
PARQUET-651: Improve Avro's isElementType check.

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
@@ -54,13 +54,24 @@ public class AvroSchemaConverter {
 
   public static final String ADD_LIST_ELEMENT_RECORDS =
       "parquet.avro.add-list-element-records";
-  private static final boolean ADD_LIST_ELEMENT_RECORDS_DEFAULT = true;
+  private static final boolean ADD_LIST_ELEMENT_RECORDS_DEFAULT = false;
 
   private final boolean assumeRepeatedIsListElement;
   private final boolean writeOldListStructure;
 
   public AvroSchemaConverter() {
     this.assumeRepeatedIsListElement = ADD_LIST_ELEMENT_RECORDS_DEFAULT;
+    this.writeOldListStructure = WRITE_OLD_LIST_STRUCTURE_DEFAULT;
+  }
+
+  /**
+   * Constructor used by {@link AvroRecordConverter#isElementType}, which always
+   * uses the 2-level list conversion.
+   *
+   * @param assumeRepeatedIsListElement whether to assume 2-level lists
+   */
+  AvroSchemaConverter(boolean assumeRepeatedIsListElement) {
+    this.assumeRepeatedIsListElement = assumeRepeatedIsListElement;
     this.writeOldListStructure = WRITE_OLD_LIST_STRUCTURE_DEFAULT;
   }
 
@@ -217,6 +228,10 @@ public class AvroSchemaConverter {
   }
 
   public Schema convert(MessageType parquetSchema) {
+    return convertFields(parquetSchema.getName(), parquetSchema.getFields());
+  }
+
+  Schema convert(GroupType parquetSchema) {
     return convertFields(parquetSchema.getName(), parquetSchema.getFields());
   }
 

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
@@ -54,7 +54,7 @@ public class AvroSchemaConverter {
 
   public static final String ADD_LIST_ELEMENT_RECORDS =
       "parquet.avro.add-list-element-records";
-  private static final boolean ADD_LIST_ELEMENT_RECORDS_DEFAULT = false;
+  private static final boolean ADD_LIST_ELEMENT_RECORDS_DEFAULT = true;
 
   private final boolean assumeRepeatedIsListElement;
   private final boolean writeOldListStructure;


### PR DESCRIPTION
The Avro implementation needs to check whether the read schema that is
passed by the user (or automatically converted from the file schema)
expects an extra 1-field layer to be returned, which matches the
previous behavior of Avro when reading a 3-level list. Before this
commit, the check was done by testing the structure of the expected list
element type against the repeated group's schema. If they matched, then
Avro assumed that the user expected an extra layer. However, for records
that happened to match (1-field records with a field named "element")
the check could be wrong and would cause exceptions later.

This commit updates the check to convert the file's element schema to
Avro and compare the compatibility of that schema with what was passed
by the user. This checks the entire tree from the element down and gets
the answer right based on the element and its children, not just the
field names on the element.