### PR TITLE
PARQUET-389: Support predicate push down on missing columns.

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/SchemaCompatibilityValidator.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/SchemaCompatibilityValidator.java
@@ -167,6 +167,11 @@ public class SchemaCompatibilityValidator implements FilterPredicate.Visitor<Voi
     }
 
     ColumnDescriptor descriptor = getColumnDescriptor(path);
+    if (descriptor == null) {
+      // the column is missing from the schema. evaluation uses calls
+      // updateNull() a value is missing, so this will be handled correctly.
+      return;
+    }
 
     if (descriptor.getMaxRepetitionLevel() > 0) {
       throw new IllegalArgumentException("FilterPredicates do not currently support repeated columns. "
@@ -177,8 +182,6 @@ public class SchemaCompatibilityValidator implements FilterPredicate.Visitor<Voi
   }
 
   private ColumnDescriptor getColumnDescriptor(ColumnPath columnPath) {
-    ColumnDescriptor cd = columnsAccordingToSchema.get(columnPath);
-    checkArgument(cd != null, "Column " + columnPath + " was not found in schema!");
-    return cd;
+    return columnsAccordingToSchema.get(columnPath);
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/TestFiltersWithMissingColumns.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/TestFiltersWithMissingColumns.java
@@ -1,0 +1,265 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.filter2;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.example.GroupReadSupport;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Types;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import java.io.File;
+import java.io.IOException;
+
+import static org.apache.parquet.filter2.predicate.FilterApi.and;
+import static org.apache.parquet.filter2.predicate.FilterApi.binaryColumn;
+import static org.apache.parquet.filter2.predicate.FilterApi.doubleColumn;
+import static org.apache.parquet.filter2.predicate.FilterApi.eq;
+import static org.apache.parquet.filter2.predicate.FilterApi.gt;
+import static org.apache.parquet.filter2.predicate.FilterApi.gtEq;
+import static org.apache.parquet.filter2.predicate.FilterApi.longColumn;
+import static org.apache.parquet.filter2.predicate.FilterApi.lt;
+import static org.apache.parquet.filter2.predicate.FilterApi.ltEq;
+import static org.apache.parquet.filter2.predicate.FilterApi.notEq;
+import static org.apache.parquet.filter2.predicate.FilterApi.or;
+import static org.apache.parquet.io.api.Binary.fromString;
+import static org.apache.parquet.schema.OriginalType.UTF8;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.junit.Assert.assertEquals;
+
+public class TestFiltersWithMissingColumns {
+  @Rule
+  public final TemporaryFolder temp = new TemporaryFolder();
+
+  public Path path;
+
+  @Before
+  public void createDataFile() throws Exception {
+    File file = temp.newFile("test.parquet");
+    this.path = new Path(file.toString());
+
+    MessageType type = Types.buildMessage()
+        .required(INT64).named("id")
+        .required(BINARY).as(UTF8).named("data")
+        .named("test");
+
+    SimpleGroupFactory factory = new SimpleGroupFactory(type);
+
+    ParquetWriter<Group> writer = ExampleParquetWriter.builder(path)
+        .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
+        .withType(type)
+        .build();
+
+    try {
+      for (long i = 0; i < 1000; i += 1) {
+        Group g = factory.newGroup();
+        g.add(0, i);
+        g.add(1, "data-" + i);
+        writer.write(g);
+      }
+    } finally {
+      writer.close();
+    }
+  }
+
+  @Test
+  public void testNormalFilter() throws Exception {
+    assertEquals(500, countFilteredRecords(path, lt(longColumn("id"), 500L)));
+  }
+
+  @Test
+  public void testSimpleMissingColumnFilter() throws Exception {
+    assertEquals(0, countFilteredRecords(path, lt(longColumn("missing"), 500L)));
+  }
+
+  @Test
+  public void testAndMissingColumnFilter() throws Exception {
+    // missing column filter is true
+    assertEquals(500, countFilteredRecords(path, and(
+        lt(longColumn("id"), 500L),
+        eq(binaryColumn("missing"), null)
+    )));
+    assertEquals(500, countFilteredRecords(path, and(
+        lt(longColumn("id"), 500L),
+        notEq(binaryColumn("missing"), fromString("any"))
+    )));
+
+    assertEquals(500, countFilteredRecords(path, and(
+        eq(binaryColumn("missing"), null),
+        lt(longColumn("id"), 500L)
+    )));
+    assertEquals(500, countFilteredRecords(path, and(
+        notEq(binaryColumn("missing"), fromString("any")),
+        lt(longColumn("id"), 500L)
+    )));
+
+    // missing column filter is false
+    assertEquals(0, countFilteredRecords(path, and(
+        lt(longColumn("id"), 500L),
+        eq(binaryColumn("missing"), fromString("any"))
+    )));
+    assertEquals(0, countFilteredRecords(path, and(
+        lt(longColumn("id"), 500L),
+        notEq(binaryColumn("missing"), null)
+    )));
+    assertEquals(0, countFilteredRecords(path, and(
+        lt(longColumn("id"), 500L),
+        lt(doubleColumn("missing"), 33.33)
+    )));
+    assertEquals(0, countFilteredRecords(path, and(
+        lt(longColumn("id"), 500L),
+        ltEq(doubleColumn("missing"), 33.33)
+    )));
+    assertEquals(0, countFilteredRecords(path, and(
+        lt(longColumn("id"), 500L),
+        gt(doubleColumn("missing"), 33.33)
+    )));
+    assertEquals(0, countFilteredRecords(path, and(
+        lt(longColumn("id"), 500L),
+        gtEq(doubleColumn("missing"), 33.33)
+    )));
+
+    assertEquals(0, countFilteredRecords(path, and(
+        eq(binaryColumn("missing"), fromString("any")),
+        lt(longColumn("id"), 500L)
+    )));
+    assertEquals(0, countFilteredRecords(path, and(
+        notEq(binaryColumn("missing"), null),
+        lt(longColumn("id"), 500L)
+    )));
+    assertEquals(0, countFilteredRecords(path, and(
+        lt(doubleColumn("missing"), 33.33),
+        lt(longColumn("id"), 500L)
+    )));
+    assertEquals(0, countFilteredRecords(path, and(
+        ltEq(doubleColumn("missing"), 33.33),
+        lt(longColumn("id"), 500L)
+    )));
+    assertEquals(0, countFilteredRecords(path, and(
+        gt(doubleColumn("missing"), 33.33),
+        lt(longColumn("id"), 500L)
+    )));
+    assertEquals(0, countFilteredRecords(path, and(
+        gtEq(doubleColumn("missing"), 33.33),
+        lt(longColumn("id"), 500L)
+    )));
+  }
+
+  @Test
+  public void testOrMissingColumnFilter() throws Exception {
+    // missing column filter is false
+    assertEquals(500, countFilteredRecords(path, or(
+        lt(longColumn("id"), 500L),
+        eq(binaryColumn("missing"), fromString("any"))
+    )));
+    assertEquals(500, countFilteredRecords(path, or(
+        lt(longColumn("id"), 500L),
+        notEq(binaryColumn("missing"), null)
+    )));
+    assertEquals(500, countFilteredRecords(path, or(
+        lt(longColumn("id"), 500L),
+        lt(doubleColumn("missing"), 33.33)
+    )));
+    assertEquals(500, countFilteredRecords(path, or(
+        lt(longColumn("id"), 500L),
+        ltEq(doubleColumn("missing"), 33.33)
+    )));
+    assertEquals(500, countFilteredRecords(path, or(
+        lt(longColumn("id"), 500L),
+        gt(doubleColumn("missing"), 33.33)
+    )));
+    assertEquals(500, countFilteredRecords(path, or(
+        lt(longColumn("id"), 500L),
+        gtEq(doubleColumn("missing"), 33.33)
+    )));
+
+    assertEquals(500, countFilteredRecords(path, or(
+        eq(binaryColumn("missing"), fromString("any")),
+        lt(longColumn("id"), 500L)
+    )));
+    assertEquals(500, countFilteredRecords(path, or(
+        notEq(binaryColumn("missing"), null),
+        lt(longColumn("id"), 500L)
+    )));
+    assertEquals(500, countFilteredRecords(path, or(
+        lt(doubleColumn("missing"), 33.33),
+        lt(longColumn("id"), 500L)
+    )));
+    assertEquals(500, countFilteredRecords(path, or(
+        ltEq(doubleColumn("missing"), 33.33),
+        lt(longColumn("id"), 500L)
+    )));
+    assertEquals(500, countFilteredRecords(path, or(
+        gt(doubleColumn("missing"), 33.33),
+        lt(longColumn("id"), 500L)
+    )));
+    assertEquals(500, countFilteredRecords(path, or(
+        gtEq(doubleColumn("missing"), 33.33),
+        lt(longColumn("id"), 500L)
+    )));
+
+    // missing column filter is false
+    assertEquals(1000, countFilteredRecords(path, or(
+        lt(longColumn("id"), 500L),
+        eq(binaryColumn("missing"), null)
+    )));
+    assertEquals(1000, countFilteredRecords(path, or(
+        lt(longColumn("id"), 500L),
+        notEq(binaryColumn("missing"), fromString("any"))
+    )));
+
+    assertEquals(1000, countFilteredRecords(path, or(
+        eq(binaryColumn("missing"), null),
+        lt(longColumn("id"), 500L)
+    )));
+    assertEquals(1000, countFilteredRecords(path, or(
+        notEq(binaryColumn("missing"), fromString("any")),
+        lt(longColumn("id"), 500L)
+    )));
+  }
+
+  public static long countFilteredRecords(Path path, FilterPredicate pred) throws IOException{
+    ParquetReader<Group> reader = ParquetReader
+        .builder(new GroupReadSupport(), path)
+        .withFilter(FilterCompat.get(pred))
+        .build();
+
+    long count = 0;
+    try {
+      while (reader.read() != null) {
+        count += 1;
+      }
+    } finally {
+      reader.close();
+    }
+    return count;
+  }
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
@@ -383,6 +383,60 @@ public class DictionaryFilterTest {
     verifyZeroInteractions(dictionaryStore);
   }
 
+  @Test
+  public void testEqMissingColumn() throws Exception {
+    BinaryColumn b = binaryColumn("missing_column");
+
+    assertTrue("Should drop block for non-null query",
+        canDrop(eq(b, Binary.fromString("any")), ccmd, dictionaries));
+
+    assertFalse("Should not drop block null query",
+        canDrop(eq(b, null), ccmd, dictionaries));
+  }
+
+  @Test
+  public void testNotEqMissingColumn() throws Exception {
+    BinaryColumn b = binaryColumn("missing_column");
+
+    assertFalse("Should not drop block for non-null query",
+        canDrop(notEq(b, Binary.fromString("any")), ccmd, dictionaries));
+
+    assertTrue("Should not drop block null query",
+        canDrop(notEq(b, null), ccmd, dictionaries));
+  }
+
+  @Test
+  public void testLtMissingColumn() throws Exception {
+    BinaryColumn b = binaryColumn("missing_column");
+
+    assertTrue("Should drop block for any non-null query",
+        canDrop(lt(b, Binary.fromString("any")), ccmd, dictionaries));
+  }
+
+  @Test
+  public void testLtEqMissingColumn() throws Exception {
+    BinaryColumn b = binaryColumn("missing_column");
+
+    assertTrue("Should drop block for any non-null query",
+        canDrop(ltEq(b, Binary.fromString("any")), ccmd, dictionaries));
+  }
+
+  @Test
+  public void testGtMissingColumn() throws Exception {
+    BinaryColumn b = binaryColumn("missing_column");
+
+    assertTrue("Should drop block for any non-null query",
+        canDrop(gt(b, Binary.fromString("any")), ccmd, dictionaries));
+  }
+
+  @Test
+  public void testGtEqMissingColumn() throws Exception {
+    BinaryColumn b = binaryColumn("missing_column");
+
+    assertTrue("Should drop block for any non-null query",
+        canDrop(gtEq(b, Binary.fromString("any")), ccmd, dictionaries));
+  }
+
   private static double toDouble(int value) {
     return (value * 1.0);
   }


### PR DESCRIPTION
Predicate push-down will complain when predicates reference columns that aren't in a file's schema. This makes it difficult to implement predicate push-down in engines where schemas evolve because each task needs to process the predicates and prune references to columns not in that task's file. This PR implements predicate evaluation for missing columns, where the values are all null. This allows engines to pass predicates as they are written.

A future commit should rewrite the predicates to avoid the extra work currently done in record-level filtering, but that isn't included here because it is an optimization.