### PR TITLE
Parquet-884: Add support for Decimal datatype to Parquet-Pig record reader

### DIFF
--- a/parquet-pig/src/main/java/org/apache/parquet/pig/PigSchemaConverter.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/PigSchemaConverter.java
@@ -244,8 +244,12 @@ public class PigSchemaConverter {
 
       @Override
       public FieldSchema convertFIXED_LEN_BYTE_ARRAY(
-          PrimitiveTypeName primitiveTypeName) throws FrontendException {
-        return new FieldSchema(fieldName, null, DataType.BYTEARRAY);
+        PrimitiveTypeName primitiveTypeName) throws FrontendException {
+        if (originalType == OriginalType.DECIMAL) {
+          return new FieldSchema(fieldName, null, DataType.BIGDECIMAL);
+        } else {
+          return new FieldSchema(fieldName, null, DataType.BYTEARRAY);
+        }
       }
 
       @Override

--- a/parquet-pig/src/main/java/org/apache/parquet/pig/convert/DecimalUtils.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/convert/DecimalUtils.java
@@ -1,0 +1,42 @@
+package org.apache.parquet.pig.convert;
+
+import java.nio.ByteBuffer;
+import java.math.BigInteger;
+import java.math.BigDecimal;
+import static java.lang.Math.pow;
+
+import org.apache.parquet.io.api.Binary;
+
+/*
+ * Conversion between Parquet Decimal Type to Java BigDecimal in Pig
+ * Code Based on the Apache Spark ParquetRowConverter.java
+ * 
+ *
+ */
+
+public class DecimalUtils {
+
+  public static BigDecimal binaryToDecimal(Binary value, int precision, int scale) {
+    if (precision <= 18) {
+      ByteBuffer buffer = value.toByteBuffer();
+      byte[] bytes = buffer.array();
+      int start = buffer.arrayOffset() + buffer.position();
+      int end = buffer.arrayOffset() + buffer.limit();
+      long unscaled = 0L;
+      int i = start;
+      while ( i < end ) {
+        unscaled = ( unscaled << 8 | bytes[i] & 0xff );
+        i++;
+      }
+      int bits = 8*(end - start);
+      long unscaledNew = (unscaled << (64 - bits)) >> (64 - bits);
+      if (unscaledNew <= -pow(10,18) || unscaledNew >= pow(10,18)) {
+        return new BigDecimal(unscaledNew);
+      } else {
+        return BigDecimal.valueOf(unscaledNew / pow(10,scale));
+      }
+    } else {
+      return new BigDecimal(new BigInteger(value.getBytes()), scale);
+    }
+  }
+}

--- a/parquet-pig/src/main/java/org/apache/parquet/pig/convert/DecimalUtils.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/convert/DecimalUtils.java
@@ -28,7 +28,7 @@ import org.apache.parquet.io.api.Binary;
 
 /*
  * Conversion between Parquet Decimal Type to Java BigDecimal in Pig
- * Code Based on the Apache Spark ParquetRowConverter.java
+ * Code Based on the Apache Spark ParquetRowConverter.scala
  * 
  *
  */
@@ -36,6 +36,10 @@ import org.apache.parquet.io.api.Binary;
 public class DecimalUtils {
 
   public static BigDecimal binaryToDecimal(Binary value, int precision, int scale) {
+    /*
+     * Precision <= 18 checks for the max number of digits for an unscaled long,
+     * else treat with big integer conversion
+     */
     if (precision <= 18) {
       ByteBuffer buffer = value.toByteBuffer();
       byte[] bytes = buffer.array();

--- a/parquet-pig/src/main/java/org/apache/parquet/pig/convert/DecimalUtils.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/convert/DecimalUtils.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.parquet.pig.convert;
 
 import java.nio.ByteBuffer;

--- a/parquet-pig/src/main/java/org/apache/parquet/pig/convert/TupleConverter.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/convert/TupleConverter.java
@@ -548,14 +548,10 @@ public class TupleConverter extends GroupConverter {
 
     @Override
     final public void addBinary(Binary value) {
-      if (primitiveType != null) {
-        int precision = primitiveType.asPrimitiveType().getDecimalMetadata().getPrecision();
-        int scale = primitiveType.asPrimitiveType().getDecimalMetadata().getScale();
-        BigDecimal finaldecimal = DecimalUtils.binaryToDecimal(value, precision, scale);
-        parent.add(finaldecimal);
-      } else {
-        parent.add("Broken DecimalType");
-      }
+      int precision = primitiveType.asPrimitiveType().getDecimalMetadata().getPrecision();
+      int scale = primitiveType.asPrimitiveType().getDecimalMetadata().getScale();
+      BigDecimal finaldecimal = DecimalUtils.binaryToDecimal(value, precision, scale);
+      parent.add(finaldecimal);
     }
   }
 

--- a/parquet-pig/src/test/java/org/apache/parquet/pig/TestDecimalUtils.java
+++ b/parquet-pig/src/test/java/org/apache/parquet/pig/TestDecimalUtils.java
@@ -1,0 +1,60 @@
+package org.apache.parquet.pig;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import static java.lang.Math.abs;
+import java.nio.ByteBuffer;
+
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.pig.convert.DecimalUtils;
+
+public class TestDecimalUtils {
+  
+  private void testDecimalConversion(double value, int precision, int scale, String stringValue) {
+    String originalString = Double.toString(value);
+    BigDecimal originalValue = new BigDecimal(originalString);
+    BigDecimal convertedValue = DecimalUtils.binaryToDecimal(Binary.fromByteArray(originalValue.unscaledValue().toByteArray()),
+                                                             precision,scale);
+    assertEquals(stringValue, convertedValue.toString());
+  }
+
+  private void testDecimalConversion(int value, int precision, int scale, String stringValue) {
+    String originalString = Integer.toString(value);
+    BigDecimal originalValue = new BigDecimal(originalString);
+    BigDecimal convertedValue = DecimalUtils.binaryToDecimal(Binary.fromByteArray(originalValue.unscaledValue().toByteArray()),
+                                                             precision,scale);
+    assertEquals(stringValue, convertedValue.toString());
+  }
+
+  private void testDecimalConversion(long value, int precision, int scale, String stringValue) {
+    String originalString = Long.toString(value);
+    BigDecimal originalValue = new BigDecimal(originalString);
+    BigDecimal convertedValue = DecimalUtils.binaryToDecimal(Binary.fromByteArray(originalValue.unscaledValue().toByteArray()),
+                                                             precision, scale);
+    assertEquals(stringValue, convertedValue.toString());
+  }
+
+  @Test
+  public void testBinaryToDecimal() throws Exception {
+    // Known issue: testing Nx10^M doubles from BigDecimal.unscaledValue() always converts to Nx10 regardless of M
+    // Known issue: any double with precision > 17 breaks in test but not in functional testing
+    
+    // Test LONG
+    testDecimalConversion(Long.MAX_VALUE,19,0,"9223372036854775807");
+    testDecimalConversion(Long.MIN_VALUE,19,0,"-9223372036854775808");
+    testDecimalConversion(0L,0,0,"0.0");
+
+    // Test INTEGER
+    testDecimalConversion(Integer.MAX_VALUE,10,0,"2147483647");
+    testDecimalConversion(Integer.MIN_VALUE,10,0,"-2147483648");
+    testDecimalConversion(0,0,0,"0.0");
+
+    // Test DOUBLE
+    testDecimalConversion(12345678912345678d,17,0,"12345678912345678");
+    testDecimalConversion(123456789123456.78,17,2,"123456789123456.78");
+    testDecimalConversion(0.12345678912345678,17,17,"0.12345678912345678");
+    testDecimalConversion(-0.000102,6,6,"-0.000102");
+  }
+}

--- a/parquet-pig/src/test/java/org/apache/parquet/pig/TestDecimalUtils.java
+++ b/parquet-pig/src/test/java/org/apache/parquet/pig/TestDecimalUtils.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.parquet.pig;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Adds conversion support to Pig for Decimal datatype. Based on the scala code in the spark project that provides a similar function for their sql library.