### PR TITLE
PARQUET-1005: Fix DumpCommand parsing to allow column projection

### DIFF
--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -32,6 +32,8 @@
   <properties>
     <elephant-bird.version>4.4</elephant-bird.version>
     <protobuf.version>3.2.0</protobuf.version>
+    <!-- allow using protoc from an alternative path -->
+    <protoc.path>protoc</protoc.path>
   </properties>
 
 
@@ -155,7 +157,7 @@
               <tasks>
                 <mkdir dir="${project.build.directory}/generated-test-sources" />
                 <mkdir dir="${project.build.directory}/generated-test-sources/java" />
-                <exec failonerror="true" executable="protoc">
+                <exec failonerror="true" executable="${protoc.path}">
                   <arg value="--java_out=${project.build.directory}/generated-test-sources/java" />
                   <arg value="src/test/resources/TestProtobuf.proto" />
                   <arg value="src/test/resources/TestProto3.proto" />

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/Main.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/Main.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -200,7 +200,6 @@ public class Main {
     }
 
     boolean debug = false;
-    Options options = mergeOptions(OPTIONS, command.getOptions());
     try {
       String[] cargs = Arrays.copyOfRange(args, 1, args.length);
 

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/DumpCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/DumpCommand.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -47,7 +47,6 @@ import org.apache.parquet.column.page.DataPageV2;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.column.page.PageReader;
-import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
@@ -91,7 +90,7 @@ public class DumpCommand extends ArgsOnlyCommand {
 
         Option cl = OptionBuilder.withLongOpt("column")
                                  .withDescription("Dump only the given column, can be specified more than once")
-                                 .hasArgs()
+                                 .hasArg()
                                  .create('c');
 
         OPTIONS.addOption(md);


### PR DESCRIPTION
DumpCommand option for -c is specified as hasArgs() for unlimited
number of arguments following -c. The very description of the option
shows the real intent of using hasArg() such that multiple columns
can be specified as '-c c1 -c c2 ...'. Otherwise, the input path
is parsed as an argument for -c instead of the command itself.