### PR TITLE
PARQUET-686: Allow for Unsigned Statistics in Binary Type

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/BinaryStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/BinaryStatistics.java
@@ -38,9 +38,29 @@ public class BinaryStatistics extends Statistics<Binary> {
   @Override
   public void updateStats(Binary value) {
     if (!this.hasNonNullValue()) {
-      initializeStats(value, value);
+      initializeStatsSigned(value, value);
+      initializeStatsUnsigned(value, value);
     } else {
-      updateStats(value, value);
+      updateStatsSigned(value, value);
+      updateStatsUnsigned(value, value);
+    }
+  }
+
+  @Override
+  public void updateStatsSigned(Binary value) {
+    if (!this.hasNonNullValue()) {
+      initializeStatsSigned(value, value);
+    } else {
+      updateStatsSigned(value, value);
+    }
+  }
+
+  @Override
+  public void updateStatsUnsigned(Binary value) {
+    if (!this.hasNonNullValue()) {
+      initializeStatsUnsigned(value, value);
+    } else {
+      updateStatsUnsigned(value, value);
     }
   }
 
@@ -48,11 +68,11 @@ public class BinaryStatistics extends Statistics<Binary> {
   public void mergeStatisticsMinMax(Statistics stats) {
     BinaryStatistics binaryStats = (BinaryStatistics)stats;
     if (!this.hasNonNullValue()) {
-      initializeStats(binaryStats.genericGetMinSigned(), binaryStats.genericGetMaxSigned());
-      initializeStats(binaryStats.genericGetMinUnsigned(), binaryStats.genericGetMaxUnsigned());
+      initializeStatsSigned(binaryStats.genericGetMinSigned(), binaryStats.genericGetMaxSigned());
+      initializeStatsUnsigned(binaryStats.genericGetMinUnsigned(), binaryStats.genericGetMaxUnsigned());
     } else {
-      updateStats(binaryStats.genericGetMinSigned(), binaryStats.genericGetMaxSigned());
-      updateStats(binaryStats.genericGetMinUnsigned(), binaryStats.genericGetMaxUnsigned());
+      updateStatsSigned(binaryStats.genericGetMinSigned(), binaryStats.genericGetMaxSigned());
+      updateStatsUnsigned(binaryStats.genericGetMinUnsigned(), binaryStats.genericGetMaxUnsigned());
     }
   }
 
@@ -136,26 +156,37 @@ public class BinaryStatistics extends Statistics<Binary> {
   }
 
   /**
-   * @deprecated use {@link #updateStats(Binary)}, will be removed in 2.0.0
+   * Tries to update the unsigned min and max to the new potential min_value and max_value.
    */
-  @Deprecated
-  public void updateStats(Binary min_value, Binary max_value) {
-    if (minSigned.compareTo(min_value) > 0) { minSigned = min_value.copy(); }
-    if (maxSigned.compareTo(max_value) < 0) { maxSigned = max_value.copy(); }
+  public void updateStatsUnsigned(Binary min_value, Binary max_value) {
     if (Binary.compareTwoBinaryUnsigned(minUnsigned, min_value) > 0) { minUnsigned = min_value.copy(); }
     if (Binary.compareTwoBinaryUnsigned(maxUnsigned, max_value) < 0) { maxUnsigned = max_value.copy(); }
   }
 
   /**
-   * @deprecated use {@link #updateStats(Binary)}, will be removed in 2.0.0
+   * Tries to update the signed min and max to the new potential min_value and max_value.
    */
-  @Deprecated
-  public void initializeStats(Binary min_value, Binary max_value) {
-      minSigned = min_value.copy();
-      maxSigned = max_value.copy();
-      minUnsigned = min_value.copy();
-      maxUnsigned = max_value.copy();
-      this.markAsNotEmpty();
+  public void updateStatsSigned(Binary min_value, Binary max_value) {
+    if (minSigned.compareTo(min_value) > 0) { minSigned = min_value.copy(); }
+    if (maxSigned.compareTo(max_value) < 0) { maxSigned = max_value.copy(); }
+  }
+
+  /**
+   * Only initialize the unsigned min/max fields.
+   */
+  public void initializeStatsUnsigned(Binary min_value, Binary max_value) {
+    minUnsigned = min_value.copy();
+    maxUnsigned = max_value.copy();
+    this.markAsNotEmpty();
+  }
+
+  /**
+   * Only initialize the signed min/max fields.
+   */
+  public void initializeStatsSigned(Binary min_value, Binary max_value) {
+    minSigned = min_value.copy();
+    maxSigned = max_value.copy();
+    this.markAsNotEmpty();
   }
 
   /**

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/BinaryStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/BinaryStatistics.java
@@ -18,12 +18,22 @@
  */
 package org.apache.parquet.column.statistics;
 
+import org.apache.parquet.filter2.predicate.ByteSignedness;
 import org.apache.parquet.io.api.Binary;
 
+/**
+ * BinaryStatistics: tracks statistics information on binary data columns.
+ * There are two sets of mins and maxes: those based on signed and unsigned byte comparisons.
+ * For example, given a set of Binary values {@code Binary.fromString("a")}, {@code Binary.fromString("é")},
+ * the signed min will be "é" as the first byte of the codepoint will be larger than 127
+ */
 public class BinaryStatistics extends Statistics<Binary> {
 
-  private Binary max;
-  private Binary min;
+  private Binary maxSigned;
+  private Binary minSigned;
+
+  private Binary minUnsigned;
+  private Binary maxUnsigned;
 
   @Override
   public void updateStats(Binary value) {
@@ -38,44 +48,87 @@ public class BinaryStatistics extends Statistics<Binary> {
   public void mergeStatisticsMinMax(Statistics stats) {
     BinaryStatistics binaryStats = (BinaryStatistics)stats;
     if (!this.hasNonNullValue()) {
-      initializeStats(binaryStats.getMin(), binaryStats.getMax());
+      initializeStats(binaryStats.genericGetMinSigned(), binaryStats.genericGetMaxSigned());
+      initializeStats(binaryStats.genericGetMinUnsigned(), binaryStats.genericGetMaxUnsigned());
     } else {
-      updateStats(binaryStats.getMin(), binaryStats.getMax());
+      updateStats(binaryStats.genericGetMinSigned(), binaryStats.genericGetMaxSigned());
+      updateStats(binaryStats.genericGetMinUnsigned(), binaryStats.genericGetMaxUnsigned());
     }
   }
 
   /**
-   * Sets min and max values, re-uses the byte[] passed in.
-   * Any changes made to byte[] will be reflected in min and max values as well.
-   * @param minBytes byte array to set the min value to
-   * @param maxBytes byte array to set the max value to
+   * Sets minSigned and maxSigned values, re-uses the byte[] passed in.
+   * Any changes made to byte[] will be reflected in minSigned and maxSigned values as well.
+   * @param minBytes byte array to set the minSigned value to
+   * @param maxBytes byte array to set the maxSigned value to
    */
   @Override
   public void setMinMaxFromBytes(byte[] minBytes, byte[] maxBytes) {
-    max = Binary.fromReusedByteArray(maxBytes);
-    min = Binary.fromReusedByteArray(minBytes);
+    maxSigned = Binary.fromReusedByteArray(maxBytes);
+    minSigned = Binary.fromReusedByteArray(minBytes);
+    maxUnsigned = maxSigned.copy();
+    minUnsigned = minSigned.copy();
     this.markAsNotEmpty();
   }
 
   @Override
-  public byte[] getMaxBytes() {
-    return max == null ? null : max.getBytes();
+  public void setMinMaxSignedFromBytes(byte[] minBytes, byte[] maxBytes) {
+    this.minSigned = Binary.fromReusedByteArray(minBytes);
+    this.maxSigned = Binary.fromReusedByteArray(maxBytes);
   }
 
   @Override
+  public void setMinMaxUnsignedFromBytes(byte[] minBytes, byte[] maxBytes) {
+    this.minUnsigned = Binary.fromReusedByteArray(minBytes);
+    this.maxUnsigned = Binary.fromReusedByteArray(maxBytes);
+  }
+
+  /**
+   * Use either getMaxBytesSigned() or getMaxBytesUnsigned() directly instead.
+   */
+  @Deprecated
+  @Override
+  public byte[] getMaxBytes() {
+    return getMaxBytesSigned();
+  }
+
+  /**
+   * Use either getMinBytesSigned() or getMinBytesUnsigned() directly instead.
+   */
+  @Deprecated
+  @Override
   public byte[] getMinBytes() {
-    return min == null ? null : min.getBytes();
+    return getMinBytesSigned();
+  }
+
+  public byte[] getMaxBytesSigned() {
+    return maxSigned == null ? null : maxSigned.getBytes();
+  }
+
+  @Override
+  public byte[] getMinBytesSigned() {
+    return minSigned == null ? null : minSigned.getBytes();
+  }
+
+  @Override
+  public byte[] getMaxBytesUnsigned() {
+    return maxUnsigned == null ? null : maxUnsigned.getBytes();
+  }
+
+  @Override
+  public byte[] getMinBytesUnsigned() {
+    return minUnsigned == null ? null : minUnsigned.getBytes();
   }
 
   @Override
   public boolean isSmallerThan(long size) {
-    return !hasNonNullValue() || ((min.length() + max.length()) < size);
+    return !hasNonNullValue() || (((minSigned.length() + maxSigned.length()) < size) && ((minUnsigned.length() + maxUnsigned.length()) < size));
   }
 
   @Override
   public String toString() {
     if (this.hasNonNullValue())
-      return String.format("min: %s, max: %s, num_nulls: %d", min.toStringUsingUTF8(), max.toStringUsingUTF8(), this.getNumNulls());
+      return String.format("min: %s, max: %s, num_nulls: %d", minSigned.toStringUsingUTF8(), maxSigned.toStringUsingUTF8(), this.getNumNulls());
    else if (!this.isEmpty())
       return String.format("num_nulls: %d, min/max not defined", this.getNumNulls());
    else
@@ -87,8 +140,10 @@ public class BinaryStatistics extends Statistics<Binary> {
    */
   @Deprecated
   public void updateStats(Binary min_value, Binary max_value) {
-    if (min.compareTo(min_value) > 0) { min = min_value.copy(); }
-    if (max.compareTo(max_value) < 0) { max = max_value.copy(); }
+    if (minSigned.compareTo(min_value) > 0) { minSigned = min_value.copy(); }
+    if (maxSigned.compareTo(max_value) < 0) { maxSigned = max_value.copy(); }
+    if (Binary.compareTwoBinaryUnsigned(minUnsigned, min_value) > 0) { minUnsigned = min_value.copy(); }
+    if (Binary.compareTwoBinaryUnsigned(maxUnsigned, max_value) < 0) { maxUnsigned = max_value.copy(); }
   }
 
   /**
@@ -96,19 +151,49 @@ public class BinaryStatistics extends Statistics<Binary> {
    */
   @Deprecated
   public void initializeStats(Binary min_value, Binary max_value) {
-      min = min_value.copy();
-      max = max_value.copy();
+      minSigned = min_value.copy();
+      maxSigned = max_value.copy();
+      minUnsigned = min_value.copy();
+      maxUnsigned = max_value.copy();
       this.markAsNotEmpty();
   }
 
+  /**
+   * For BinaryStatistics use one of genericGetMinSigned() or genericGetMinUnsigned()
+   */
+  @Deprecated
   @Override
   public Binary genericGetMin() {
-    return min;
+    return genericGetMinSigned();
+  }
+
+  /**
+   * For BinaryStatistics use one of genericGetMaxSigned() or generic getMaxUnsigned()
+   */
+  @Deprecated
+  @Override
+  public Binary genericGetMax() {
+    return genericGetMaxSigned();
   }
 
   @Override
-  public Binary genericGetMax() {
-    return max;
+  public Binary genericGetMinSigned() {
+    return minSigned;
+  }
+
+  @Override
+  public Binary genericGetMaxSigned() {
+    return maxSigned;
+  }
+
+  @Override
+  public Binary genericGetMinUnsigned() {
+    return minUnsigned;
+  }
+
+  @Override
+  public Binary genericGetMaxUnsigned() {
+    return maxUnsigned;
   }
 
   /**
@@ -116,7 +201,7 @@ public class BinaryStatistics extends Statistics<Binary> {
    */
   @Deprecated
   public Binary getMax() {
-    return max;
+    return maxSigned;
   }
 
   /**
@@ -124,7 +209,7 @@ public class BinaryStatistics extends Statistics<Binary> {
    */
   @Deprecated
   public Binary getMin() {
-    return min;
+    return minSigned;
   }
 
   /**
@@ -132,8 +217,29 @@ public class BinaryStatistics extends Statistics<Binary> {
    */
   @Deprecated
   public void setMinMax(Binary min, Binary max) {
-    this.max = max;
-    this.min = min;
+    this.maxSigned = max;
+    this.minSigned = min;
+    this.maxUnsigned = max;
+    this.minUnsigned = min;
     this.markAsNotEmpty();
   }
+
+  @Override
+  public final int compareValueToMin(Binary value, ByteSignedness signedness) {
+    if (signedness == ByteSignedness.SIGNED) {
+      return value.compareTo(genericGetMinSigned());
+    } else {
+      return Binary.compareTwoBinaryUnsigned(value, genericGetMinUnsigned());
+    }
+  }
+
+  @Override
+  public final int compareValueToMax(Binary value, ByteSignedness signedness) {
+    if (signedness == ByteSignedness.SIGNED) {
+      return value.compareTo(genericGetMaxSigned());
+    } else {
+      return Binary.compareTwoBinaryUnsigned(value, genericGetMaxUnsigned());
+    }
+  }
+
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/Statistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/Statistics.java
@@ -19,6 +19,7 @@
 package org.apache.parquet.column.statistics;
 
 import org.apache.parquet.column.UnknownColumnTypeException;
+import org.apache.parquet.filter2.predicate.ByteSignedness;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import java.util.Arrays;
@@ -175,8 +176,48 @@ public abstract class Statistics<T extends Comparable<T>> {
    */
   abstract public void setMinMaxFromBytes(byte[] minBytes, byte[] maxBytes);
 
+  public void setMinMaxSignedFromBytes(byte[] minBytes, byte[] maxBytes) {
+    setMinMaxFromBytes(minBytes, maxBytes);
+  }
+
+  public void setMinMaxUnsignedFromBytes(byte[] minBytes, byte[] maxBytes) {
+    setMinMaxFromBytes(minBytes, maxBytes);
+  }
+
   abstract public T genericGetMin();
   abstract public T genericGetMax();
+
+  public T genericGetMinSigned() {
+    return genericGetMin();
+  }
+  public T genericGetMaxSigned() {
+    return genericGetMax();
+  }
+
+  public T genericGetMinUnsigned() {
+    return genericGetMin();
+  }
+
+  public T genericGetMaxUnsigned() {
+    return genericGetMax();
+  }
+
+  public int compareValueToMin(T value, ByteSignedness signedness) {
+    if (signedness == ByteSignedness.SIGNED) {
+      return value.compareTo(genericGetMinSigned());
+    } else {
+      return value.compareTo(genericGetMinUnsigned());
+    }
+  }
+
+  public int compareValueToMax(T value, ByteSignedness signedness) {
+    if (signedness == ByteSignedness.SIGNED) {
+      return value.compareTo(genericGetMaxSigned());
+    } else {
+      return value.compareTo(genericGetMaxUnsigned());
+    }
+  }
+
 
   /**
    * Abstract method to return the max value as a byte array
@@ -189,6 +230,22 @@ public abstract class Statistics<T extends Comparable<T>> {
    * @return byte array corresponding to the min value
    */
   abstract public byte[] getMinBytes();
+
+  public byte[] getMinBytesSigned() {
+    return getMinBytes();
+  }
+
+  public byte[] getMaxBytesSigned() {
+    return getMaxBytes();
+  }
+
+  public byte[] getMinBytesUnsigned() {
+    return getMinBytes();
+  }
+
+  public byte[] getMaxBytesUnsigned() {
+    return getMaxBytes();
+  }
 
   /**
    * Abstract method to return whether the min and max values fit in the given

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/Statistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/Statistics.java
@@ -117,6 +117,24 @@ public abstract class Statistics<T extends Comparable<T>> {
   }
 
   /**
+   * updates statistics signed_min and signed_max using the
+   * passed value
+   * @param value value to use to update signed_min and signed_max
+   */
+  public void updateStatsSigned(Binary value) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * updates statistics unsigned_min and unsigned_max using the
+   * passed value
+   * @param value value to use to update unsigned_min and unsigned_max
+   */
+  public void updateStatsUnsigned(Binary value) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Equality comparison method to compare two statistics objects.
    * @param other Object to compare against
    * @return true if objects are equal, false otherwise

--- a/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/ByteSignedness.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/ByteSignedness.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.filter2.predicate;
+
+/**
+ * The way bytes should be interpreted, either as signed 8-bit values or as unsigned 8-bit values.
+ */
+public enum ByteSignedness {
+    SIGNED,
+    UNSIGNED
+}

--- a/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/FilterApi.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/FilterApi.java
@@ -103,6 +103,13 @@ public final class FilterApi {
   }
 
   /**
+   * Same as {@link FilterApi#eq(Column, Comparable)}, but allows specifying signedness.
+   */
+  public static <T extends Comparable<T>, C extends Column<T> & SupportsEqNotEq> Eq<T> eq(C column, T value, ByteSignedness signedness) {
+    return new Eq<T>(column, value, signedness);
+  }
+
+  /**
    * Keeps records if their value is not equal to the provided value.
    * Nulls are treated the same way the java programming language does.
    * For example:
@@ -121,6 +128,13 @@ public final class FilterApi {
   }
 
   /**
+   * Same as {@link FilterApi#notEq(Column, Comparable)}, but allows specifying signedness.
+   */
+  public static <T extends Comparable<T>, C extends Column<T> & SupportsEqNotEq> NotEq<T> notEq(C column, T value, ByteSignedness signedness) {
+    return new NotEq<T>(column, value, signedness);
+  }
+
+  /**
    * Keeps records if their value is less than (but not equal to) the provided value.
    * The provided value cannot be null, as less than null has no meaning.
    * Records with null values will be dropped.
@@ -132,6 +146,14 @@ public final class FilterApi {
   }
 
   /**
+   * Same as {@link FilterApi#lt(Column, Comparable)}, but allows specifying signedness.
+   */
+  public static <T extends Comparable<T>, C extends Column<T> & SupportsLtGt> Lt<T> lt(C column, T value, ByteSignedness signedness) {
+    return new Lt<T>(column, value, signedness);
+  }
+
+
+  /**
    * Keeps records if their value is less than or equal to the provided value.
    * The provided value cannot be null, as less than null has no meaning.
    * Records with null values will be dropped.
@@ -140,6 +162,13 @@ public final class FilterApi {
    */
   public static <T extends Comparable<T>, C extends Column<T> & SupportsLtGt> LtEq<T> ltEq(C column, T value) {
     return new LtEq<T>(column, value);
+  }
+
+  /**
+   * Same as {@link FilterApi#ltEq(Column, Comparable)}, but allows specifying signedness.
+   */
+  public static <T extends Comparable<T>, C extends Column<T> & SupportsLtGt> LtEq<T> ltEq(C column, T value, ByteSignedness signedness) {
+    return new LtEq<T>(column, value, signedness);
   }
 
   /**
@@ -154,6 +183,13 @@ public final class FilterApi {
   }
 
   /**
+   * Same as {@link FilterApi#gt(Column, Comparable)}, but allows specifying signedness.
+   */
+  public static <T extends Comparable<T>, C extends Column<T> & SupportsLtGt> Gt<T> gt(C column, T value, ByteSignedness signedness) {
+    return new Gt<T>(column, value, signedness);
+  }
+
+  /**
    * Keeps records if their value is greater than or equal to the provided value.
    * The provided value cannot be null, as less than null has no meaning.
    * Records with null values will be dropped.
@@ -162,6 +198,13 @@ public final class FilterApi {
    */
   public static <T extends Comparable<T>, C extends Column<T> & SupportsLtGt> GtEq<T> gtEq(C column, T value) {
     return new GtEq<T>(column, value);
+  }
+
+  /**
+   * Same as {@link FilterApi#gtEq(Column, Comparable)}, but allows specifying signedness.
+   */
+  public static <T extends Comparable<T>, C extends Column<T> & SupportsLtGt> GtEq<T> gtEq(C column, T value, ByteSignedness signedness) {
+    return new GtEq<T>(column, value, signedness);
   }
 
   /**

--- a/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/Operators.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/Operators.java
@@ -122,8 +122,14 @@ public final class Operators {
     private final Column<T> column;
     private final T value;
     private final String toString;
+    private final ByteSignedness signedness;
 
     protected ColumnFilterPredicate(Column<T> column, T value) {
+      // Default is to assume signed comparisons when not specified.
+      this(column, value, ByteSignedness.SIGNED);
+    }
+
+    protected ColumnFilterPredicate(Column<T> column, T value, ByteSignedness signedness) {
       this.column = checkNotNull(column, "column");
 
       // Eq and NotEq allow value to be null, Lt, Gt, LtEq, GtEq however do not, so they guard against
@@ -132,6 +138,8 @@ public final class Operators {
 
       String name = getClass().getSimpleName().toLowerCase(Locale.ENGLISH);
       this.toString = name + "(" + column.getColumnPath().toDotString() + ", " + value + ")";
+
+      this.signedness = signedness;
     }
 
     public Column<T> getColumn() {
@@ -140,6 +148,10 @@ public final class Operators {
 
     public T getValue() {
       return value;
+    }
+
+    public ByteSignedness getSignedness() {
+      return signedness;
     }
 
     @Override
@@ -176,6 +188,11 @@ public final class Operators {
       super(column, value);
     }
 
+    // value can be null
+    Eq(Column<T> column, T value, ByteSignedness signedness) {
+      super(column, value, signedness);
+    }
+
     @Override
     public <R> R accept(Visitor<R> visitor) {
       return visitor.visit(this);
@@ -190,6 +207,12 @@ public final class Operators {
       super(column, value);
     }
 
+    // value can be null
+    NotEq(Column<T> column, T value, ByteSignedness signedness) {
+      super(column, value, signedness);
+    }
+
+
     @Override
     public <R> R accept(Visitor<R> visitor) {
       return visitor.visit(this);
@@ -201,7 +224,12 @@ public final class Operators {
 
     // value cannot be null
     Lt(Column<T> column, T value) {
-      super(column, checkNotNull(value, "value"));
+      super(column, value);
+    }
+
+    // value cannot be null
+    Lt(Column<T> column, T value, ByteSignedness signedness) {
+      super(column, checkNotNull(value, "value"), signedness);
     }
 
     @Override
@@ -215,6 +243,11 @@ public final class Operators {
     // value cannot be null
     LtEq(Column<T> column, T value) {
       super(column, checkNotNull(value, "value"));
+    }
+
+    // value cannot be null
+    LtEq(Column<T> column, T value, ByteSignedness signedness) {
+      super(column, checkNotNull(value, "value"), signedness);
     }
 
     @Override
@@ -231,6 +264,12 @@ public final class Operators {
       super(column, checkNotNull(value, "value"));
     }
 
+    // value cannot be null
+    Gt(Column<T> column, T value, ByteSignedness signedness) {
+      super(column, checkNotNull(value, "value"), signedness);
+    }
+
+
     @Override
     public <R> R accept(Visitor<R> visitor) {
       return visitor.visit(this);
@@ -242,6 +281,11 @@ public final class Operators {
     // value cannot be null
     GtEq(Column<T> column, T value) {
       super(column, checkNotNull(value, "value"));
+    }
+
+    // value cannot be null
+    GtEq(Column<T> column, T value, ByteSignedness signedness) {
+      super(column, checkNotNull(value, "value"), signedness);
     }
 
     @Override

--- a/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/Operators.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/Operators.java
@@ -224,7 +224,7 @@ public final class Operators {
 
     // value cannot be null
     Lt(Column<T> column, T value) {
-      super(column, value);
+      super(column, checkNotNull(value, "value"));
     }
 
     // value cannot be null

--- a/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
@@ -194,12 +194,12 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
 
     @Override
     int compareTo(byte[] other, int otherOffset, int otherLength) {
-      return Binary.compareTwoByteArrays(value, offset, length, other, otherOffset, otherLength);
+      return Binary.compareTwoByteArraysSigned(value, offset, length, other, otherOffset, otherLength);
     }
 
     @Override
     int compareTo(ByteBuffer bytes, int otherOffset, int otherLength) {
-      return Binary.compareByteArrayToByteBuffer(value, offset, length, bytes, otherOffset, otherLength);
+      return Binary.compareByteArrayToByteBufferSigned(value, offset, length, bytes, otherOffset, otherLength);
     }
 
     @Override
@@ -350,12 +350,12 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
 
     @Override
     int compareTo(byte[] other, int otherOffset, int otherLength) {
-      return Binary.compareTwoByteArrays(value, 0, value.length, other, otherOffset, otherLength);
+      return Binary.compareTwoByteArraysSigned(value, 0, value.length, other, otherOffset, otherLength);
     }
 
     @Override
     int compareTo(ByteBuffer bytes, int otherOffset, int otherLength) {
-      return Binary.compareByteArrayToByteBuffer(value, 0, value.length, bytes, otherOffset, otherLength);
+      return Binary.compareByteArrayToByteBufferSigned(value, 0, value.length, bytes, otherOffset, otherLength);
     }
 
     @Override
@@ -515,16 +515,16 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     @Override
     int compareTo(byte[] other, int otherOffset, int otherLength) {
       if (value.hasArray()) {
-        return Binary.compareTwoByteArrays(value.array(), value.arrayOffset() + offset, length,
+        return Binary.compareTwoByteArraysSigned(value.array(), value.arrayOffset() + offset, length,
             other, otherOffset, otherLength);
       } {
-        return Binary.compareByteBufferToByteArray(value, offset, length, other, otherOffset, otherLength);
+        return Binary.compareByteBufferToByteArraySigned(value, offset, length, other, otherOffset, otherLength);
       }
     }
 
     @Override
     int compareTo(ByteBuffer bytes, int otherOffset, int otherLength) {
-      return Binary.compareTwoByteBuffers(value, offset, length, bytes, otherOffset, otherLength);
+      return Binary.compareTwoByteBuffersSigned(value, offset, length, bytes, otherOffset, otherLength);
     }
 
     @Override
@@ -666,13 +666,13 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     return true;
   }
 
-  private static final int compareByteBufferToByteArray(ByteBuffer buf, int offset1, int length1,
-                                                        byte[] array, int offset2, int length2) {
-    return -1 * Binary.compareByteArrayToByteBuffer(array, offset1, length1, buf, offset2, length2);
+  private static final int compareByteBufferToByteArraySigned(ByteBuffer buf, int offset1, int length1,
+                                                              byte[] array, int offset2, int length2) {
+    return -1 * Binary.compareByteArrayToByteBufferSigned(array, offset1, length1, buf, offset2, length2);
   }
 
-  private static final int compareByteArrayToByteBuffer(byte[] array1, int offset1, int length1,
-                                                        ByteBuffer buf, int offset2, int length2) {
+  private static final int compareByteArrayToByteBufferSigned(byte[] array1, int offset1, int length1,
+                                                              ByteBuffer buf, int offset2, int length2) {
     if (array1 == null && buf == null) return 0;
     int min_length = (length1 < length2) ? length1 : length2;
     for (int i = 0; i < min_length; i++) {
@@ -683,15 +683,11 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
       }
     }
     // check remainder
-    if (length1 == length2) {
-      return 0;
-    } else {
-      return length2 - length1;
-    }
+    return length2 - length1;
   }
 
-  private static final int compareTwoByteBuffers(ByteBuffer buf1, int offset1, int length1,
-                                                        ByteBuffer buf2, int offset2, int length2) {
+  private static final int compareTwoByteBuffersSigned(ByteBuffer buf1, int offset1, int length1,
+                                                       ByteBuffer buf2, int offset2, int length2) {
     if (buf1 == null && buf2 == null) return 0;
     int min_length = (length1 < length2) ? length1 : length2;
     for (int i = 0; i < min_length; i++) {
@@ -702,15 +698,11 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
       }
     }
     // check remainder
-    if (length1 == length2) {
-      return 0;
-    } else {
-      return length2 - length1;
-    }
+    return length2 - length1;
   }
 
-  private static final int compareTwoByteArrays(byte[] array1, int offset1, int length1,
-                                                byte[] array2, int offset2, int length2) {
+  private static final int compareTwoByteArraysSigned(byte[] array1, int offset1, int length1,
+                                                      byte[] array2, int offset2, int length2) {
     if (array1 == null && array2 == null) return 0;
     if (array1 == array2 && offset1 == offset2 && length1 == length2) return 0;
     int min_length = (length1 < length2) ? length1 : length2;
@@ -722,11 +714,7 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
       }
     }
     // check remainder
-    if (length1 == length2) {
-      return 0;
-    } else {
-      return length2 - length1;
-    }
+    return length2 - length1;
   }
 
   public static final int compareTwoBinaryUnsigned(Binary first, Binary second) {
@@ -745,10 +733,6 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
       }
     }
     // check remainder
-    if (length1 == length2) {
-      return 0;
-    } else {
-      return length1 - length2;
-    }
+    return length1 - length2;
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
@@ -676,17 +676,18 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     if (array1 == null && buf == null) return 0;
     int min_length = (length1 < length2) ? length1 : length2;
     for (int i = 0; i < min_length; i++) {
-      if (array1[i + offset1] < buf.get(i + offset2)) {
-        return 1;
-      }
-      if (array1[i + offset1] > buf.get(i + offset2)) {
-        return -1;
+      int value1 = array1[i + offset1];
+      int value2 = buf.get(i + offset2);
+      if (value1 != value2) {
+        return value2 - value1;
       }
     }
     // check remainder
-    if (length1 == length2) { return 0; }
-    else if (length1 < length2) { return 1;}
-    else { return -1; }
+    if (length1 == length2) {
+      return 0;
+    } else {
+      return length2 - length1;
+    }
   }
 
   private static final int compareTwoByteBuffers(ByteBuffer buf1, int offset1, int length1,
@@ -694,17 +695,18 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     if (buf1 == null && buf2 == null) return 0;
     int min_length = (length1 < length2) ? length1 : length2;
     for (int i = 0; i < min_length; i++) {
-      if (buf1.get(i + offset1) < buf2.get(i + offset2)) {
-        return 1;
-      }
-      if (buf1.get(i + offset1) > buf2.get(i + offset2)) {
-        return -1;
+      int value1 = buf1.get(i + offset1);
+      int value2 = buf2.get(i + offset2);
+      if (value1 != value2) {
+        return value2 - value1;
       }
     }
     // check remainder
-    if (length1 == length2) { return 0; }
-    else if (length1 < length2) { return 1;}
-    else { return -1; }
+    if (length1 == length2) {
+      return 0;
+    } else {
+      return length2 - length1;
+    }
   }
 
   private static final int compareTwoByteArrays(byte[] array1, int offset1, int length1,
@@ -713,16 +715,40 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     if (array1 == array2 && offset1 == offset2 && length1 == length2) return 0;
     int min_length = (length1 < length2) ? length1 : length2;
     for (int i = 0; i < min_length; i++) {
-      if (array1[i + offset1] < array2[i + offset2]) {
-        return 1;
-      }
-      if (array1[i + offset1] > array2[i + offset2]) {
-        return -1;
+      int value1 = array1[i + offset1];
+      int value2 = array2[i + offset2];
+      if (value1 != value2) {
+        return value2 - value1;
       }
     }
     // check remainder
-    if (length1 == length2) { return 0; }
-    else if (length1 < length2) { return 1;}
-    else { return -1; }
+    if (length1 == length2) {
+      return 0;
+    } else {
+      return length2 - length1;
+    }
+  }
+
+  public static final int compareTwoBinaryUnsigned(Binary first, Binary second) {
+    byte[] array1 = first.getBytes();
+    byte[] array2 = second.getBytes();
+    if ((array1 == null) && (array2 == null)) return 0;
+    if (array1 == array2) return 0;
+    int length1 = array1.length;
+    int length2 = array2.length;
+    int min_length = (length1 < length2) ? length1 : length2;
+    for (int i = 0; i < min_length; i++) {
+      int value1 = array1[i] & 0xFF;
+      int value2 = array2[i] & 0xFF;
+      if (value1 != value2) {
+        return value1 - value2;
+      }
+    }
+    // check remainder
+    if (length1 == length2) {
+      return 0;
+    } else {
+      return length1 - length2;
+    }
   }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/statistics/TestStatistics.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/statistics/TestStatistics.java
@@ -384,6 +384,19 @@ public class TestStatistics {
   }
 
   @Test
+  public void testBinaryMinMaxUnsigned() {
+    stringArray = new String[] {"é", "a", "b", "c"};
+    BinaryStatistics stats = new BinaryStatistics();
+
+    for (String s: stringArray) {
+      stats.updateStats(Binary.fromString(s));
+    }
+
+    assertEquals(stats.genericGetMaxUnsigned(), Binary.fromString("é"));
+    assertEquals(stats.genericGetMinUnsigned(), Binary.fromString("a"));
+  }
+
+  @Test
   public void testBinaryMinMaxForReusedBackingByteArray() {
     BinaryStatistics stats = new BinaryStatistics();
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/compat/RowGroupFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/compat/RowGroupFilter.java
@@ -18,7 +18,9 @@
  */
 package org.apache.parquet.filter2.compat;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.parquet.filter2.compat.FilterCompat.Filter;
 import org.apache.parquet.filter2.compat.FilterCompat.NoOpFilter;
@@ -29,7 +31,6 @@ import org.apache.parquet.filter2.predicate.SchemaCompatibilityValidator;
 import org.apache.parquet.filter2.statisticslevel.StatisticsFilter;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
-import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.schema.MessageType;
 
 import static org.apache.parquet.Preconditions.checkNotNull;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/compat/RowGroupFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/compat/RowGroupFilter.java
@@ -18,9 +18,7 @@
  */
 package org.apache.parquet.filter2.compat;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import org.apache.parquet.filter2.compat.FilterCompat.Filter;
 import org.apache.parquet.filter2.compat.FilterCompat.NoOpFilter;
@@ -31,6 +29,7 @@ import org.apache.parquet.filter2.predicate.SchemaCompatibilityValidator;
 import org.apache.parquet.filter2.statisticslevel.StatisticsFilter;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.schema.MessageType;
 
 import static org.apache.parquet.Preconditions.checkNotNull;
@@ -71,9 +70,9 @@ public class RowGroupFilter implements Visitor<List<BlockMetaData>> {
 
   private RowGroupFilter(List<FilterLevel> levels, List<BlockMetaData> blocks, ParquetFileReader reader) {
     this.blocks = checkNotNull(blocks, "blocks");
-    this.reader = checkNotNull(reader, "reader");
     this.schema = reader.getFileMetaData().getSchema();
     this.levels = levels;
+    this.reader = checkNotNull(reader, "reader");
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/statisticslevel/StatisticsFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/statisticslevel/StatisticsFilter.java
@@ -18,7 +18,9 @@
  */
 package org.apache.parquet.filter2.statisticslevel;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.filter2.predicate.ByteSignedness;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/statisticslevel/StatisticsFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/statisticslevel/StatisticsFilter.java
@@ -68,8 +68,8 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
   private static final boolean BLOCK_CANNOT_MATCH = true;
 
   public static boolean canDrop(FilterPredicate pred, List<ColumnChunkMetaData> columns) {
-    checkNotNull(pred, "predicate cannot be null");
-    checkNotNull(columns, "columns cannot be null");
+    checkNotNull(pred, "pred");
+    checkNotNull(columns, "columns");
     return pred.accept(new StatisticsFilter(columns));
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/statisticslevel/TestStatisticsFilter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/statisticslevel/TestStatisticsFilter.java
@@ -18,10 +18,11 @@
  */
 package org.apache.parquet.filter2.statisticslevel;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 
 import org.apache.parquet.column.statistics.BinaryStatistics;
-import org.apache.parquet.filter2.predicate.*;
 import org.apache.parquet.io.api.Binary;
 import org.junit.Test;
 
@@ -29,15 +30,24 @@ import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.statistics.DoubleStatistics;
 import org.apache.parquet.column.statistics.IntStatistics;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.filter2.predicate.ByteSignedness;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.filter2.predicate.LogicalInverseRewriter;
 import org.apache.parquet.filter2.predicate.Operators.BinaryColumn;
 import org.apache.parquet.filter2.predicate.Operators.DoubleColumn;
 import org.apache.parquet.filter2.predicate.Operators.IntColumn;
+import org.apache.parquet.filter2.predicate.Statistics;
+import org.apache.parquet.filter2.predicate.UserDefinedPredicate;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 
 import static org.apache.parquet.filter2.predicate.FilterApi.binaryColumn;
 import static org.apache.parquet.io.api.Binary.fromString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.apache.parquet.filter2.predicate.FilterApi.and;
 import static org.apache.parquet.filter2.predicate.FilterApi.doubleColumn;
 import static org.apache.parquet.filter2.predicate.FilterApi.eq;
@@ -51,7 +61,6 @@ import static org.apache.parquet.filter2.predicate.FilterApi.notEq;
 import static org.apache.parquet.filter2.predicate.FilterApi.or;
 import static org.apache.parquet.filter2.predicate.FilterApi.userDefined;
 import static org.apache.parquet.filter2.statisticslevel.StatisticsFilter.canDrop;
-import static org.junit.Assert.*;
 
 public class TestStatisticsFilter {
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <hadoop1.version>1.1.0</hadoop1.version>
     <cascading.version>2.5.3</cascading.version>
     <cascading3.version>3.0.3</cascading3.version>
-    <parquet.format.version>2.3.1</parquet.format.version>
+    <parquet.format.version>2.3.2-SNAPSHOT</parquet.format.version>
     <previous.version>1.7.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <scala.version>2.10.4</scala.version>


### PR DESCRIPTION
Currently, ordering of Binary in Parquet is based on byte-by-byte comparison. This doesn't match the standard method of lexicographic sorting of Unicode strings, you can see an example of this in 
- Avro: https://github.com/apache/avro/blob/master/lang/java/avro/src/main/java/org/apache/avro/io/BinaryData.java#L184
- Spark: https://github.com/apache/spark/blob/master/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java#L835

This overrides comparison on `FromStringBinary` to implement correct sort order.

@julienledem
