### PR TITLE
PARQUET-964 Fix ParquetDecodingException: totalValueCount '0' <= 0

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderImpl.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderImpl.java
@@ -352,8 +352,8 @@ public class ColumnReaderImpl implements ColumnReader {
       this.dictionary = null;
     }
     this.totalValueCount = pageReader.getTotalValueCount();
-    if (totalValueCount <= 0) {
-      throw new ParquetDecodingException("totalValueCount '" + totalValueCount + "' <= 0");
+    if (totalValueCount < 0) {
+      throw new ParquetDecodingException("totalValueCount '" + totalValueCount + "' < 0");
     }
     consume();
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/PARQUET-964

Problem is reproduced for:
```
message TestProtobuf.ListOfList {
  optional binary top_field (UTF8);
  required group first_array (LIST) {
    repeated group array {
      optional int32 inner_field;
      required group second_array (LIST) {
        repeated int32 array;
      }
    }
  }
}
```

When `inner_field` is not populated, the `totalValueCount` is 0 and fails with exception, instead of skipping the column and parsing the `second_array` (which is populated). This PR fixes the issue.