### PR TITLE
PARQUET-667: Update committers lists to point to apache website

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,16 +202,7 @@ Thank you for getting involved!
 
 ## Authors and contributors
 
-* Julien Le Dem [@J_](http://twitter.com/J_) <https://github.com/julienledem>
-* Tom White <https://github.com/tomwhite>
-* Mickaël Lacour <https://github.com/mickaellcr>
-* Remy Pecqueur <https://github.com/Lordshinjo>
-* Avi Bryant <https://github.com/avibryant>
-* Dmitriy Ryaboy [@squarecog](https://twitter.com/squarecog) <https://github.com/dvryaboy>
-* Jonathan Coveney <http://twitter.com/jco>
-* Brock Noland <https://github.com/brockn>
-* Tianshuo Deng <https://github.com/tsdeng>
-* and many others -- see the [Contributor report]( https://github.com/apache/parquet-mr/contributors)
+Please see: [Apache Parquet Committers and PMC](http://people.apache.org/committers-by-project.html#parquet)
 
 ## Code of Conduct
 

--- a/dev/COMMITTERS.md
+++ b/dev/COMMITTERS.md
@@ -17,30 +17,11 @@
   ~ under the License.
   -->
 
-# Committers (in aplhabetical order):
+# Committers (in alphabetical order):
 
-| Name               | Apache Id  | github id      | JIRA id     |
-|--------------------|------------|----------------|-------------|
-| Aniket Mokashi     | aniket486  | aniket486      |             |
-| Brock Noland       | brock      | brockn         |             |
-| Cheng Lian         | lian       | liancheng      | lian cheng  |
-| Chris Aniszczyk    | caniszczyk |                |             |
-| Dmitriy Ryaboy     | dvryaboy   | dvryaboy       |             |
-| Jake Farrell       | jfarrell   |                |             |
-| Jonathan Coveney   | jcoveney   | jcoveney       |             |
-| Julien Le Dem      | julien     | julienledem    | julienledem |
-| Lukas Nalezenec    | lukas      | lukasnalezenec |             |
-| Marcel Kornacker   | marcel     |                |             |
-| Mickael Lacour     | mlacour    | mickaellcr     |             |
-| Nong Li            | nong       | nongli         |             |
-| Remy Pecqueur      | rpecqueur  | Lordshinjo     |             |
-| Ryan Blue          | blue       | rdblue         |             |
-| Sergio Pena        | spena      | spena          | spena       |
-| Tianshuo Deng      | tianshuo   | tsdeng         |             |
-| Tom White          | tomwhite   | tomwhite       |             |
-| Wesley Graham Peck | wesleypeck | wesleypeck     |             |
+Please see: [Apache Parquet Committers and PMC](http://people.apache.org/committers-by-project.html#parquet)
 
-Reviewing guidelines:
+# Reviewing guidelines:
 Committers have the responsibility to give constructive and timely feedback on the pull requests.
 Anybody can give feedback on a pull request but only committers can merge it.
 


### PR DESCRIPTION
We have two out of date lists of committers in .md files in the repo.
This PR changes them to point to the apache website which should stay up to date automatically.