### PR TITLE
PARQUET-1133 Add int96 support by returning bytearray, Skip originalType comparison for map types when originalType is null

### DIFF
--- a/parquet-pig/src/main/java/org/apache/parquet/pig/PigSchemaConverter.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/PigSchemaConverter.java
@@ -239,7 +239,8 @@ public class PigSchemaConverter {
       @Override
       public FieldSchema convertINT96(PrimitiveTypeName primitiveTypeName)
           throws FrontendException {
-        throw new FrontendException("NYI");
+        LOG.warn("Converting type " + primitiveTypeName + " to bytearray");
+        return new FieldSchema(fieldName, null, DataType.BYTEARRAY);
       }
 
       @Override
@@ -283,7 +284,7 @@ public class PigSchemaConverter {
         }
         GroupType mapKeyValType = parquetGroupType.getType(0).asGroupType();
         if (!mapKeyValType.isRepetition(Repetition.REPEATED) ||
-            !mapKeyValType.getOriginalType().equals(OriginalType.MAP_KEY_VALUE) ||
+            (mapKeyValType.getOriginalType() != null && !mapKeyValType.getOriginalType().equals(OriginalType.MAP_KEY_VALUE)) ||
             mapKeyValType.getFieldCount()!=2) {
           throw new SchemaConversionException("Invalid map type " + parquetGroupType);
         }

--- a/parquet-pig/src/test/java/org/apache/parquet/pig/TestPigSchemaConverter.java
+++ b/parquet-pig/src/test/java/org/apache/parquet/pig/TestPigSchemaConverter.java
@@ -244,6 +244,34 @@ public class TestPigSchemaConverter {
   }
 
   @Test
+  public void testMapWithFixedWithoutOriginalType() throws Exception {
+    testFixedConversion(
+      "message spark_schema {\n" +
+      "  optional binary a;\n" +
+      "  optional group b (MAP) {\n" +
+      "    repeated group map {\n" +
+      "      required binary key;\n" +
+      "      optional group value {\n" +
+      "        optional fixed_len_byte_array(5) c;\n" +
+      "        optional fixed_len_byte_array(7) d;\n" +
+      "      }\n" +
+      "    }\n" +
+      "  }\n" +
+      "}\n",
+      "a:bytearray, b:[(c:bytearray, d:bytearray)]");
+  }
+
+  @Test
+  public void testInt96() throws Exception {
+    testFixedConversion(
+      "message spark_schema {\n" +
+        "  optional int96 datetime;\n" +
+        "}",
+      "datetime:bytearray"
+    );
+  }
+
+  @Test
   public void testAnnonymousField() throws Exception {
     testConversion(
         "a:chararray, int",


### PR DESCRIPTION
- PigSchemaConverter: Added a null check before comparing a mapKeyValueType's original type with the static constant
- PigSchemaConverter: Changed the handling of int96 types - return bytearray instead of rejecting input
- PigSchemaConverterTest: Added unit tests for int96 conversion and handling map entries without original type specified