### PR TITLE
PARQUET-748: Update parquet-tools assembly and README

### DIFF
--- a/parquet-tools/README.md
+++ b/parquet-tools/README.md
@@ -27,23 +27,40 @@ Currently these tools are available for UN*X systems.
 
 ## Build
 
-If you want to use parquet-tools in local mode, you should use the local profile so the 
+If you want to use parquet-tools in local mode, you should use the local profile so the
 hadoop client dependency is included.
 
 ```sh
-cd parquet-tools && mvn clean package -Plocal 
+cd parquet-tools && mvn clean package -Plocal
 ```
 
 To use it in hadoop mode, the default profile will exclude the hadoop client dependency
 
 ```sh
-cd parquet-tools && mvn clean package 
+cd parquet-tools && mvn clean package
 ```
 
 The resulting jar is target/parquet-tools-<Version>.jar, you can copy it to the place where you
 want to use it
 
-#Run from hadoop
+## Create distribution
+
+You can create distribution (recommended to include client-dependency) that includes scripts for
+common commands (see below) and all dependencies necessary to run them. Distribution is created in
+`{projectDirectory}/target` in `.zip` and `.tar.gz`.
+
+```sh
+cd parquet-tools && mvn clean package -Plocal assembly:single
+```
+
+Output should look like this:
+```sh
+$ ls -l parquet-tools/target
+parquet-tools-<Version>-bin.tar.gz
+parquet-tools-<Version>-bin.zip
+```
+
+## Run from hadoop
 
 See Commands Usage for command to use
 
@@ -51,21 +68,49 @@ See Commands Usage for command to use
 hadoop jar ./parquet-tools-<VERSION>.jar <command> my_parquet_file.lzo.parquet
 ```
 
-#Run locally
+## Run locally
 
 See Commands Usage for command to use
 
-```
+```sh
 java jar ./parquet-tools-<VERSION>.jar <command> my_parquet_file.lzo.parquet
+```
+
+## Run using distribution
+
+See Commands Usage for available scripts/commands to use
+
+```sh
+./parquet-tools <command> my_parquet_file.lzo.parquet
+```
+
+Or each script, e.g. for displaying schema
+
+```sh
+./parquet-schema my_parquet_file.lzo.parquet
 ```
 
 ## Commands Usage
 
-To see usage instructions for all commands: 
+To see usage instructions for all commands:
 
-```
+```sh
 java jar ./parquet-tools-<VERSION>.jar --help
 ```
+
+If you use distribution, to see usage:
+```sh
+./parquet-tools --help
+```
+
+Scripts available in distribution:
+- `parquet-cat`
+- `parquet-head`
+- `parquet-dump`
+- `parquet-merge`
+- `parquet-meta`
+- `parquet-schema`
+- `parquet-tools` as a master script
 
 **Note:** To run it on hadoop, you should use `hadoop jar` instead of `java jar`
 

--- a/parquet-tools/pom.xml
+++ b/parquet-tools/pom.xml
@@ -129,6 +129,17 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <descriptors>
+            <descriptor>src/assembly/assembly.xml</descriptor>
+          </descriptors>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/parquet-tools/src/assembly/assembly.xml
+++ b/parquet-tools/src/assembly/assembly.xml
@@ -16,7 +16,7 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0" 
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
   <id>bin</id>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/PARQUET-748

This PR adds assembly plugin to `pom.xml` in `parquet-tools` and updates README on building distribution and usage for distribution scripts.

Tested patch manually by building distribution from `parquet-tools` directory, using produced tar archive to read sample parquet files with scripts included.