### PR TITLE
PARQUET-783: Close the underlying stream when an H2SeekableInputStream is closed

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/H2SeekableInputStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/H2SeekableInputStream.java
@@ -45,6 +45,11 @@ class H2SeekableInputStream extends SeekableInputStream {
   }
 
   @Override
+  public void close() throws IOException {
+    stream.close();
+  }
+
+  @Override
   public long getPos() throws IOException {
     return stream.getPos();
   }


### PR DESCRIPTION
This PR addresses https://issues.apache.org/jira/browse/PARQUET-783.

`ParquetFileReader` opens a `SeekableInputStream` to read a footer. In the process, it opens a new `FSDataInputStream` and wraps it. However, `H2SeekableInputStream` does not override the `close` method. Therefore, when `ParquetFileReader` closes it, the underlying `FSDataInputStream` is not closed. As a result, these stale connections can exhaust a clusters' data nodes' connection resources and lead to mysterious HDFS read failures in HDFS clients, e.g.

```
org.apache.hadoop.hdfs.BlockMissingException: Could not obtain block: BP-905337612-172.16.70.103-1444328960665:blk_1720536852_646811517
```