### PR TITLE
update readme: required protobuf version is 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Parquet-MR uses Maven to build and depends on both the thrift and protoc compile
 To build and install the protobuf compiler, run:
 
 ```
-wget https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz
-tar xzf protobuf-2.5.0.tar.gz
-cd  protobuf-2.5.0
+wget https://github.com/google/protobuf/releases/download/v3.2.0/protobuf-cpp-3.2.0.tar.gz
+tar xzf protobuf-cpp-3.2.0.tar.gz
+cd  protobuf-3.2.0
 ./configure
 make
 sudo make install


### PR DESCRIPTION
Trying to use LC_ALL=C mvn clean install with protobuf 2.5.0 generates errors. Needed version is 3.2.0, as specified by <protobuf.version>3.2.0</protobuf.version> in parquet-protobuf/pom.xml.