### PR TITLE
PARQUET-623: Fix DeltaByteArrayReader#skip.

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayReader.java
@@ -55,8 +55,8 @@ public class DeltaByteArrayReader extends ValuesReader implements RequiresPrevio
   
   @Override
   public void skip() {
-    prefixLengthReader.skip();
-    suffixReader.skip();
+    // read the next value to skip so that previous is correct.
+    readBytes();
   }
 
   @Override


### PR DESCRIPTION
Previously, this passed the skip to the underlying readers, but would
not update previous and would corrupt values or cause exceptions.