### PR TITLE
PARQUET-856: Do not pass knownClass if it is abstract/interface/Object.

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -138,6 +138,11 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
       };
 
       Class<?> fieldClass = fields.get(avroField.name());
+      if ((null != fieldClass) && (Modifier.isAbstract(fieldClass.getModifiers()) ||
+          Modifier.isInterface(fieldClass.getModifiers()) ||
+          fieldClass.equals(Object.class)) ) {
+        fieldClass = null;
+      }
       converters[parquetFieldIndex] = newConverter(
           nonNullSchema, parquetField, this.model, fieldClass, container);
 


### PR DESCRIPTION
Fixes a very small cornercase in parquet-avro if reflection of abstract generic fields are used.