### PR TITLE
optimize the storage for repetition level and definition level

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderImpl.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderImpl.java
@@ -352,9 +352,6 @@ public class ColumnReaderImpl implements ColumnReader {
       this.dictionary = null;
     }
     this.totalValueCount = pageReader.getTotalValueCount();
-    if (totalValueCount <= 0) {
-      throw new ParquetDecodingException("totalValueCount '" + totalValueCount + "' <= 0");
-    }
     consume();
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
@@ -89,6 +89,11 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
                           Encoding rlEncoding,
                           Encoding dlEncoding,
                           Encoding valuesEncoding) throws IOException {
+      if (!statistics.hasNonNullValue()) {
+        LOG.debug("Ignore all-null field.");
+        return;
+      }
+
       long uncompressedSize = bytes.size();
       if (uncompressedSize > Integer.MAX_VALUE) {
         throw new ParquetEncodingException(

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -602,10 +602,10 @@ public class TestParquetFileWriter {
     
     ParquetMetadata readFooter = ParquetFileReader.readFooter(configuration, path);
     
-    // assert the statistics object is not empty
-    assertTrue((readFooter.getBlocks().get(0).getColumns().get(0).getStatistics().isEmpty()) == false);
-    // assert the number of nulls are correct for the first block
-    assertEquals(1, (readFooter.getBlocks().get(0).getColumns().get(0).getStatistics().getNumNulls()));
+    // assert the statistics object is empty
+    assertTrue((readFooter.getBlocks().get(0).getColumns().get(0).getStatistics().isEmpty()) == true);
+    // no data written actually
+    assertEquals(0, (readFooter.getBlocks().get(0).getColumns().get(0).getStatistics().getNumNulls()));
   }
 
   private void validateFooters(final List<Footer> metadata) {


### PR DESCRIPTION
This update optimizes the storage for all-null fields.

In some cases there are thousands of fields, which most of them are null in one data block, and the null value does not occur on the same nesting level.
The repetition level and definition level of null fields vary from 0, 1, 2, etc, and waste appreciable storage space.

In this update, writer skips writing chunk page if all data in the field are null, and reader is compatible for the change.