### PR TITLE
PARQUET-786: 'java -jar', not 'java jar' closes #377, #374

### DIFF
--- a/parquet-tools/README.md
+++ b/parquet-tools/README.md
@@ -56,7 +56,7 @@ hadoop jar ./parquet-tools-<VERSION>.jar <command> my_parquet_file.lzo.parquet
 See Commands Usage for command to use
 
 ```
-java jar ./parquet-tools-<VERSION>.jar <command> my_parquet_file.lzo.parquet
+java -jar ./parquet-tools-<VERSION>.jar <command> my_parquet_file.lzo.parquet
 ```
 
 ## Commands Usage
@@ -64,10 +64,10 @@ java jar ./parquet-tools-<VERSION>.jar <command> my_parquet_file.lzo.parquet
 To see usage instructions for all commands: 
 
 ```
-java jar ./parquet-tools-<VERSION>.jar --help
+java -jar ./parquet-tools-<VERSION>.jar --help
 ```
 
-**Note:** To run it on hadoop, you should use `hadoop jar` instead of `java jar`
+**Note:** To run it on hadoop, you should use `hadoop jar` instead of `java -jar`
 
 ## Meta Legend
 


### PR DESCRIPTION
Fix for PARQUET-786: parquet-tools/README.md should say to run parquet-tools locally with 'java -jar ...', not 'java jar ...'