### PR TITLE
PARQUET-1077: Use long key ids in KEYS file

### DIFF
--- a/KEYS
+++ b/KEYS
@@ -2,19 +2,17 @@ This file contains the PGP keys of various developers.
 
 Users: pgp < KEYS
   gpg --import KEYS
-Developers: 
+Developers:
   pgp -kxa <your name> and append it to this file.
   (pgpk -ll <your name> && pgpk -xa <your name>) >> this file.
-  (gpg --list-sigs <your name>
+  (gpg --list-sigs --keyid-format long <your name>
     && gpg --armor --export <your name>) >> this file.
 
-pub   2048R/7AE7E47B 2013-04-10 [expires: 2017-04-10]
-uid                  Julien Le Dem <julien@ledem.net>
-sig 3        7AE7E47B 2013-04-10  Julien Le Dem <julien@ledem.net>
-sig          D3924CCD 2014-09-08  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
-sig          71F0F13B 2014-09-08  Tianshuo Deng <tdeng@twitter.com>
-sub   2048R/03C4E111 2013-04-10 [expires: 2017-04-10]
-sig          7AE7E47B 2013-04-10  Julien Le Dem <julien@ledem.net>
+pub   2048R/97D7E8647AE7E47B 2013-04-10 [expired: 2017-04-10]
+uid                          Julien Le Dem <julien@ledem.net>
+sig 3        97D7E8647AE7E47B 2013-04-10  Julien Le Dem <julien@ledem.net>
+sig          FCB3CBD9D3924CCD 2014-09-08  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
+sig          7CD8278971F0F13B 2014-09-08  Tianshuo Deng <tdeng@twitter.com>
 
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1
@@ -70,13 +68,13 @@ cqCIvQIvmBpPdlyaoglwJ8wWb76uIE6VFcN71FF3EfV51/yUeQGJaoExWLY6IH8x
 Xtn3IWkBWA==
 =xpC8
 -----END PGP PUBLIC KEY BLOCK-----
-pub   2048R/71F0F13B 2013-08-26
-uid                  Tianshuo Deng <tdeng@twitter.com>
-sig 3        71F0F13B 2013-08-26  Tianshuo Deng <tdeng@twitter.com>
-sig          D3924CCD 2014-09-08  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
-sig          7AE7E47B 2014-09-08  Julien Le Dem <julien@ledem.net>
-sub   2048R/0CEDD7ED 2013-08-26
-sig          71F0F13B 2013-08-26  Tianshuo Deng <tdeng@twitter.com>
+pub   2048R/7CD8278971F0F13B 2013-08-26
+uid                          Tianshuo Deng <tdeng@twitter.com>
+sig 3        7CD8278971F0F13B 2013-08-26  Tianshuo Deng <tdeng@twitter.com>
+sig          FCB3CBD9D3924CCD 2014-09-08  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
+sig          97D7E8647AE7E47B 2014-09-08  Julien Le Dem <julien@ledem.net>
+sub   2048R/F98EFADB0CEDD7ED 2013-08-26
+sig          7CD8278971F0F13B 2013-08-26  Tianshuo Deng <tdeng@twitter.com>
 
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1
@@ -125,19 +123,19 @@ woq9HFeHZ5sSVQ56GOwENRvjCeqDOTmbwus0MIymrcs3yHC6O0UEHPlpHzePNLJl
 /Otnj+wHn/N9LAoxr7gDpu/cpBFiPSLD189FCbU15FnFVAEuC5Vd9Y/3IhMwvg==
 =Gd1/
 -----END PGP PUBLIC KEY BLOCK-----
-pub   1024D/4318F669 2009-06-30
-uid                  Tom White (CODE SIGNING KEY) <tomwhite@apache.org>
-sig          68E327C1 2010-09-23  [User ID not found]
-sig          A7239D59 2010-09-23  Doug Cutting (Lucene guy) <cutting@apache.org>
-sig          299EB32C 2010-09-25  [User ID not found]
-sig          AEC77EAF 2010-09-27  [User ID not found]
-sig          1F27E622 2010-10-27  [User ID not found]
-sig 3        4318F669 2009-06-30  Tom White (CODE SIGNING KEY) <tomwhite@apache.org>
-sig          C987200D 2010-10-02  [User ID not found]
-sig          3D0C92B9 2010-09-24  [User ID not found]
-sig          D3924CCD 2014-09-04  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
-sub   2048g/BAEBF3E3 2009-06-30
-sig          4318F669 2009-06-30  Tom White (CODE SIGNING KEY) <tomwhite@apache.org>
+pub   1024D/4FB955854318F669 2009-06-30
+uid                          Tom White (CODE SIGNING KEY) <tomwhite@apache.org>
+sig          E22A746A68E327C1 2010-09-23  [User ID not found]
+sig          DBAF69BEA7239D59 2010-09-23  [User ID not found]
+sig          E952F459299EB32C 2010-09-25  [User ID not found]
+sig          5E43CAB9AEC77EAF 2010-09-27  [User ID not found]
+sig          220F69801F27E622 2010-10-27  [User ID not found]
+sig 3        4FB955854318F669 2009-06-30  Tom White (CODE SIGNING KEY) <tomwhite@apache.org>
+sig          2C89EE98C987200D 2010-10-02  [User ID not found]
+sig          1209E7F13D0C92B9 2010-09-24  [User ID not found]
+sig          FCB3CBD9D3924CCD 2014-09-04  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
+sub   2048g/A306EFF1BAEBF3E3 2009-06-30
+sig          4FB955854318F669 2009-06-30  Tom White (CODE SIGNING KEY) <tomwhite@apache.org>
 
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1
@@ -210,19 +208,19 @@ yDChOIyfrt/T8ooJQVaI8IhJBBgRAgAJBQJKSfejAhsMAAoJEE+5VYVDGPZpviQA
 njVeVF9MewkYAYXYwxDQs6J+KIx4AJ9xqFuYD+KbUSGjAUcDyaJPufpZng==
 =kUv7
 -----END PGP PUBLIC KEY BLOCK-----
-pub   4096R/D3924CCD 2014-08-13
-uid                  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
-sig 3        D3924CCD 2014-08-13  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
-sig          4318F669 2014-09-04  Tom White (CODE SIGNING KEY) <tomwhite@apache.org>
-sig          7AE7E47B 2014-09-08  Julien Le Dem <julien@ledem.net>
-uid                  Ryan Blue <blue@apache.org>
-sig 3        D3924CCD 2014-08-13  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
-sig          4318F669 2014-09-04  Tom White (CODE SIGNING KEY) <tomwhite@apache.org>
-sig          7AE7E47B 2014-09-08  Julien Le Dem <julien@ledem.net>
-sub   4096R/A8B58800 2014-08-13
-sig          D3924CCD 2014-08-13  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
-sub   4096R/A4B2E9B5 2014-08-13
-sig          D3924CCD 2014-08-13  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
+pub   4096R/FCB3CBD9D3924CCD 2014-08-13
+uid                          Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
+sig 3        FCB3CBD9D3924CCD 2014-08-13  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
+sig          4FB955854318F669 2014-09-04  Tom White (CODE SIGNING KEY) <tomwhite@apache.org>
+sig          97D7E8647AE7E47B 2014-09-08  Julien Le Dem <julien@ledem.net>
+uid                          Ryan Blue <blue@apache.org>
+sig 3        FCB3CBD9D3924CCD 2014-08-13  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
+sig          4FB955854318F669 2014-09-04  Tom White (CODE SIGNING KEY) <tomwhite@apache.org>
+sig          97D7E8647AE7E47B 2014-09-08  Julien Le Dem <julien@ledem.net>
+sub   4096R/F16C5528A8B58800 2014-08-13
+sig          FCB3CBD9D3924CCD 2014-08-13  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
+sub   4096R/86781D4FA4B2E9B5 2014-08-13
+sig          FCB3CBD9D3924CCD 2014-08-13  Ryan Blue (CODE SIGNING KEY) <blue@apache.org>
 
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1
@@ -338,17 +336,11 @@ BM83UyGyWEjVQCR3/E/ag0jKwmsnlX6ofGFfS6xSqKK+H/FoLsbI23dS4o6bF4QA
 HT2hxY8ondF9eKU5rnzLGRFYmm1+Pw==
 =gSQT
 -----END PGP PUBLIC KEY BLOCK-----
-pub   2048R/2F7D7992 2014-03-20
-uid                  Alex Levenson <alexlevenson@twitter.com>
-sig 3        2F7D7992 2014-03-20  Alex Levenson <alexlevenson@twitter.com>
-sub   2048R/2D2E4D5C 2014-03-20
-sig          2F7D7992 2014-03-20  Alex Levenson <alexlevenson@twitter.com>
-
-pub   2048R/7C58F0FE 2015-01-08
-uid                  Alex Levenson <alex@isnotinvain.com>
-sig 3        7C58F0FE 2015-01-08  Alex Levenson <alex@isnotinvain.com>
-sub   2048R/E17552B7 2015-01-08
-sig          7C58F0FE 2015-01-08  Alex Levenson <alex@isnotinvain.com>
+pub   2048R/A9358ED82F7D7992 2014-03-20
+uid                          Alex Levenson <alexlevenson@twitter.com>
+sig 3        A9358ED82F7D7992 2014-03-20  Alex Levenson <alexlevenson@twitter.com>
+sub   2048R/301C76C52D2E4D5C 2014-03-20
+sig          A9358ED82F7D7992 2014-03-20  Alex Levenson <alexlevenson@twitter.com>
 
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1
@@ -377,39 +369,52 @@ lLy0msr8AbYPLHosImrTVyURo80k1XP8VjvtEP6SJsoCAND/FeZ8uA5JPa4lpi1f
 IiXbsT1n9wxTXqQ4T/7VZQUjDDO3FaL3xAYGR21vj5h7e63Ucgaix1jAJkSm7/+E
 6uKjJHTjQOb02D48J7fsP4hIj+DZTnlwXkJptC3eARnpZN/oH2ePlvoidd9jjRzz
 3RH0YRrVNMxgSlBjlAnk10nzKi1Rk75isucB8qh/myZTNGgSkHlSPMpgzjUc8Dpc
-QZQJOY9gjcH+UBw8k+e7IjUFtLjjkjQ2lJ2/8oZaYlkEMyLvT/anmQENBFSuMHgB
-CADh5VSW6TlHG42jvvLiuBPr6Z4U0M5NMfem/LRaZhcx/tCZ+zp84gInV6iinuzO
-po1XisXM6PAXIOhF26FU7SYvomAJcWD5o0XLznkt5S3dQrp4wBAwfVaMLJSNrYaK
-dxDAw1dII45l9v/jmnhAuUoTXO1GfhuRyC4kG2lct+erNheit15o/NqyPYNPQP/g
-YWqKNSyTQVSyz0JeSsGy6UniDKH9sa4ZDTV/vZb+LCFxbOGxrkRouUi0miR64ZYo
-npgUYZxhuPYW2F6ueK/mlUWjcAE9sEgfIadEJOuhaGHzafx8lFFGDftxxsBl2RfS
-l+/Eu8/6ml5goJIWIg5hQotRABEBAAG0JEFsZXggTGV2ZW5zb24gPGFsZXhAaXNu
-b3RpbnZhaW4uY29tPokBOAQTAQIAIgUCVK4weAIbAwYLCQgHAwIGFQgCCQoLBBYC
-AwECHgECF4AACgkQRCx/rHxY8P6cxggAqnXxzfpnKZTwlDqAyLCMndigeHTdBFN7
-M6pGrx2iVQED/I00opZKS1SBVLP7Ib+KkvDW8S5RmIGZM8/TGNIdyAjnnvwi/Ae0
-ieFZSRGTZE/gsRTcD56Jabs+y7xqYAiNLjg62DfkodS7HdSD/QvQjNu82S5Blq36
-yL1YmIlErEVdDkUsfB5usZwIGuEvPBOecGXxwqKQVfkLBoOgTyLtXvm7+zTEhFp/
-3sYOkSiGbK9CL1Gs9YE6W7LhdSjuhYYSWZRqH6A1GyVVoFLgHDsLWFz4OJPm9XvP
-BmIVxUq8P1tHV1Z7NpvXOm1oOFlbvkLgalNZnopm4mbZ49lvCmV3YbkBDQRUrjB4
-AQgApAa4IuaNM/CAqIhXf5NxyIJHoyW2dAEOv04QlcNVyMGd4dXIl+cAI+NI5P8z
-PwJm3cneNT8/HKYWryE141cLki7mm/6bVZxkhT3ZAmXaDnjd9ihUJORzbZbmMnZ7
-BkEFXKi21Daf2nSBugcuQXMNZ5A0+/b/tF2OjhZ/ARW7DuT9A0wHxqqiAS4En5KD
-8eB9jdjAdw5jcxrcdGscP22RqCeH22UWIYj53l8bQmhkXB16AwFsD6dV+3O1EeTe
-NyKxRdhotkOFxuvgfo2gH7KtRRbjpkDGv0U9cupb3rH3LrtDxuCf3X4TehAoXnX6
-SAZZusQLsJQ7eUHFq95ygjODlwARAQABiQEfBBgBAgAJBQJUrjB4AhsMAAoJEEQs
-f6x8WPD+JkMH/2+/aDAA6bEurx2VtvXVgCE5r3mKebhR2qxG6zkfTnEzaYGe+9Xq
-vI7EUjguW5Aomglxp1/qh4TWacmv7F+qA23TQqWlKFW411MWRJwl/ogZ43V32OWe
-yuZb3CTJjIG9xzFkb/FpvG3KeBuPzosUGCQYq6UK/HsbTCOdwa7u3I385uiihmhu
-3bW380bkszLg4/fuLgYO9wDMazwAjKdEqW2+EtATxKaKX+V6/b/9PwZpJiSt7O1B
-pwS2/P5OVRGNuS876GCXAHM4jqVz701fY6nbdrQl5n4HAUERmSN7Eo0z2Kq4VdNM
-aVycAinKdDoRqhe0iGXbYeZyW3fmY/7iLKc=
-=2typ
+QZQJOY9gjcH+UBw8k+e7IjUFtLjjkjQ2lJ2/8oZaYlkEMyLvT/an
+=11J5
 -----END PGP PUBLIC KEY BLOCK-----
-pub   4096R/8CAAD602 2016-11-06
-uid                  Uwe L. Korn <uwe@apache.org>
-sig 3        8CAAD602 2016-11-06  Uwe L. Korn <uwe@apache.org>
-sub   4096R/7BD1BC86 2016-11-06
-sig          8CAAD602 2016-11-06  Uwe L. Korn <uwe@apache.org>
+pub   2048R/442C7FAC7C58F0FE 2015-01-08
+uid                          Alex Levenson <alex@isnotinvain.com>
+sig 3        442C7FAC7C58F0FE 2015-01-08  Alex Levenson <alex@isnotinvain.com>
+sub   2048R/52B114B5E17552B7 2015-01-08
+sig          442C7FAC7C58F0FE 2015-01-08  Alex Levenson <alex@isnotinvain.com>
+
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v1
+
+mQENBFSuMHgBCADh5VSW6TlHG42jvvLiuBPr6Z4U0M5NMfem/LRaZhcx/tCZ+zp8
+4gInV6iinuzOpo1XisXM6PAXIOhF26FU7SYvomAJcWD5o0XLznkt5S3dQrp4wBAw
+fVaMLJSNrYaKdxDAw1dII45l9v/jmnhAuUoTXO1GfhuRyC4kG2lct+erNheit15o
+/NqyPYNPQP/gYWqKNSyTQVSyz0JeSsGy6UniDKH9sa4ZDTV/vZb+LCFxbOGxrkRo
+uUi0miR64ZYonpgUYZxhuPYW2F6ueK/mlUWjcAE9sEgfIadEJOuhaGHzafx8lFFG
+DftxxsBl2RfSl+/Eu8/6ml5goJIWIg5hQotRABEBAAG0JEFsZXggTGV2ZW5zb24g
+PGFsZXhAaXNub3RpbnZhaW4uY29tPokBOAQTAQIAIgUCVK4weAIbAwYLCQgHAwIG
+FQgCCQoLBBYCAwECHgECF4AACgkQRCx/rHxY8P6cxggAqnXxzfpnKZTwlDqAyLCM
+ndigeHTdBFN7M6pGrx2iVQED/I00opZKS1SBVLP7Ib+KkvDW8S5RmIGZM8/TGNId
+yAjnnvwi/Ae0ieFZSRGTZE/gsRTcD56Jabs+y7xqYAiNLjg62DfkodS7HdSD/QvQ
+jNu82S5Blq36yL1YmIlErEVdDkUsfB5usZwIGuEvPBOecGXxwqKQVfkLBoOgTyLt
+Xvm7+zTEhFp/3sYOkSiGbK9CL1Gs9YE6W7LhdSjuhYYSWZRqH6A1GyVVoFLgHDsL
+WFz4OJPm9XvPBmIVxUq8P1tHV1Z7NpvXOm1oOFlbvkLgalNZnopm4mbZ49lvCmV3
+YbkBDQRUrjB4AQgApAa4IuaNM/CAqIhXf5NxyIJHoyW2dAEOv04QlcNVyMGd4dXI
+l+cAI+NI5P8zPwJm3cneNT8/HKYWryE141cLki7mm/6bVZxkhT3ZAmXaDnjd9ihU
+JORzbZbmMnZ7BkEFXKi21Daf2nSBugcuQXMNZ5A0+/b/tF2OjhZ/ARW7DuT9A0wH
+xqqiAS4En5KD8eB9jdjAdw5jcxrcdGscP22RqCeH22UWIYj53l8bQmhkXB16AwFs
+D6dV+3O1EeTeNyKxRdhotkOFxuvgfo2gH7KtRRbjpkDGv0U9cupb3rH3LrtDxuCf
+3X4TehAoXnX6SAZZusQLsJQ7eUHFq95ygjODlwARAQABiQEfBBgBAgAJBQJUrjB4
+AhsMAAoJEEQsf6x8WPD+JkMH/2+/aDAA6bEurx2VtvXVgCE5r3mKebhR2qxG6zkf
+TnEzaYGe+9XqvI7EUjguW5Aomglxp1/qh4TWacmv7F+qA23TQqWlKFW411MWRJwl
+/ogZ43V32OWeyuZb3CTJjIG9xzFkb/FpvG3KeBuPzosUGCQYq6UK/HsbTCOdwa7u
+3I385uiihmhu3bW380bkszLg4/fuLgYO9wDMazwAjKdEqW2+EtATxKaKX+V6/b/9
+PwZpJiSt7O1BpwS2/P5OVRGNuS876GCXAHM4jqVz701fY6nbdrQl5n4HAUERmSN7
+Eo0z2Kq4VdNMaVycAinKdDoRqhe0iGXbYeZyW3fmY/7iLKc=
+=ayJr
+-----END PGP PUBLIC KEY BLOCK-----
+pub   4096R/29D94E228CAAD602 2016-11-06
+uid                          Uwe L. Korn <uwe@apache.org>
+sig          02DABFDF1679D194 2017-02-15  [User ID not found]
+sig          B78FF05799CE3652 2017-02-17  [User ID not found]
+sig 3        29D94E228CAAD602 2016-11-06  Uwe L. Korn <uwe@apache.org>
+sub   4096R/7724C82E7BD1BC86 2016-11-06
+sig          29D94E228CAAD602 2016-11-06  Uwe L. Korn <uwe@apache.org>
 
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1
@@ -425,40 +430,63 @@ ecA5fIoMfqTWAqfQr3noxB6qLLNCgZd7IIH5KXIIhJZHpO3eMCCTJuDXiMS1Z/uo
 D1FvUL8c19nmMjPJSfQo95Uynw6gZKFy0d3xg7NKUvnJBsVI24/PTVabzRrDh/qb
 RCHvQOFjXOSYsPm2sz1BPs+ucV4AoxPZFgsCfUN2t4FRbcb39vr6oYFb+Nd3sIKX
 7wknSwAid6pATvfZuLC9NI8ykjcEDGeLL0sET3kdUeuGYjpj2kuhnrV4cwARAQAB
-tBxVd2UgTC4gS29ybiA8dXdlQGFwYWNoZS5vcmc+iQI4BBMBAgAiBQJYH3eMAhsD
-BgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRAp2U4ijKrWAos1D/98UBoLbt6L
-c7mnXTww069nkt0vOOHSz/QWJxo5rQsqFSKcSRuBhwLuaVMGTjBqCOLdEmA+XKJ8
-O+OgCZz0QZXuwL3PklX3DFvsYO0wIEIssovEJMu5e3XxDcCf5ZZtfszW5dnbWTjc
-JXP0TlEbjOR5Z0/O/24iysGtoEMiktRTLOz9R5oRXFQLN4jQSykvMfKhanCVFljX
-qEdMszjtvZhLwOiCaWkIOEo3jCrCDhdThI5nTiu/pH3vi7mkFYTNKpiva3XYKH7V
-ITEdn5WO/QNFu/VBRjtOxT+F068vuuNpvAddn5rOtZOyGMCHnEqnlRnqIIZGtJeo
-EJ87N2ytn8CtKpQKhyJIJhQIfW5jS3YW8qj1HeKN2s5wqQKnBYYsJOh+/QC9g3oE
-nllgoSHAKSzys2Y1VoOQbRxYipCqRx7uS2aAqFr6r3hQpzySWeKQuxVZSZD7ar/0
-AFB0Hg4EgUGDl6Lw5icJ7scXTgoQKZWH1UmNc/FwFbG/F1GVbU88R6DlF84D1X/P
-ArtP20eT+B3u5nfO2pCaBVi6GYyMsL2WKHO7AQAgURMgEPk0AQZZpv/OSJFa/TzI
-UQ8xTLgmwZRL/XjjNFYWs+eYecGQsHKLbKNm1BpZMEfbVSFw54PiyJgoOhdMKdyA
-Cmb+aUBkbPXf5S0ScZOoq8e8k1dYseDGOLkCDQRYH3eMARAAx/joL6ScsKMmPGRn
-n79gQ3zbcKxWSfEDMYeeFfSssRgRd2iIrgvjzr9phka2yknzPnQPi7C8GLkUTj5e
-V1dBxIGkGmP28n0DoowMqGb1xqn0WeoxDL0VQycGjkv5SOkxcbCCKS/MHOn6zenh
-patSJsEHkCqk3f4GtPngYN5oMRTXUfUj1s7AooNti1ONSQSvZNbOMKAg8MgAjAHm
-z3A+INLVTa59vqUNr5ptG/n+cB65ggeNhJf3gMaDyUy7oRZtOhrmA4D9CLpy2OBA
-gezgOCZk/mPNP5jW0sbRiL6nYqC9VTp0E+f3hYSdgXNTWGIcxOwK7xe09SRqUQ7u
-WnoKBTjkkYdCaCN4rv8IhJdrufgYdfqMGuldQZ9R/gcN3Iel7JMdon2onk94KZPs
-W58/1DCD2eRuz8CsIgleUHVXJ+mCpkdtAt45ZGyv5pFC/+6s8mS/pBQEdVl7wjEX
-kf2lrtFZCfK1uUiUTDnJJdtXNhwdtvnxJYeRg51jlD9Qg/mPV6m8KFyINtLKedLv
-hChFkAIfFsdC/r1Xt4fMiCv2eZ8Dop2dM6xV/6Ueicti0lywoTpVtugSUWPO1j8a
-N48jUfkZUV0jdELNHAloZaIDeLc7mU0uZJ3JykC4laD+YDwHT8tYUvamtU2uNgh1
-V7I3jrEu8YO4T2fiXe+0EzBwzjEAEQEAAYkCHwQYAQIACQUCWB93jAIbDAAKCRAp
-2U4ijKrWAs3bD/wOE8NLnzKqebz0v+lxQf7fRL+RMaJ8mFda/t7UFtxj6XdePGZy
-HWdqlvBFSDo/K6aEiicmpEIPbMi+V7d1Dg3tGhwtkHzgbpxNVoolR+2cF4jtrkoV
-NC7uAMaDPt0X+wqinGg4E7IFuJoT4WiS+i4lzCUbD8n7lxe6Kj9bDt8tb6gOCgld
-oweGN2k3bc4hIzeRt0jqGu1xm91Zbf8YbI3vyi8WQqmxX3zugY46NWwj8a+4Mhxz
-Ysd7SI1pPs5k7vdHif3MD3Wwx68CCuZSm2KzNsm0iGxrCXSA6dXVflK9rlq6O1Us
-UTxfX60o6S8PdFr4oOPFHYXmvDU5PY575xscWB2VVAyuSCyZWtq8d1BBU9JxcozS
-6PTefVUqgr0XXRwVldAIabSA5q13j+b5+vU6LnAuoeMlFFprRlcJN03XTWKXF/gP
-SpCDscCEMbz7aHpox8wmFckeiT+TgwDLMKO5PKRSMEBErUk+SsOyBnFpuGaPsCem
-Pi6NwQyPCt3eep4Ti0dPo3u/dCUEtdKWMpOhsPIoCvGpgqS7o5PuBC2MDHQCc7q8
-wfxeCKBeSpMuy3pvOnNy8uNYjNqizVlpNBx01I2R1MD8P14Pxteg6APi0jcusXrD
-s8g7c7dzdXM0lxreeXge8JSmxuwcCqVUswac6zbX4li03m/lov2YYxCwuw==
-=ESbR
+tBxVd2UgTC4gS29ybiA8dXdlQGFwYWNoZS5vcmc+iQIcBBABAgAGBQJYpIq+AAoJ
+EALav98WedGUbV8P/j4eFGRKWvfC0XZUEJswgg6CINyWlgAsiWfnhQl6Za+Tc/sQ
+6nvI8w1fQIrrxJU760DUDpUJ3FfQIrXOivOQ1Mb+N+/drKDB3y4m+RAOvBJMgsGo
+gmNV4ts0p6NAMvXNxFDC4LEn7K8i9B75dgFab1+3mExMBl7Ltb+G8K3IlW2E9zxs
+VulLWHMoz/jDupKuKDz2n2oEjfODfEo/yIrlT82PcKPeuj/jmZMcNI0wWOTAFJ2k
+MxXN7fb3I2ap6ZaZO5xKcMFdwQi7l/IccmFIirLuGagaF2L82Q1LtLhtImLwS5OQ
+EVAcbwpexCRpZyMliAn83deBYrgIvCMRNEfLrsMMDswZ+YfFO8m9loLA3R16Tqsy
+CbPt5pXs7xK0iCQ2ZjZfvDS+7NtiOfygktBm7KA8REHE8QyTw4vlElxssivDhC7h
+Vb+i6wTr7qCEe1r5EmYKn98TFNRhVdtE9p9RFkmNi3wsuqz12Sq9Ruvn8QU6CuLs
+IwZwUwAvGtfQQNUwXaRKBa8SDQfNwXYtzOzDGnqiGZSsE4irv0nAMDUKuMImtmNv
+QKdsluD6ti4vS2HxXzNgCN8w4xwMqUSdWiTNeVu2iJzsu+sP137wpxjEJdcz1VQY
+I2VLLGYTXno+NAWrro6WR627gH47zG8gXzbChab1oDGnNglJLwsP51YdFtIMiQIz
+BBABCAAdFiEEVxSQSV4KOhk109dQt4/wV5nONlIFAlimpkQACgkQt4/wV5nONlJO
+ug//ddNB+VLJ24ZIXfS5XYXa0HE+xQUXqFl2kuiCW0ORdyP4yn1ltm4PHqRJZaJa
+UGrZ5/OMfp3S+biH0h4RjpH47B5+rqJwPe2GbBe6jyFj7E/WD3SZcCVMKav6zGzb
+JP+QrbYtr3NnWbWYRBblwd4qru6y+Kq9yz2VFmjSpzufaAz14Ts5F+y3jv8Nljut
+Hlkbe/FGt+M7Xqm0JBAp7wj6godkTQCETwH5NS/2Mu21yNuBdBKMPsOPGsC3PpSe
+qzDbeW0RKmJn/DgCkDBDdhqZSCf1FjSWbY7BIBfynPJOuzMafnxqqaAB6ncp3YP6
+7XJbKHzKqgkywUOBxPO60M30Pl3GlYz3XEUaQSWm2qHDUMJUsL2Vx8tWuZAnzBKw
+gd2rDjF4nUeDrjtQPePnDq4puuvM6WhZx4G4wjtB5hph+GYo6JGGkCMaEAafr8qt
+JtkhskYwFPL4KfIUw8g+Lg2dXf8gdNGt2kzs9Is9WEpKWGExiCDStABLfu8+hYol
+xoo2GThpteiM8JuPAFHIe++H0e3L80N/2c5YAIuHyDNzuT66igLy/SPHElvNjgTZ
+nGuS0tWX65mgLkjlGx8n1tJwAAqzoU3RKXhXVP7WyQNphnslFjsJOqwDXVrhcTtK
+z5HrlcqfmChbxqhDBsrgF6XmigLPuNzHxC5UaETq6yH3tHmJAjgEEwECACIFAlgf
+d4wCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJECnZTiKMqtYCizUP/3xQ
+Ggtu3otzuaddPDDTr2eS3S844dLP9BYnGjmtCyoVIpxJG4GHAu5pUwZOMGoI4t0S
+YD5conw746AJnPRBle7Avc+SVfcMW+xg7TAgQiyyi8Qky7l7dfENwJ/llm1+zNbl
+2dtZONwlc/ROURuM5HlnT87/biLKwa2gQyKS1FMs7P1HmhFcVAs3iNBLKS8x8qFq
+cJUWWNeoR0yzOO29mEvA6IJpaQg4SjeMKsIOF1OEjmdOK7+kfe+LuaQVhM0qmK9r
+ddgoftUhMR2flY79A0W79UFGO07FP4XTry+642m8B12fms61k7IYwIecSqeVGeog
+hka0l6gQnzs3bK2fwK0qlAqHIkgmFAh9bmNLdhbyqPUd4o3aznCpAqcFhiwk6H79
+AL2DegSeWWChIcApLPKzZjVWg5BtHFiKkKpHHu5LZoCoWvqveFCnPJJZ4pC7FVlJ
+kPtqv/QAUHQeDgSBQYOXovDmJwnuxxdOChAplYfVSY1z8XAVsb8XUZVtTzxHoOUX
+zgPVf88Cu0/bR5P4He7md87akJoFWLoZjIywvZYoc7sBACBREyAQ+TQBBlmm/85I
+kVr9PMhRDzFMuCbBlEv9eOM0Vhaz55h5wZCwcotso2bUGlkwR9tVIXDng+LImCg6
+F0wp3IAKZv5pQGRs9d/lLRJxk6irx7yTV1ix4MY4uQINBFgfd4wBEADH+OgvpJyw
+oyY8ZGefv2BDfNtwrFZJ8QMxh54V9KyxGBF3aIiuC+POv2mGRrbKSfM+dA+LsLwY
+uRROPl5XV0HEgaQaY/byfQOijAyoZvXGqfRZ6jEMvRVDJwaOS/lI6TFxsIIpL8wc
+6frN6eGlq1ImwQeQKqTd/ga0+eBg3mgxFNdR9SPWzsCig22LU41JBK9k1s4woCDw
+yACMAebPcD4g0tVNrn2+pQ2vmm0b+f5wHrmCB42El/eAxoPJTLuhFm06GuYDgP0I
+unLY4ECB7OA4JmT+Y80/mNbSxtGIvqdioL1VOnQT5/eFhJ2Bc1NYYhzE7ArvF7T1
+JGpRDu5aegoFOOSRh0JoI3iu/wiEl2u5+Bh1+owa6V1Bn1H+Bw3ch6Xskx2ifaie
+T3gpk+xbnz/UMIPZ5G7PwKwiCV5QdVcn6YKmR20C3jlkbK/mkUL/7qzyZL+kFAR1
+WXvCMReR/aWu0VkJ8rW5SJRMOckl21c2HB22+fElh5GDnWOUP1CD+Y9XqbwoXIg2
+0sp50u+EKEWQAh8Wx0L+vVe3h8yIK/Z5nwOinZ0zrFX/pR6Jy2LSXLChOlW26BJR
+Y87WPxo3jyNR+RlRXSN0Qs0cCWhlogN4tzuZTS5kncnKQLiVoP5gPAdPy1hS9qa1
+Ta42CHVXsjeOsS7xg7hPZ+Jd77QTMHDOMQARAQABiQIfBBgBAgAJBQJYH3eMAhsM
+AAoJECnZTiKMqtYCzdsP/A4Tw0ufMqp5vPS/6XFB/t9Ev5ExonyYV1r+3tQW3GPp
+d148ZnIdZ2qW8EVIOj8rpoSKJyakQg9syL5Xt3UODe0aHC2QfOBunE1WiiVH7ZwX
+iO2uShU0Lu4AxoM+3Rf7CqKcaDgTsgW4mhPhaJL6LiXMJRsPyfuXF7oqP1sO3y1v
+qA4KCV2jB4Y3aTdtziEjN5G3SOoa7XGb3Vlt/xhsje/KLxZCqbFffO6Bjjo1bCPx
+r7gyHHNix3tIjWk+zmTu90eJ/cwPdbDHrwIK5lKbYrM2ybSIbGsJdIDp1dV+Ur2u
+Wro7VSxRPF9frSjpLw90Wvig48Udhea8NTk9jnvnGxxYHZVUDK5ILJla2rx3UEFT
+0nFyjNLo9N59VSqCvRddHBWV0AhptIDmrXeP5vn69ToucC6h4yUUWmtGVwk3TddN
+YpcX+A9KkIOxwIQxvPtoemjHzCYVyR6JP5ODAMswo7k8pFIwQEStST5Kw7IGcWm4
+Zo+wJ6Y+Lo3BDI8K3d56nhOLR0+je790JQS10pYyk6Gw8igK8amCpLujk+4ELYwM
+dAJzurzB/F4IoF5Kky7Lem86c3Ly41iM2qLNWWk0HHTUjZHUwPw/Xg/G16DoA+LS
+Ny6xesOzyDtzt3N1czSXGt55eB7wlKbG7BwKpVSzBpzrNtfiWLTeb+Wi/ZhjELC7
+=9tS8
 -----END PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
Created like so:

gpg --import < KEYS 2>&1 | grep key | sed -e 's/.*"\(.*\)".*/\1/' | \
while read k; do gpg --list-sigs --keyid-format long $k; gpg --export \
--armor $k; done > newkeys