### PR TITLE
PARQUET-806: Parquet-tools silently suppresses error messages

### DIFF
--- a/parquet-tools/src/main/java/org/apache/parquet/tools/Main.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/Main.java
@@ -162,7 +162,7 @@ public class Main {
   }
 
   public static void die(Throwable th, boolean usage, String name, Command command) {
-    die(th.getMessage(), usage, name, command);
+    die(th.toString(), usage, name, command);
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
The "error message" that used to be

org/apache/hadoop/conf/Configuration

now becomes:

NoClassDefFoundError: org/apache/hadoop/conf/Configuration