### PR TITLE
PARQUET-686: Do not return min/max for the wrong order.

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -52,6 +52,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -444,9 +445,19 @@ public class ParquetFileReader implements Closeable {
    */
   public static final ParquetMetadata readFooter(
       InputFile file, MetadataFilter filter) throws IOException {
+    ParquetMetadataConverter converter;
+    // TODO: remove this temporary work-around.
+    // this is necessary to pass the Configuration to ParquetMetadataConverter
+    // and should be removed when there is a non-Hadoop configuration.
+    if (file instanceof HadoopInputFile) {
+      converter = new ParquetMetadataConverter(
+          ((HadoopInputFile) file).getConfiguration());
+    } else {
+      converter = new ParquetMetadataConverter();
+    }
     try (SeekableInputStream in = file.newStream()) {
-      return readFooter(new ParquetMetadataConverter(), file.getLength(),
-          file.toString(), in, filter);
+
+      return readFooter(converter, file.getLength(), file.toString(), in, filter);
     }
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -24,7 +24,6 @@ import static org.apache.parquet.filter2.compat.RowGroupFilter.FilterLevel.DICTI
 import static org.apache.parquet.filter2.compat.RowGroupFilter.FilterLevel.STATISTICS;
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.SKIP_ROW_GROUPS;
-import static org.apache.parquet.format.converter.ParquetMetadataConverter.fromParquetStatistics;
 import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
 import static org.apache.parquet.hadoop.ParquetFileWriter.PARQUET_COMMON_METADATA_FILE;
 import static org.apache.parquet.hadoop.ParquetFileWriter.PARQUET_METADATA_FILE;
@@ -95,6 +94,7 @@ import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.hadoop.util.counters.BenchmarkCounter;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.InputFile;
+import org.apache.parquet.schema.PrimitiveType;
 
 /**
  * Internal implementation of the Parquet file reader as a block container
@@ -108,7 +108,7 @@ public class ParquetFileReader implements Closeable {
 
   public static String PARQUET_READ_PARALLELISM = "parquet.metadata.read.parallelism";
 
-  private static ParquetMetadataConverter converter = new ParquetMetadataConverter();
+  private final ParquetMetadataConverter converter;
 
   /**
    * for files provided, check if there's a summary file.
@@ -445,8 +445,8 @@ public class ParquetFileReader implements Closeable {
   public static final ParquetMetadata readFooter(
       InputFile file, MetadataFilter filter) throws IOException {
     try (SeekableInputStream in = file.newStream()) {
-      return readFooter(converter, file.getLength(), file.toString(),
-          in, filter);
+      return readFooter(new ParquetMetadataConverter(), file.getLength(),
+          file.toString(), in, filter);
     }
   }
 
@@ -538,6 +538,7 @@ public class ParquetFileReader implements Closeable {
   public ParquetFileReader(
       Configuration configuration, FileMetaData fileMetaData,
       Path filePath, List<BlockMetaData> blocks, List<ColumnDescriptor> columns) throws IOException {
+    this.converter = new ParquetMetadataConverter(configuration);
     this.conf = configuration;
     this.fileMetaData = fileMetaData;
     FileSystem fs = filePath.getFileSystem(configuration);
@@ -569,6 +570,7 @@ public class ParquetFileReader implements Closeable {
    * @throws IOException if the file can not be opened
    */
   public ParquetFileReader(Configuration conf, Path file, MetadataFilter filter) throws IOException {
+    this.converter = new ParquetMetadataConverter(conf);
     this.conf = conf;
     FileSystem fs = file.getFileSystem(conf);
     this.fileStatus = fs.getFileStatus(file);
@@ -592,6 +594,7 @@ public class ParquetFileReader implements Closeable {
    * @throws IOException if the file can not be opened
    */
   public ParquetFileReader(Configuration conf, Path file, ParquetMetadata footer) throws IOException {
+    this.converter = new ParquetMetadataConverter(conf);
     this.conf = conf;
     FileSystem fs = file.getFileSystem(conf);
     this.fileStatus = fs.getFileStatus(file);
@@ -781,7 +784,7 @@ public class ParquetFileReader implements Closeable {
         compressedPage.getEncoding());
   }
 
-  private static DictionaryPage readCompressedDictionary(
+  private DictionaryPage readCompressedDictionary(
       PageHeader pageHeader, SeekableInputStream fin) throws IOException {
     DictionaryPageHeader dictHeader = pageHeader.getDictionary_page_header();
 
@@ -843,6 +846,8 @@ public class ParquetFileReader implements Closeable {
     public ColumnChunkPageReader readAllPages() throws IOException {
       List<DataPage> pagesInChunk = new ArrayList<DataPage>();
       DictionaryPage dictionaryPage = null;
+      PrimitiveType type = getFileMetaData().getSchema()
+          .getType(descriptor.col.getPath()).asPrimitiveType();
       long valuesCountReadSoFar = 0;
       while (valuesCountReadSoFar < descriptor.metadata.getValueCount()) {
         PageHeader pageHeader = readPageHeader();
@@ -870,10 +875,10 @@ public class ParquetFileReader implements Closeable {
                     this.readAsBytesInput(compressedPageSize),
                     dataHeaderV1.getNum_values(),
                     uncompressedPageSize,
-                    fromParquetStatistics(
+                    converter.fromParquetStatistics(
                         getFileMetaData().getCreatedBy(),
                         dataHeaderV1.getStatistics(),
-                        descriptor.col.getType()),
+                        type),
                     converter.getEncoding(dataHeaderV1.getRepetition_level_encoding()),
                     converter.getEncoding(dataHeaderV1.getDefinition_level_encoding()),
                     converter.getEncoding(dataHeaderV1.getEncoding())
@@ -893,10 +898,10 @@ public class ParquetFileReader implements Closeable {
                     converter.getEncoding(dataHeaderV2.getEncoding()),
                     this.readAsBytesInput(dataSize),
                     uncompressedPageSize,
-                    fromParquetStatistics(
+                    converter.fromParquetStatistics(
                         getFileMetaData().getCreatedBy(),
                         dataHeaderV2.getStatistics(),
-                        descriptor.col.getType()),
+                        type),
                     dataHeaderV2.isIs_compressed()
                     ));
             valuesCountReadSoFar += dataHeaderV2.getNum_values();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
@@ -31,22 +31,28 @@ public class HadoopInputFile implements InputFile {
 
   private final FileSystem fs;
   private final FileStatus stat;
+  private final Configuration conf;
 
   public static HadoopInputFile fromPath(Path path, Configuration conf)
       throws IOException {
     FileSystem fs = path.getFileSystem(conf);
-    return new HadoopInputFile(fs, fs.getFileStatus(path));
+    return new HadoopInputFile(fs, fs.getFileStatus(path), conf);
   }
 
   public static HadoopInputFile fromStatus(FileStatus stat, Configuration conf)
       throws IOException {
     FileSystem fs = stat.getPath().getFileSystem(conf);
-    return new HadoopInputFile(fs, stat);
+    return new HadoopInputFile(fs, stat, conf);
   }
 
-  private HadoopInputFile(FileSystem fs, FileStatus stat) {
+  private HadoopInputFile(FileSystem fs, FileStatus stat, Configuration conf) {
     this.fs = fs;
     this.stat = stat;
+    this.conf = conf;
+  }
+
+  public Configuration getConfiguration() {
+    return conf;
   }
 
   @Override

--- a/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import com.google.common.collect.Sets;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.Version;
 import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.column.statistics.BinaryStatistics;
@@ -401,8 +402,9 @@ public class TestParquetMetadataConverter {
     Assert.assertFalse("Num nulls should not be set",
         formatStats.isSetNull_count());
 
-    Statistics roundTripStats = ParquetMetadataConverter.fromParquetStatistics(
-        Version.FULL_VERSION, formatStats, PrimitiveTypeName.BINARY);
+    Statistics roundTripStats = ParquetMetadataConverter.fromParquetStatisticsInternal(
+        Version.FULL_VERSION, formatStats, PrimitiveTypeName.BINARY,
+        ParquetMetadataConverter.SortOrder.SIGNED);
 
     Assert.assertTrue(roundTripStats.isEmpty());
   }
@@ -514,5 +516,51 @@ public class TestParquetMetadataConverter {
         max, BytesUtils.bytesToBool(formatStats.getMax()));
     Assert.assertEquals("Num nulls should match",
         3004, formatStats.getNull_count());
+  }
+
+  @Test
+  public void testIgnoreStatsWithSignedSortOrder() {
+    ParquetMetadataConverter converter = new ParquetMetadataConverter();
+    BinaryStatistics stats = new BinaryStatistics();
+    stats.incrementNumNulls();
+    stats.updateStats(Binary.fromString("A"));
+    stats.incrementNumNulls();
+    stats.updateStats(Binary.fromString("z"));
+    stats.incrementNumNulls();
+
+    Statistics convertedStats = converter.fromParquetStatistics(
+        Version.FULL_VERSION,
+        ParquetMetadataConverter.toParquetStatistics(stats),
+        Types.required(PrimitiveTypeName.BINARY)
+            .as(OriginalType.UTF8).named("b"));
+
+    Assert.assertTrue("Stats should be empty", convertedStats.isEmpty());
+  }
+
+  @Test
+  public void testUseStatsWithSignedSortOrder() {
+    // override defaults and use stats that were accumulated using signed order
+    Configuration conf = new Configuration();
+    conf.set("parquet.strings.use-signed-order", "true");
+
+    ParquetMetadataConverter converter = new ParquetMetadataConverter(conf);
+    BinaryStatistics stats = new BinaryStatistics();
+    stats.incrementNumNulls();
+    stats.updateStats(Binary.fromString("A"));
+    stats.incrementNumNulls();
+    stats.updateStats(Binary.fromString("z"));
+    stats.incrementNumNulls();
+
+    Statistics convertedStats = converter.fromParquetStatistics(
+        Version.FULL_VERSION,
+        ParquetMetadataConverter.toParquetStatistics(stats),
+        Types.required(PrimitiveTypeName.BINARY).named("b"));
+
+    Assert.assertFalse("Stats should not be empty", convertedStats.isEmpty());
+    Assert.assertEquals("Should have 3 nulls", 3, convertedStats.getNumNulls());
+    Assert.assertEquals("Should have correct min (unsigned sort)",
+        Binary.fromString("A"), convertedStats.genericGetMin());
+    Assert.assertEquals("Should have correct max (unsigned sort)",
+        Binary.fromString("z"), convertedStats.genericGetMax());
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
@@ -541,7 +541,7 @@ public class TestParquetMetadataConverter {
   public void testUseStatsWithSignedSortOrder() {
     // override defaults and use stats that were accumulated using signed order
     Configuration conf = new Configuration();
-    conf.set("parquet.strings.use-signed-order", "true");
+    conf.setBoolean("parquet.strings.signed-min-max.enabled", true);
 
     ParquetMetadataConverter converter = new ParquetMetadataConverter(conf);
     BinaryStatistics stats = new BinaryStatistics();
@@ -554,7 +554,8 @@ public class TestParquetMetadataConverter {
     Statistics convertedStats = converter.fromParquetStatistics(
         Version.FULL_VERSION,
         ParquetMetadataConverter.toParquetStatistics(stats),
-        Types.required(PrimitiveTypeName.BINARY).named("b"));
+        Types.required(PrimitiveTypeName.BINARY)
+            .as(OriginalType.UTF8).named("b"));
 
     Assert.assertFalse("Stats should not be empty", convertedStats.isEmpty());
     Assert.assertEquals("Should have 3 nulls", 3, convertedStats.getNumNulls());

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -24,9 +24,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.parquet.CorruptStatistics;
 import org.apache.parquet.Version;
-import org.apache.parquet.VersionParser;
 import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.hadoop.ParquetOutputFormat.JobSummaryLevel;
 import org.junit.Assume;
@@ -452,9 +450,9 @@ public class TestParquetFileWriter {
 
     Path path = new Path(testFile.toURI());
     Configuration configuration = new Configuration();
-    configuration.set("parquet.strings.use-signed-order", "true");
+    configuration.setBoolean("parquet.strings.signed-min-max.enabled", true);
 
-    MessageType schema = MessageTypeParser.parseMessageType("message m { required group a {required binary b;} required group c { required int64 d; }}");
+    MessageType schema = MessageTypeParser.parseMessageType("message m { required group a {required binary b (UTF8);} required group c { required int64 d; }}");
     String[] path1 = {"a", "b"};
     ColumnDescriptor c1 = schema.getColumnDescription(path1);
     String[] path2 = {"c", "d"};
@@ -585,14 +583,14 @@ public class TestParquetFileWriter {
     testFile.delete();
 
     writeSchema = "message example {\n" +
-            "required binary content;\n" +
+            "required binary content (UTF8);\n" +
             "}";
 
     Path path = new Path(testFile.toURI());
 
     MessageType schema = MessageTypeParser.parseMessageType(writeSchema);
     Configuration configuration = new Configuration();
-    configuration.set("parquet.strings.use-signed-order", "true");
+    configuration.setBoolean("parquet.strings.signed-min-max.enabled", true);
     GroupWriteSupport.setSchema(schema, configuration);
 
     ParquetWriter<Group> writer = new ParquetWriter<Group>(path, configuration, new GroupWriteSupport());

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -452,6 +452,7 @@ public class TestParquetFileWriter {
 
     Path path = new Path(testFile.toURI());
     Configuration configuration = new Configuration();
+    configuration.set("parquet.strings.use-signed-order", "true");
 
     MessageType schema = MessageTypeParser.parseMessageType("message m { required group a {required binary b;} required group c { required int64 d; }}");
     String[] path1 = {"a", "b"};
@@ -591,6 +592,7 @@ public class TestParquetFileWriter {
 
     MessageType schema = MessageTypeParser.parseMessageType(writeSchema);
     Configuration configuration = new Configuration();
+    configuration.set("parquet.strings.use-signed-order", "true");
     GroupWriteSupport.setSchema(schema, configuration);
 
     ParquetWriter<Group> writer = new ParquetWriter<Group>(path, configuration, new GroupWriteSupport());

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestThriftToParquetFileWriter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestThriftToParquetFileWriter.java
@@ -114,6 +114,7 @@ public class TestThriftToParquetFileWriter {
                           new RequiredPrimitiveFixture(false, (byte)100, (short)100, 100, 287l, -9.0d, "world"),
                           new RequiredPrimitiveFixture(true, (byte)2, (short)2, 9, -17l, 9.63d, "hello"));
       final Configuration configuration = new Configuration();
+      configuration.set("parquet.strings.use-signed-order", "true");
       final FileSystem fs = p.getFileSystem(configuration);
       FileStatus fileStatus = fs.getFileStatus(p);
       ParquetMetadata footer = ParquetFileReader.readFooter(configuration, p);
@@ -160,6 +161,7 @@ public class TestThriftToParquetFileWriter {
 
       // make new configuration and create file with new large stats
       final Configuration configuration_large = new Configuration();
+      configuration_large.set("parquet.strings.use-signed-order", "true");
       final FileSystem fs_large = p_large.getFileSystem(configuration_large);
       FileStatus fileStatus_large = fs_large.getFileStatus(p_large);
       ParquetMetadata footer_large = ParquetFileReader.readFooter(configuration_large, p_large);

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestThriftToParquetFileWriter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestThriftToParquetFileWriter.java
@@ -114,7 +114,7 @@ public class TestThriftToParquetFileWriter {
                           new RequiredPrimitiveFixture(false, (byte)100, (short)100, 100, 287l, -9.0d, "world"),
                           new RequiredPrimitiveFixture(true, (byte)2, (short)2, 9, -17l, 9.63d, "hello"));
       final Configuration configuration = new Configuration();
-      configuration.set("parquet.strings.use-signed-order", "true");
+      configuration.setBoolean("parquet.strings.signed-min-max.enabled", true);
       final FileSystem fs = p.getFileSystem(configuration);
       FileStatus fileStatus = fs.getFileStatus(p);
       ParquetMetadata footer = ParquetFileReader.readFooter(configuration, p);
@@ -161,7 +161,7 @@ public class TestThriftToParquetFileWriter {
 
       // make new configuration and create file with new large stats
       final Configuration configuration_large = new Configuration();
-      configuration_large.set("parquet.strings.use-signed-order", "true");
+      configuration.setBoolean("parquet.strings.signed-min-max.enabled", true);
       final FileSystem fs_large = p_large.getFileSystem(configuration_large);
       FileStatus fileStatus_large = fs_large.getFileStatus(p_large);
       ParquetMetadata footer_large = ParquetFileReader.readFooter(configuration_large, p_large);


### PR DESCRIPTION
Min and max are currently calculated using the default Java ordering
that uses signed comparison for all values. This is not correct for
binary types like strings and decimals or for unsigned numeric types.
This commit prevents statistics accumulated using the signed ordering
from being returned by ParquetMetadataConverter when the type should use
the unsigned ordering.

Because many binary strings are not affected by using the wrong
ordering, this adds a property, parquet.strings.use-signed-order to
allow overriding this change.