### PR TITLE
PARQUET-765 - Upgrade Avro to 1.8.1

### DIFF
--- a/parquet-avro/src/test/resources/car.avdl
+++ b/parquet-avro/src/test/resources/car.avdl
@@ -21,7 +21,7 @@
 protocol Cars {
 
     record Service {
-        long date;
+        long `date`;
         string mechanic;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <fastutil.version>6.5.7</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <avro.version>1.8.0</avro.version>
+    <avro.version>1.8.1</avro.version>
     <guava.version>11.0</guava.version>
     <mockito.version>1.9.5</mockito.version>
   </properties>


### PR DESCRIPTION
Escaping the field name `date` to make the test compatible to Avro 1.8.1 as _date_ is a keyword in avdl from 1.8.1.

Tested by setting the maven parameter `avro.version` to `1.8.1` and initiated a full build by `mvn clean install`.