### PR TITLE
PARQUET-791: Add missing column support for UserDefinedPredicate

### DIFF
--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/statisticslevel/TestStatisticsFilter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/statisticslevel/TestStatisticsFilter.java
@@ -270,7 +270,10 @@ public class TestStatisticsFilter {
 
     @Override
     public boolean keep(Integer value) {
-      throw new RuntimeException("this method should not be called");
+      if (value == null) {
+        return true;
+      }
+      throw new RuntimeException("this method should not be called with value != null");
     }
 
     @Override
@@ -284,13 +287,26 @@ public class TestStatisticsFilter {
     }
   }
 
+  public static class DropNullUdp extends SevensAndEightsUdp {
+    @Override
+    public boolean keep(Integer value) {
+      if (value == null) {
+        return false;
+      }
+      throw new RuntimeException("this method should not be called with value != null");
+    }
+  }
+
   @Test
   public void testUdp() {
     FilterPredicate pred = userDefined(intColumn, SevensAndEightsUdp.class);
     FilterPredicate invPred = LogicalInverseRewriter.rewrite(not(userDefined(intColumn, SevensAndEightsUdp.class)));
 
-    FilterPredicate predForMissingColumn = userDefined(missingColumn2, SevensAndEightsUdp.class);
-    FilterPredicate invPredForMissingColumn = LogicalInverseRewriter.rewrite(not(userDefined(missingColumn2, SevensAndEightsUdp.class)));
+    FilterPredicate udpDropMissingColumn = userDefined(missingColumn2, DropNullUdp.class);
+    FilterPredicate invUdpDropMissingColumn = LogicalInverseRewriter.rewrite(not(userDefined(missingColumn2, DropNullUdp.class)));
+
+    FilterPredicate udpKeepMissingColumn = userDefined(missingColumn2, SevensAndEightsUdp.class);
+    FilterPredicate invUdpKeepMissingColumn = LogicalInverseRewriter.rewrite(not(userDefined(missingColumn2, SevensAndEightsUdp.class)));
 
     IntStatistics seven = new IntStatistics();
     seven.setMinMax(7, 7);
@@ -325,27 +341,55 @@ public class TestStatisticsFilter {
         getIntColumnMeta(neither, 177L),
         getDoubleColumnMeta(doubleStats, 177L))));
 
-    assertFalse(canDrop(predForMissingColumn, Arrays.asList(
+    // udpDropMissingColumn drops null column.
+    assertTrue(canDrop(udpDropMissingColumn, Arrays.asList(
         getIntColumnMeta(seven, 177L),
         getDoubleColumnMeta(doubleStats, 177L))));
 
-    assertFalse(canDrop(predForMissingColumn, Arrays.asList(
+    assertTrue(canDrop(udpDropMissingColumn, Arrays.asList(
         getIntColumnMeta(eight, 177L),
         getDoubleColumnMeta(doubleStats, 177L))));
 
-    assertFalse(canDrop(predForMissingColumn, Arrays.asList(
+    assertTrue(canDrop(udpDropMissingColumn, Arrays.asList(
         getIntColumnMeta(neither, 177L),
         getDoubleColumnMeta(doubleStats, 177L))));
 
-    assertFalse(canDrop(invPredForMissingColumn, Arrays.asList(
+    // invUdpDropMissingColumn (i.e., not(udpDropMissingColumn)) keeps null column.
+    assertFalse(canDrop(invUdpDropMissingColumn, Arrays.asList(
         getIntColumnMeta(seven, 177L),
         getDoubleColumnMeta(doubleStats, 177L))));
 
-    assertFalse(canDrop(invPredForMissingColumn, Arrays.asList(
+    assertFalse(canDrop(invUdpDropMissingColumn, Arrays.asList(
         getIntColumnMeta(eight, 177L),
         getDoubleColumnMeta(doubleStats, 177L))));
 
-    assertFalse(canDrop(invPredForMissingColumn, Arrays.asList(
+    assertFalse(canDrop(invUdpDropMissingColumn, Arrays.asList(
+        getIntColumnMeta(neither, 177L),
+        getDoubleColumnMeta(doubleStats, 177L))));
+
+    // udpKeepMissingColumn keeps null column.
+    assertFalse(canDrop(udpKeepMissingColumn, Arrays.asList(
+        getIntColumnMeta(seven, 177L),
+        getDoubleColumnMeta(doubleStats, 177L))));
+
+    assertFalse(canDrop(udpKeepMissingColumn, Arrays.asList(
+        getIntColumnMeta(eight, 177L),
+        getDoubleColumnMeta(doubleStats, 177L))));
+
+    assertFalse(canDrop(udpKeepMissingColumn, Arrays.asList(
+        getIntColumnMeta(neither, 177L),
+        getDoubleColumnMeta(doubleStats, 177L))));
+
+    // invUdpKeepMissingColumn (i.e., not(udpKeepMissingColumn)) drops null column.
+    assertTrue(canDrop(invUdpKeepMissingColumn, Arrays.asList(
+        getIntColumnMeta(seven, 177L),
+        getDoubleColumnMeta(doubleStats, 177L))));
+
+    assertTrue(canDrop(invUdpKeepMissingColumn, Arrays.asList(
+        getIntColumnMeta(eight, 177L),
+        getDoubleColumnMeta(doubleStats, 177L))));
+
+    assertTrue(canDrop(invUdpKeepMissingColumn, Arrays.asList(
         getIntColumnMeta(neither, 177L),
         getDoubleColumnMeta(doubleStats, 177L))));
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/statisticslevel/TestStatisticsFilter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/statisticslevel/TestStatisticsFilter.java
@@ -83,6 +83,7 @@ public class TestStatisticsFilter {
   private static final IntColumn intColumn = intColumn("int.column");
   private static final DoubleColumn doubleColumn = doubleColumn("double.column");
   private static final BinaryColumn missingColumn = binaryColumn("missing");
+  private static final IntColumn missingColumn2 = intColumn("missing.int");
 
   private static final IntStatistics intStats = new IntStatistics();
   private static final IntStatistics nullIntStats = new IntStatistics();
@@ -288,6 +289,9 @@ public class TestStatisticsFilter {
     FilterPredicate pred = userDefined(intColumn, SevensAndEightsUdp.class);
     FilterPredicate invPred = LogicalInverseRewriter.rewrite(not(userDefined(intColumn, SevensAndEightsUdp.class)));
 
+    FilterPredicate predForMissingColumn = userDefined(missingColumn2, SevensAndEightsUdp.class);
+    FilterPredicate invPredForMissingColumn = LogicalInverseRewriter.rewrite(not(userDefined(missingColumn2, SevensAndEightsUdp.class)));
+
     IntStatistics seven = new IntStatistics();
     seven.setMinMax(7, 7);
 
@@ -318,6 +322,30 @@ public class TestStatisticsFilter {
         getDoubleColumnMeta(doubleStats, 177L))));
 
     assertFalse(canDrop(invPred, Arrays.asList(
+        getIntColumnMeta(neither, 177L),
+        getDoubleColumnMeta(doubleStats, 177L))));
+
+    assertFalse(canDrop(predForMissingColumn, Arrays.asList(
+        getIntColumnMeta(seven, 177L),
+        getDoubleColumnMeta(doubleStats, 177L))));
+
+    assertFalse(canDrop(predForMissingColumn, Arrays.asList(
+        getIntColumnMeta(eight, 177L),
+        getDoubleColumnMeta(doubleStats, 177L))));
+
+    assertFalse(canDrop(predForMissingColumn, Arrays.asList(
+        getIntColumnMeta(neither, 177L),
+        getDoubleColumnMeta(doubleStats, 177L))));
+
+    assertFalse(canDrop(invPredForMissingColumn, Arrays.asList(
+        getIntColumnMeta(seven, 177L),
+        getDoubleColumnMeta(doubleStats, 177L))));
+
+    assertFalse(canDrop(invPredForMissingColumn, Arrays.asList(
+        getIntColumnMeta(eight, 177L),
+        getDoubleColumnMeta(doubleStats, 177L))));
+
+    assertFalse(canDrop(invPredForMissingColumn, Arrays.asList(
         getIntColumnMeta(neither, 177L),
         getDoubleColumnMeta(doubleStats, 177L))));
   }


### PR DESCRIPTION
This extends the fixing #354 to UserDefinedPredicate.