### PR TITLE
PARQUET-822: Upgrade java dependencies

### DIFF
--- a/parquet-benchmarks/pom.xml
+++ b/parquet-benchmarks/pom.xml
@@ -32,7 +32,7 @@
   <url>https://parquet.apache.org</url>
 
   <properties>
-    <jmh.version>1.3.4</jmh.version>
+    <jmh.version>1.17.3</jmh.version>
     <uberjar.name>parquet-benchmarks</uberjar.name>
   </properties>
 

--- a/parquet-column/pom.xml
+++ b/parquet-column/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.5</version>
+      <version>1.10</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -68,13 +68,13 @@
     <dependency>
       <groupId>com.carrotsearch</groupId>
       <artifactId>junit-benchmarks</artifactId>
-      <version>0.7.0</version>
+      <version>0.7.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.3.149</version>
+      <version>1.4.193</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/parquet-encoding/pom.xml
+++ b/parquet-encoding/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.5</version>
+      <version>1.10</version>
       <scope>compile</scope>
     </dependency>
 

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -70,14 +70,14 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.1.1.6</version>
+      <version>1.1.2.6</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>commons-pool</groupId>
       <artifactId>commons-pool</artifactId>
-      <version>1.5.4</version>
+      <version>1.6</version>
     </dependency>
 
     <dependency>

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestMemoryManager.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestMemoryManager.java
@@ -61,7 +61,7 @@ public class TestMemoryManager {
     conf.setLong(ParquetOutputFormat.BLOCK_SIZE, rowGroupSize);
 
     // the memory manager is not initialized until a writer is created
-    createWriter(1).close(null);
+    createWriter(0).close(null);
   }
 
   @Test

--- a/parquet-hive/parquet-hive-storage-handler/pom.xml
+++ b/parquet-hive/parquet-hive-storage-handler/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.4</version>
+      <version>2.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/parquet-pig/pom.xml
+++ b/parquet-pig/pom.xml
@@ -89,13 +89,13 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>1.6</version>
+      <version>2.9.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr-runtime</artifactId>
-      <version>3.4</version>
+      <version>3.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <elephant-bird.version>4.4</elephant-bird.version>
-    <protobuf.version>2.5.0</protobuf.version>
+    <protobuf.version>2.6.1</protobuf.version>
   </properties>
 
 

--- a/parquet-scala/pom.xml
+++ b/parquet-scala/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <version>2.2.1</version>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -92,7 +92,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>scrooge-core_${scala.binary.version}</artifactId>
-      <version>3.17.0</version>
+      <version>4.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -100,13 +100,13 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>1.6</version>
+      <version>2.9.7</version>
       <scope>provided</scope>
     </dependency>
     <dependency> <!-- for pig runtime in tests -->
       <groupId>org.antlr</groupId>
       <artifactId>antlr-runtime</artifactId>
-      <version>3.4</version>
+      <version>3.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/parquet-tools/pom.xml
+++ b/parquet-tools/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.2</version>
+      <version>1.3.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,29 +66,29 @@
     <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
     <maven-thrift-plugin.version>0.1.11</maven-thrift-plugin.version>
     <jackson.groupId>org.codehaus.jackson</jackson.groupId>
-    <jackson.version>1.9.11</jackson.version>
+    <jackson.version>1.9.13</jackson.version>
     <jackson.package>org.codehaus.jackson</jackson.package>
     <shade.prefix>shaded.parquet</shade.prefix>
-    <hadoop.version>2.3.0</hadoop.version>
+    <hadoop.version>2.7.3</hadoop.version>
     <hadoop1.version>1.1.0</hadoop1.version>
-    <cascading.version>2.5.3</cascading.version>
-    <cascading3.version>3.0.3</cascading3.version>
+    <cascading.version>2.7.1</cascading.version>
+    <cascading3.version>3.1.2</cascading3.version>
     <parquet.format.version>2.3.1</parquet.format.version>
     <previous.version>1.7.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
-    <scala.version>2.10.4</scala.version>
+    <scala.version>2.10.6</scala.version>
     <!-- scala.binary.version is used for projects that fetch dependencies that are in scala -->
     <scala.binary.version>2.10</scala.binary.version>
     <scala.maven.test.skip>false</scala.maven.test.skip>
-    <pig.version>0.14.0</pig.version>
+    <pig.version>0.16.0</pig.version>
     <pig.classifier>h2</pig.classifier>
     <thrift.version>0.7.0</thrift.version>
-    <fastutil.version>6.5.7</fastutil.version>
+    <fastutil.version>7.0.13</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>
-    <slf4j.version>1.7.5</slf4j.version>
+    <slf4j.version>1.7.22</slf4j.version>
     <avro.version>1.8.1</avro.version>
-    <guava.version>11.0</guava.version>
-    <mockito.version>1.9.5</mockito.version>
+    <guava.version>20.0</guava.version>
+    <mockito.version>1.10.19</mockito.version>
   </properties>
 
   <modules>
@@ -119,19 +119,19 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-      <version>3.2</version>
+      <version>3.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.0.1</version>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -233,6 +233,7 @@
                      <exclude>org/apache/parquet/hadoop/ParquetInputSplit</exclude>
                      <exclude>org/apache/parquet/hadoop/CodecFactory**</exclude>
                      <exclude>shaded/**</exclude> <!-- shaded by parquet -->
+                     <exclude>org/apache/parquet/it/unimi/dsi/fastutil/**</exclude> <!-- Another shaded dependency from parquet-column -->
                      <!-- temporary exclusions for false-positives -->
                      <exclude>org/apache/parquet/Version</exclude>
                      <exclude>org/apache/parquet/schema/**</exclude> <!-- methods moved to new superclass -->

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <jackson.package>org.codehaus.jackson</jackson.package>
     <shade.prefix>shaded.parquet</shade.prefix>
     <hadoop.version>2.7.3</hadoop.version>
-    <hadoop1.version>1.1.0</hadoop1.version>
+    <hadoop1.version>1.2.1</hadoop1.version>
     <cascading.version>2.7.1</cascading.version>
     <cascading3.version>3.1.2</cascading3.version>
     <parquet.format.version>2.3.1</parquet.format.version>
@@ -128,10 +128,11 @@
       <version>3.4</version>
       <scope>test</scope>
     </dependency>
+    <!-- hadoop-1 requires the old httpclient for testing -->
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
+      <groupId>commons-httpclient</groupId>
+      <artifactId>commons-httpclient</artifactId>
+      <version>3.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
2 minor code/config modification related to the version upgrades:
- TestMemoryManager.java: I guess, it was caused by the junit upgrade however, it is not clear why it was working before. The issue was that the second run of `createWriter(1).close(null)` failed with `IOException` about that the file already exists.
- pom.xml (added exclusion for fastutil): The shaded dependency upgrade in `parquet-column`  caused failure of API version compatibility check.

`mvn clean install` worked fine. Any idea about additional testing is welcomed.