### PR TITLE
PARQUET-41: Add bloom filter.

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -35,6 +35,9 @@ import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWrite
 import org.apache.parquet.column.values.factory.ValuesWriterFactory;
 import org.apache.parquet.schema.MessageType;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * This class represents all the configurable Parquet properties.
  *
@@ -89,12 +92,12 @@ public class ParquetProperties {
   private final ByteBufferAllocator allocator;
   private final ValuesWriterFactory valuesWriterFactory;
   private final boolean enableBloomFilter;
-  private final String bloomFilterColumnNames;
+  private final Set<String> bloomFilterColumnNames;
   private final int bloomFilterSize;
 
   private ParquetProperties(WriterVersion writerVersion, int pageSize, int dictPageSize, boolean enableDict, int minRowCountForPageSizeCheck,
                             int maxRowCountForPageSizeCheck, boolean estimateNextSizeCheck, ByteBufferAllocator allocator,
-                            ValuesWriterFactory writerFactory, boolean enableBloomFilter, String bloomFilterColumnNames, int bloomFilterSize) {
+                            ValuesWriterFactory writerFactory, boolean enableBloomFilter, Set<String> bloomFilterColumnNames, int bloomFilterSize) {
     this.pageSizeThreshold = pageSize;
     this.initialSlabSize = CapacityByteArrayOutputStream
       .initialSlabSizeHeuristic(MIN_SLAB_SIZE, pageSizeThreshold, 10);
@@ -171,7 +174,7 @@ public class ParquetProperties {
 
   public boolean isBloomFilterEnabled() {return enableBloomFilter;}
 
-  public String getBloomFilterColumnNames() {return bloomFilterColumnNames;}
+  public Set<String> getBloomFilterColumnNames() {return bloomFilterColumnNames;}
 
   public int getBloomFilterSize() {return bloomFilterSize;}
 
@@ -217,15 +220,14 @@ public class ParquetProperties {
     private boolean enableDict = DEFAULT_IS_DICTIONARY_ENABLED;
     private boolean enableBloomFilter = DEFAULT_BLOOM_FILTER_ENABLED;
     private int bloomFilterSize = DEFAULT_MAXIMUM_BLOOM_FILTER_SIZE;
-    private String bloomFilterColumnNames = null;
+    private Set<String> bloomFilterColumnNames = new HashSet<>();
     private WriterVersion writerVersion = DEFAULT_WRITER_VERSION;
     private int minRowCountForPageSizeCheck = DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK;
     private int maxRowCountForPageSizeCheck = DEFAULT_MAXIMUM_RECORD_COUNT_FOR_CHECK;
     private boolean estimateNextSizeCheck = DEFAULT_ESTIMATE_ROW_COUNT_FOR_PAGE_SIZE_CHECK;
     private ByteBufferAllocator allocator = new HeapByteBufferAllocator();
     private ValuesWriterFactory valuesWriterFactory = DEFAULT_VALUES_WRITER_FACTORY;
-
-
+    
     private Builder() {
     }
 
@@ -309,7 +311,10 @@ public class ParquetProperties {
      * @return this builder for method chaining
      */
     public Builder withBloomFilterColumnNames(String names) {
-      this.bloomFilterColumnNames = names;
+      String[] cols = names.split(",");
+      for(String col : cols) {
+        this.bloomFilterColumnNames.add(col);
+      }
       return this;
     }
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreV1.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreV1.java
@@ -18,8 +18,12 @@
  */
 package org.apache.parquet.column.impl;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeMap;
 
 import org.apache.parquet.column.values.bloom.BloomDataWriter;
 import org.apache.parquet.column.ColumnDescriptor;
@@ -56,7 +60,6 @@ public class ColumnWriteStoreV1 implements ColumnWriteStore {
 
   private ColumnWriterV1 newMemColumn(ColumnDescriptor path) {
     PageWriter pageWriter = pageWriteStore.getPageWriter(path);
-
     if (props.isBloomFilterEnabled() && props.getBloomFilterColumnNames() != null) {
       BloomDataWriter bloomDataWriter = pageWriteStore.getBloomDataWriter(path);
       return new ColumnWriterV1(path, pageWriter, bloomDataWriter, props);

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreV1.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreV1.java
@@ -18,19 +18,14 @@
  */
 package org.apache.parquet.column.impl;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
 
-import org.apache.parquet.bytes.ByteBufferAllocator;
+import org.apache.parquet.column.values.bloom.BloomDataWriter;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnWriteStore;
 import org.apache.parquet.column.ColumnWriter;
 import org.apache.parquet.column.ParquetProperties;
-import org.apache.parquet.column.ParquetProperties.WriterVersion;
 import org.apache.parquet.column.page.PageWriteStore;
 import org.apache.parquet.column.page.PageWriter;
 
@@ -61,7 +56,13 @@ public class ColumnWriteStoreV1 implements ColumnWriteStore {
 
   private ColumnWriterV1 newMemColumn(ColumnDescriptor path) {
     PageWriter pageWriter = pageWriteStore.getPageWriter(path);
-    return new ColumnWriterV1(path, pageWriter, props);
+
+    if (props.isBloomFilterEnabled() && props.getBloomFilterColumnNames() != null) {
+      BloomDataWriter bloomDataWriter = pageWriteStore.getBloomDataWriter(path);
+      return new ColumnWriterV1(path, pageWriter, bloomDataWriter, props);
+    } else {
+      return new ColumnWriterV1(path, pageWriter, props);
+    }
   }
 
   @Override

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterV2.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterV2.java
@@ -30,6 +30,8 @@ import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageWriter;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.bloom.Bloom;
+import org.apache.parquet.column.values.bloom.BloomDataWriter;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridEncoder;
 import org.apache.parquet.io.ParquetEncodingException;
 import org.apache.parquet.io.api.Binary;
@@ -56,6 +58,9 @@ final class ColumnWriterV2 implements ColumnWriter {
   private ValuesWriter dataColumn;
   private int valueCount;
 
+  private BloomDataWriter bloomDataWriter;
+  private Bloom bloomData;
+
   private Statistics<?> statistics;
   private long rowsWrittenSoFar = 0;
 
@@ -70,6 +75,24 @@ final class ColumnWriterV2 implements ColumnWriter {
     this.repetitionLevelColumn = props.newRepetitionLevelEncoder(path);
     this.definitionLevelColumn = props.newDefinitionLevelEncoder(path);
     this.dataColumn = props.newValuesWriter(path);
+  }
+
+  public ColumnWriterV2(
+    ColumnDescriptor path,
+    PageWriter pageWriter,
+    BloomDataWriter bloomDataWriter,
+    ParquetProperties props) {
+    this(path, pageWriter, props);
+
+    // Current not support nested column.
+    if (path.getPath().length == 1) {
+      this.bloomDataWriter = bloomDataWriter;
+      String bloomCols = props.getBloomFilterColumnNames();
+
+      if (bloomCols != null && bloomCols.indexOf(path.getPath()[0]) != -1) {
+        this.bloomData = Bloom.getBloomOnType(this.path.getType(), props.getBloomFilterSize());
+      }
+    }
   }
 
   private void log(Object value, int r, int d) {
@@ -137,6 +160,7 @@ final class ColumnWriterV2 implements ColumnWriter {
     definitionLevel(definitionLevel);
     dataColumn.writeDouble(value);
     statistics.updateStats(value);
+    if (bloomData != null) bloomData.insert(value);
     ++ valueCount;
   }
 
@@ -152,6 +176,7 @@ final class ColumnWriterV2 implements ColumnWriter {
     definitionLevel(definitionLevel);
     dataColumn.writeFloat(value);
     statistics.updateStats(value);
+    if (bloomData != null) bloomData.insert(value);
     ++ valueCount;
   }
 
@@ -167,6 +192,7 @@ final class ColumnWriterV2 implements ColumnWriter {
     definitionLevel(definitionLevel);
     dataColumn.writeBytes(value);
     statistics.updateStats(value);
+    if (bloomData != null) bloomData.insert(value);
     ++ valueCount;
   }
 
@@ -197,6 +223,7 @@ final class ColumnWriterV2 implements ColumnWriter {
     definitionLevel(definitionLevel);
     dataColumn.writeInteger(value);
     statistics.updateStats(value);
+    if (bloomData != null) bloomData.insert(value);
     ++ valueCount;
   }
 
@@ -212,6 +239,7 @@ final class ColumnWriterV2 implements ColumnWriter {
     definitionLevel(definitionLevel);
     dataColumn.writeLong(value);
     statistics.updateStats(value);
+    if (bloomData != null) bloomData.insert(value);
     ++ valueCount;
   }
 
@@ -230,6 +258,11 @@ final class ColumnWriterV2 implements ColumnWriter {
       }
       dataColumn.resetDictionary();
     }
+
+    if (bloomDataWriter != null && bloomData != null) {
+      bloomData.flush();
+      bloomDataWriter.writeBloomData(bloomData);
+    }
   }
 
   /**
@@ -237,9 +270,10 @@ final class ColumnWriterV2 implements ColumnWriter {
    * @return the number of bytes of memory used to buffer the current data
    */
   public long getCurrentPageBufferedSize() {
-    return repetitionLevelColumn.getBufferedSize()
-        + definitionLevelColumn.getBufferedSize()
-        + dataColumn.getBufferedSize();
+    long size = repetitionLevelColumn.getBufferedSize()
+      + definitionLevelColumn.getBufferedSize()
+      + dataColumn.getBufferedSize();
+    return bloomData == null ? size : bloomData.getBufferedSize();
   }
 
   /**
@@ -247,20 +281,22 @@ final class ColumnWriterV2 implements ColumnWriter {
    * @return the number of bytes of memory used to buffer the current data and the previously written pages
    */
   public long getTotalBufferedSize() {
-    return repetitionLevelColumn.getBufferedSize()
-        + definitionLevelColumn.getBufferedSize()
-        + dataColumn.getBufferedSize()
-        + pageWriter.getMemSize();
+    long size = repetitionLevelColumn.getBufferedSize()
+      + definitionLevelColumn.getBufferedSize()
+      + dataColumn.getBufferedSize()
+      + pageWriter.getMemSize();
+    return bloomData == null ? size : size + bloomData.getBufferedSize();
   }
 
   /**
    * @return actual memory used
    */
   public long allocatedSize() {
-    return repetitionLevelColumn.getAllocatedSize()
-    + definitionLevelColumn.getAllocatedSize()
-    + dataColumn.getAllocatedSize()
-    + pageWriter.allocatedSize();
+    long size = repetitionLevelColumn.getAllocatedSize()
+      + definitionLevelColumn.getAllocatedSize()
+      + dataColumn.getAllocatedSize()
+      + pageWriter.allocatedSize();
+    return bloomData == null ? size : size + bloomData.getAllocatedSize();
   }
 
   /**
@@ -273,6 +309,8 @@ final class ColumnWriterV2 implements ColumnWriter {
     b.append(indent).append(" d:").append(definitionLevelColumn.getAllocatedSize()).append(" bytes\n");
     b.append(dataColumn.memUsageString(indent + "  data:")).append("\n");
     b.append(pageWriter.memUsageString(indent + "  pages:")).append("\n");
+    if (bloomData != null)
+      b.append(bloomData.memUsageString(indent + " bloomData:")).append("\n");
     b.append(indent).append(String.format("  total: %,d/%,d", getTotalBufferedSize(), allocatedSize())).append("\n");
     b.append(indent).append("}\n");
     return b.toString();

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloom/Bloom.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloom/Bloom.java
@@ -1,0 +1,429 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.bloom;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import org.apache.parquet.Preconditions;
+import org.apache.parquet.bytes.*;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.io.ParquetEncodingException;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.PrimitiveType;
+
+
+/**
+ * Bloom Filter is a compat structure to indicate whether an item is not in set or probably in set. Bloom class is
+ * underlying class of Bloom Filter which stores a bit set represents elements set, hash strategy and bloom filter
+ * algorithm.
+ *
+ * Bloom Filter algorithm is implemented using block Bloom filters from Putze et al.'s "Cache-, Hash- and Space-Efficient Bloom
+ * Filters". The basic idea is to hash the item to a tiny Bloom Filter which size fit a single cache line or smaller.
+ * This implementation sets 8 bits in each tiny Bloom Filter. Tiny bloom filter are 32 bytes to take advantage of 32-bytes
+ * SIMD instruction.
+ *
+ */
+
+public abstract class Bloom<T extends Comparable<T>> {
+  public enum HASH {
+    MURMUR3_X64_128,
+  }
+
+  public enum ALGORITHM {
+    BLOCK,
+  }
+
+  public double FPP = 0.01;
+  public static int BLOOM_HEADER_SIZE = 8;
+  public final int BYTES_PER_BUCKET = 32;
+  public final int MINIMUM_BLOOM_SIZE = 256;
+
+  public final short bloomFilterHash = (short)HASH.MURMUR3_X64_128.ordinal();
+  public final short bloomFilterAlgorithm = (short)ALGORITHM.BLOCK.ordinal();
+
+  private HashSet<Long> elements = new HashSet<>();
+
+  private byte[] bitset;
+  private int numBytes;
+
+  /**
+   * Create bitset immediately if numBytes is not zero.
+   * @param numBytes
+   */
+  public Bloom(int numBytes) {
+    if (numBytes != 0)
+      initBitset(numBytes);
+  }
+
+  /**
+   * Construct the bloom filter with given bit set.
+   * @param bitset given bitset
+   */
+  public Bloom(byte[] bitset) {
+    this.bitset = bitset;
+    this.numBytes = bitset.length;
+  }
+
+  /**
+   * Construct the bloom filter with given bit set.
+   * @param input given bitset
+   */
+  public Bloom(ByteBuffer input) {
+    if (input.isDirect()){
+      bitset = new byte[input.remaining()];
+      input.get(bitset);
+    } else {
+      this.bitset = input.array();
+    }
+    this.numBytes = input.array().length;
+  }
+
+  /**
+   * Create a new allcated bit set for bloom filter, at least 256 bits will be create.
+   * @param numBytes number of bytes for bit set.
+   */
+  public void initBitset(int numBytes) {
+    Preconditions.checkArgument((numBytes & (numBytes-1)) == 0,
+      "Bloom Filter size should be power of 2");
+    if (numBytes < MINIMUM_BLOOM_SIZE) numBytes = MINIMUM_BLOOM_SIZE;
+    if (numBytes > ParquetProperties.DEFAULT_MAXIMUM_BLOOM_FILTER_SIZE)
+      numBytes = ParquetProperties.DEFAULT_MAXIMUM_BLOOM_FILTER_SIZE;
+
+    // wrap to 4 bytes align.
+    numBytes |= 0x11;
+
+    ByteBuffer bytes = ByteBuffer.allocate(numBytes).order(ByteOrder.BIG_ENDIAN);
+    this.bitset = bytes.array();
+    this.numBytes = numBytes;
+  }
+
+  /**
+   * Create bitset from a given byte array.
+   * @param bitset given bitset.
+   */
+  public void initBitset(byte[] bitset) {
+    this.bitset = bitset;
+    this.numBytes = bitset.length;
+  }
+
+  /**
+   * Get size of elements in buffer which stores in hash map.
+   */
+  public long getBufferedSize() {
+    return bitset == null ? elements.size() * 8 : elements.size() * 8 + numBytes;
+  }
+
+  /**
+   * Get bitset size.
+   * @return
+   */
+  public long getBloomSize() {
+    return numBytes;
+  }
+
+  public long getAllocatedSize() {
+    return getBufferedSize();
+  }
+
+
+  public BytesInput getBytes() throws IOException {
+    List<BytesInput> inputs= new ArrayList<>();
+
+    // number of bytes.
+    inputs.add(BytesInput.fromInt(numBytes));
+
+    // algorithm and hash
+    inputs.add(BytesInput.fromInt(0));
+
+    // bitset.
+    inputs.add(BytesInput.from(bitset, 0, bitset.length));
+
+    return BytesInput.concat(inputs);
+  }
+
+  /**
+   * Add an element which represent by hash to bloom bitset.
+   * @param hash hash result of element.
+   */
+  public void bloomInsert(long hash) {
+    // The size of one bucket is set to 32 bytes.
+    int idx = (int)(hash >> 32) & (numBytes / BYTES_PER_BUCKET - 1);
+    int key = (int)hash;
+
+    int mask[] = new int[BYTES_PER_BUCKET/4];
+    setMask(key, mask);
+
+    byte[] bucket = new byte[BYTES_PER_BUCKET];
+
+    IntBuffer intBuffer = ByteBuffer.wrap(bucket).
+      order(ByteOrder.BIG_ENDIAN).asIntBuffer();
+
+    intBuffer.put(mask);
+
+    for (int i = 0; i < BYTES_PER_BUCKET; ++i) {
+      bitset[BYTES_PER_BUCKET * idx + i] |= bucket[i];
+    }
+  }
+
+  /**
+   * Build bloom filter bitset according existing elements in buffer.
+   */
+  public void flush() {
+    if (bitset == null) {
+      initBitset(optimalNumOfBits(elements.size(), FPP)/8);
+    }
+    for (long hash : elements) {
+      bloomInsert(hash);
+    }
+    elements.clear();
+  }
+
+  /**
+   * Calculate optimal size according to the number of distinct values and false positive probability.
+   * @param n: The number of distinct values.
+   * @param p: The false positive probability.
+   * @return optimal number of bits of given n and p.
+   */
+  public static int optimalNumOfBits(long n, double p) {
+       int bits = (int)(-n * Math.log(p) / (Math.log(2) * Math.log(2)));
+
+    bits --;
+    bits |= bits >> 1;
+    bits |= bits >> 2;
+    bits |= bits >> 4;
+    bits |= bits >> 8;
+    bits |= bits >> 16;
+    bits++;
+    return bits;
+  }
+
+
+  private int[] setMask(int key, int mask[]) {
+    final int SALT[] = {0x47b6137b, 0x44974d91, 0x8824ad5b, 0xa2b7289d, 0x705495c7, 0x2df1424b, 0x9efc4947, 0x5c6bfb31};
+
+    for (int i = 0; i < 8; ++i) {
+      mask[i] = key * SALT[i];
+    }
+
+    for (int i = 0; i < 8; ++i) {
+      mask[i] = mask[i] >> 27;
+    }
+
+    for (int i = 0; i < 8; ++i) {
+      mask[i] = 0x1 << mask[i];
+    }
+    return mask;
+  }
+
+  /**
+   * Determine where an element is must not in set or probably in set.
+   * @param hash represent element
+   * @return false if element is must not in set, true if element probably in set.
+   */
+  public boolean bloomFind(long hash) {
+    int idx = (int)(hash >> 32) & (numBytes / 32 - 1);
+    int key = (int)hash;
+    int mask[] = new int[8];
+    setMask(key, mask);
+
+    IntBuffer intBuffer = ByteBuffer.wrap(bitset, 32 * idx, 32).
+      order(ByteOrder.BIG_ENDIAN).asIntBuffer();
+
+    int[] intset = new int[8];
+    intBuffer.get(intset);
+
+    for (int i = 0; i < 8; ++i) {
+      if (0 == (intset[i] & mask[i]))
+        return false;
+    }
+
+    return true;
+
+  }
+
+  /**
+   * Element is represented by hash in bloom filter. The hash function takes plain encoding of element as input.
+   */
+  public Encoding getEncoding() {
+    return Encoding.PLAIN;
+  }
+
+  public String memUsageString(String prefix) {
+    return String.format(
+      "%s BloomDataWriter{\n" + "%s}\n",
+      prefix, String.valueOf(bitset.length)
+    );
+  }
+
+  public static Bloom getBloomOnType(PrimitiveType.PrimitiveTypeName type, int size) {
+    switch(type) {
+      case INT32:
+        return new IntBloom(size);
+      case INT64:
+        return new LongBloom(size);
+      case FLOAT:
+        return new FloatBloom(size);
+      case DOUBLE:
+        return new DoubleBloom(size);
+      case BINARY:
+        return new BinaryBloom(size);
+      case INT96:
+        return new BinaryBloom(size);
+      case FIXED_LEN_BYTE_ARRAY:
+        return new BinaryBloom(size);
+
+      default:
+        return null;
+    }
+  }
+
+
+  public abstract long hash(T value);
+
+  public void insert(T value) {
+    elements.add(hash(value));
+  }
+
+  public boolean find (T value) {
+    return bloomFind(hash(value));
+  }
+
+  public static class BinaryBloom extends Bloom<Binary> {
+    private CapacityByteArrayOutputStream arrayout = new CapacityByteArrayOutputStream(1024, 64 * 1024, new HeapByteBufferAllocator());
+    private LittleEndianDataOutputStream out = new LittleEndianDataOutputStream(arrayout);
+
+    public BinaryBloom(int size) {
+      super(size);
+    }
+
+    @Override
+    public long hash(Binary value) {
+      try {
+        out.writeInt(value.length());
+        value.writeTo(out);
+        out.flush();
+        byte[] encoded = BytesInput.from(arrayout).toByteArray();
+        arrayout.reset();
+        switch (bloomFilterHash) {
+          case 0:
+          default:
+            return Murmur3.hash64(encoded);
+        }
+      } catch (IOException e) {
+        throw new ParquetEncodingException("could not insert Binary value to bloom ", e);
+      }
+    }
+  }
+
+
+  public static class LongBloom extends Bloom<Long> {
+    public ByteArrayOutputStream arrayout = new ByteArrayOutputStream(Long.SIZE/Byte.SIZE);
+    public LittleEndianDataOutputStream out = new LittleEndianDataOutputStream(arrayout);
+
+    public LongBloom (int size) {
+      super(size);
+    }
+    @Override
+    public long hash(Long value) {
+      try {
+        out.writeLong(value);
+        out.flush();
+        byte[] encoded = arrayout.toByteArray();
+        arrayout.reset();
+        return Murmur3.hash64(encoded);
+      } catch (IOException e) {
+        throw new ParquetEncodingException("could not write int", e);
+      }
+    }
+  }
+
+
+  public static class IntBloom extends Bloom<Integer> {
+    private ByteArrayOutputStream arrayout = new ByteArrayOutputStream(Integer.SIZE/Byte.SIZE);
+    private LittleEndianDataOutputStream out = new LittleEndianDataOutputStream(arrayout);
+
+    public IntBloom(int size) {
+      super(size);
+    }
+    @Override
+    public long hash(Integer value) {
+      try {
+        out.writeInt(value);
+        out.flush();
+        byte[] encoded = arrayout.toByteArray();
+        arrayout.reset();
+        return Murmur3.hash64(encoded);
+      } catch (IOException e) {
+        throw new ParquetEncodingException("could not write int", e);
+      }
+    }
+  }
+
+  public static class FloatBloom extends Bloom<Float> {
+    private ByteArrayOutputStream arrayout = new ByteArrayOutputStream(Float.SIZE/Byte.SIZE);
+    private LittleEndianDataOutputStream out = new LittleEndianDataOutputStream(arrayout);
+
+    public FloatBloom(int size) {
+      super(size);
+    }
+
+    @Override
+    public long hash(Float value) {
+      try {
+        out.writeFloat(value);
+        out.flush();
+        byte[] encoded = arrayout.toByteArray();
+        arrayout.reset();
+        return Murmur3.hash64(encoded);
+      } catch (IOException e) {
+        throw new ParquetEncodingException("could not write float", e);
+      }
+    }
+  }
+
+  public static class DoubleBloom extends Bloom<Double> {
+    private ByteArrayOutputStream arrayout = new ByteArrayOutputStream(Double.SIZE/Byte.SIZE);
+    private LittleEndianDataOutputStream out = new LittleEndianDataOutputStream(arrayout);
+
+    public DoubleBloom(int size) {
+      super(size);
+    }
+
+    @Override
+    public long hash(Double value) {
+      try {
+        out.writeDouble(value.doubleValue());
+        out.flush();
+        byte[] encoded = arrayout.toByteArray();
+        arrayout.reset();
+        return Murmur3.hash64(encoded);
+      }catch (IOException e) {
+        throw new ParquetEncodingException("count not find Double", e);
+      }
+    }
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloom/BloomDataReadStore.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloom/BloomDataReadStore.java
@@ -20,7 +20,18 @@ package org.apache.parquet.column.values.bloom;
 
 import org.apache.parquet.column.ColumnDescriptor;
 
+/**
+ * Interface to read bloom data for all the columns of a row group
+ */
+
 public interface BloomDataReadStore {
+  /**
+   * Returns a {@link Bloom} for the given column descriptor.
+   * The dictionary page bytes are uncompressed.
+   *
+   * @param path the descriptor of the column
+   * @return the bloom dta for that column, or null if there isn't one
+   */
   Bloom readBloomData(ColumnDescriptor path);
 }
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloom/BloomDataReadStore.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloom/BloomDataReadStore.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,26 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.parquet.column.page;
+package org.apache.parquet.column.values.bloom;
 
-import org.apache.parquet.column.values.bloom.BloomDataWriter;
 import org.apache.parquet.column.ColumnDescriptor;
 
-/**
- * contains all the writers for the columns in the corresponding row group
- *
- * @author Julien Le Dem
- *
- */
-public interface PageWriteStore {
-
-  /**
-   *
-   * @param path the descriptor for the column
-   * @return the corresponding page writer
-   */
-  PageWriter getPageWriter(ColumnDescriptor path);
-
-  BloomDataWriter getBloomDataWriter(ColumnDescriptor path);
-
+public interface BloomDataReadStore {
+  Bloom readBloomData(ColumnDescriptor path);
 }
+
+

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloom/BloomDataWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloom/BloomDataWriter.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,26 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.parquet.column.page;
+package org.apache.parquet.column.values.bloom;
 
-import org.apache.parquet.column.values.bloom.BloomDataWriter;
-import org.apache.parquet.column.ColumnDescriptor;
-
-/**
- * contains all the writers for the columns in the corresponding row group
- *
- * @author Julien Le Dem
- *
- */
-public interface PageWriteStore {
-
-  /**
-   *
-   * @param path the descriptor for the column
-   * @return the corresponding page writer
-   */
-  PageWriter getPageWriter(ColumnDescriptor path);
-
-  BloomDataWriter getBloomDataWriter(ColumnDescriptor path);
-
+public interface BloomDataWriter {
+  void writeBloomData(Bloom bloom);
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloom/BloomDataWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloom/BloomDataWriter.java
@@ -18,6 +18,9 @@
  */
 package org.apache.parquet.column.values.bloom;
 
+/**
+ * A bloom data writer for a given column chunk.
+ */
 public interface BloomDataWriter {
   void writeBloomData(Bloom bloom);
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloom/Murmur3.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloom/Murmur3.java
@@ -1,0 +1,333 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.column.values.bloom;
+
+/**
+ * Murmur3 is successor to Murmur2 fast non-crytographic hash algorithms.
+ *
+ * Murmur3 32 and 128 bit variants.
+ * 32-bit Java port of https://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp#94
+ * 128-bit Java port of https://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp#255
+ *
+ * This is a public domain code with no copyrights.
+ * From homepage of MurmurHash (https://code.google.com/p/smhasher/),
+ * "All MurmurHash versions are public domain software, and the author disclaims all copyright
+ * to their code."
+ */
+public class Murmur3 {
+  // from 64-bit linear congruential generator
+  public static final long NULL_HASHCODE = 2862933555777941757L;
+
+  // Constants for 32 bit variant
+  private static final int C1_32 = 0xcc9e2d51;
+  private static final int C2_32 = 0x1b873593;
+  private static final int R1_32 = 15;
+  private static final int R2_32 = 13;
+  private static final int M_32 = 5;
+  private static final int N_32 = 0xe6546b64;
+
+  // Constants for 128 bit variant
+  private static final long C1 = 0x87c37b91114253d5L;
+  private static final long C2 = 0x4cf5ad432745937fL;
+  private static final int R1 = 31;
+  private static final int R2 = 27;
+  private static final int R3 = 33;
+  private static final int M = 5;
+  private static final int N1 = 0x52dce729;
+  private static final int N2 = 0x38495ab5;
+
+  private static final int DEFAULT_SEED = 104729;
+
+  /**
+   * Murmur3 32-bit variant.
+   *
+   * @param data - input byte array
+   * @return - hashcode
+   */
+  public static int hash32(byte[] data) {
+    return hash32(data, data.length, DEFAULT_SEED);
+  }
+
+  /**
+   * Murmur3 32-bit variant.
+   *
+   * @param data   - input byte array
+   * @param length - length of array
+   * @param seed   - seed. (default 0)
+   * @return - hashcode
+   */
+  public static int hash32(byte[] data, int length, int seed) {
+    int hash = seed;
+    final int nblocks = length >> 2;
+
+    // body
+    for (int i = 0; i < nblocks; i++) {
+      int i_4 = i << 2;
+      int k = (data[i_4] & 0xff)
+        | ((data[i_4 + 1] & 0xff) << 8)
+        | ((data[i_4 + 2] & 0xff) << 16)
+        | ((data[i_4 + 3] & 0xff) << 24);
+
+      // mix functions
+      k *= C1_32;
+      k = Integer.rotateLeft(k, R1_32);
+      k *= C2_32;
+      hash ^= k;
+      hash = Integer.rotateLeft(hash, R2_32) * M_32 + N_32;
+    }
+
+    // tail
+    int idx = nblocks << 2;
+    int k1 = 0;
+    switch (length - idx) {
+      case 3:
+        k1 ^= data[idx + 2] << 16;
+      case 2:
+        k1 ^= data[idx + 1] << 8;
+      case 1:
+        k1 ^= data[idx];
+
+        // mix functions
+        k1 *= C1_32;
+        k1 = Integer.rotateLeft(k1, R1_32);
+        k1 *= C2_32;
+        hash ^= k1;
+    }
+
+    // finalization
+    hash ^= length;
+    hash ^= (hash >>> 16);
+    hash *= 0x85ebca6b;
+    hash ^= (hash >>> 13);
+    hash *= 0xc2b2ae35;
+    hash ^= (hash >>> 16);
+
+    return hash;
+  }
+
+  /**
+   * Murmur3 64-bit variant. This is essentially MSB 8 bytes of Murmur3 128-bit variant.
+   *
+   * @param data - input byte array
+   * @return - hashcode
+   */
+  public static long hash64(byte[] data) {
+    return hash64(data, data.length, DEFAULT_SEED);
+  }
+
+  public static long hash64(byte[] data, int length) {
+    return hash64(data, length, DEFAULT_SEED);
+  }
+
+  /**
+   * Murmur3 64-bit variant. This is essentially MSB 8 bytes of Murmur3 128-bit variant.
+   *
+   * @param data   - input byte array
+   * @param length - length of array
+   * @param seed   - seed. (default is 0)
+   * @return - hashcode
+   */
+  public static long hash64(byte[] data, int length, int seed) {
+    long hash = seed;
+    final int nblocks = length >> 3;
+
+    // body
+    for (int i = 0; i < nblocks; i++) {
+      final int i8 = i << 3;
+      long k = ((long) data[i8] & 0xff)
+        | (((long) data[i8 + 1] & 0xff) << 8)
+        | (((long) data[i8 + 2] & 0xff) << 16)
+        | (((long) data[i8 + 3] & 0xff) << 24)
+        | (((long) data[i8 + 4] & 0xff) << 32)
+        | (((long) data[i8 + 5] & 0xff) << 40)
+        | (((long) data[i8 + 6] & 0xff) << 48)
+        | (((long) data[i8 + 7] & 0xff) << 56);
+
+      // mix functions
+      k *= C1;
+      k = Long.rotateLeft(k, R1);
+      k *= C2;
+      hash ^= k;
+      hash = Long.rotateLeft(hash, R2) * M + N1;
+    }
+
+    // tail
+    long k1 = 0;
+    int tailStart = nblocks << 3;
+    switch (length - tailStart) {
+      case 7:
+        k1 ^= ((long) data[tailStart + 6] & 0xff) << 48;
+      case 6:
+        k1 ^= ((long) data[tailStart + 5] & 0xff) << 40;
+      case 5:
+        k1 ^= ((long) data[tailStart + 4] & 0xff) << 32;
+      case 4:
+        k1 ^= ((long) data[tailStart + 3] & 0xff) << 24;
+      case 3:
+        k1 ^= ((long) data[tailStart + 2] & 0xff) << 16;
+      case 2:
+        k1 ^= ((long) data[tailStart + 1] & 0xff) << 8;
+      case 1:
+        k1 ^= ((long) data[tailStart] & 0xff);
+        k1 *= C1;
+        k1 = Long.rotateLeft(k1, R1);
+        k1 *= C2;
+        hash ^= k1;
+    }
+
+    // finalization
+    hash ^= length;
+    hash = fmix64(hash);
+
+    return hash;
+  }
+
+  /**
+   * Murmur3 128-bit variant.
+   *
+   * @param data - input byte array
+   * @return - hashcode (2 longs)
+   */
+  public static long[] hash128(byte[] data) {
+    return hash128(data, data.length, DEFAULT_SEED);
+  }
+
+  /**
+   * Murmur3 128-bit variant.
+   *
+   * @param data   - input byte array
+   * @param length - length of array
+   * @param seed   - seed. (default is 0)
+   * @return - hashcode (2 longs)
+   */
+  public static long[] hash128(byte[] data, int length, int seed) {
+    long h1 = seed;
+    long h2 = seed;
+    final int nblocks = length >> 4;
+
+    // body
+    for (int i = 0; i < nblocks; i++) {
+      final int i16 = i << 4;
+      long k1 = ((long) data[i16] & 0xff)
+        | (((long) data[i16 + 1] & 0xff) << 8)
+        | (((long) data[i16 + 2] & 0xff) << 16)
+        | (((long) data[i16 + 3] & 0xff) << 24)
+        | (((long) data[i16 + 4] & 0xff) << 32)
+        | (((long) data[i16 + 5] & 0xff) << 40)
+        | (((long) data[i16 + 6] & 0xff) << 48)
+        | (((long) data[i16 + 7] & 0xff) << 56);
+
+      long k2 = ((long) data[i16 + 8] & 0xff)
+        | (((long) data[i16 + 9] & 0xff) << 8)
+        | (((long) data[i16 + 10] & 0xff) << 16)
+        | (((long) data[i16 + 11] & 0xff) << 24)
+        | (((long) data[i16 + 12] & 0xff) << 32)
+        | (((long) data[i16 + 13] & 0xff) << 40)
+        | (((long) data[i16 + 14] & 0xff) << 48)
+        | (((long) data[i16 + 15] & 0xff) << 56);
+
+      // mix functions for k1
+      k1 *= C1;
+      k1 = Long.rotateLeft(k1, R1);
+      k1 *= C2;
+      h1 ^= k1;
+      h1 = Long.rotateLeft(h1, R2);
+      h1 += h2;
+      h1 = h1 * M + N1;
+
+      // mix functions for k2
+      k2 *= C2;
+      k2 = Long.rotateLeft(k2, R3);
+      k2 *= C1;
+      h2 ^= k2;
+      h2 = Long.rotateLeft(h2, R1);
+      h2 += h1;
+      h2 = h2 * M + N2;
+    }
+
+    // tail
+    long k1 = 0;
+    long k2 = 0;
+    int tailStart = nblocks << 4;
+    switch (length - tailStart) {
+      case 15:
+        k2 ^= (long) (data[tailStart + 14] & 0xff) << 48;
+      case 14:
+        k2 ^= (long) (data[tailStart + 13] & 0xff) << 40;
+      case 13:
+        k2 ^= (long) (data[tailStart + 12] & 0xff) << 32;
+      case 12:
+        k2 ^= (long) (data[tailStart + 11] & 0xff) << 24;
+      case 11:
+        k2 ^= (long) (data[tailStart + 10] & 0xff) << 16;
+      case 10:
+        k2 ^= (long) (data[tailStart + 9] & 0xff) << 8;
+      case 9:
+        k2 ^= (long) (data[tailStart + 8] & 0xff);
+        k2 *= C2;
+        k2 = Long.rotateLeft(k2, R3);
+        k2 *= C1;
+        h2 ^= k2;
+
+      case 8:
+        k1 ^= (long) (data[tailStart + 7] & 0xff) << 56;
+      case 7:
+        k1 ^= (long) (data[tailStart + 6] & 0xff) << 48;
+      case 6:
+        k1 ^= (long) (data[tailStart + 5] & 0xff) << 40;
+      case 5:
+        k1 ^= (long) (data[tailStart + 4] & 0xff) << 32;
+      case 4:
+        k1 ^= (long) (data[tailStart + 3] & 0xff) << 24;
+      case 3:
+        k1 ^= (long) (data[tailStart + 2] & 0xff) << 16;
+      case 2:
+        k1 ^= (long) (data[tailStart + 1] & 0xff) << 8;
+      case 1:
+        k1 ^= (long) (data[tailStart] & 0xff);
+        k1 *= C1;
+        k1 = Long.rotateLeft(k1, R1);
+        k1 *= C2;
+        h1 ^= k1;
+    }
+
+    // finalization
+    h1 ^= length;
+    h2 ^= length;
+
+    h1 += h2;
+    h2 += h1;
+
+    h1 = fmix64(h1);
+    h2 = fmix64(h2);
+
+    h1 += h2;
+    h2 += h1;
+
+    return new long[]{h1, h2};
+  }
+
+  private static long fmix64(long h) {
+    h ^= (h >>> 33);
+    h *= 0xff51afd7ed558ccdL;
+    h ^= (h >>> 33);
+    h *= 0xc4ceb9fe1a85ec53L;
+    h ^= (h >>> 33);
+    return h;
+  }
+}

--- a/parquet-column/src/test/java/org/apache/parquet/column/mem/TestMemColumn.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/mem/TestMemColumn.java
@@ -21,6 +21,7 @@ package org.apache.parquet.column.mem;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.column.page.mem.MemPageWriter;
 import org.junit.Test;
 
 import org.apache.parquet.column.ColumnDescriptor;
@@ -116,6 +117,31 @@ public class TestMemColumn {
       assertEquals(columnReader.getCurrentRepetitionLevel(), 0);
       assertEquals(columnReader.getCurrentDefinitionLevel(), 0);
       assertEquals(columnReader.getLong(), 42);
+      columnReader.consume();
+    }
+  }
+
+  @Test
+  public void testBloomColumn() throws Exception {
+    MessageType schema = MessageTypeParser.parseMessageType("message test { required int32 foo; }");
+    ColumnDescriptor path = schema.getColumns().get(0);
+    MemPageStore memPageStore = new MemPageStore(10);
+    ColumnWriteStoreV1 memColumnsStore = new ColumnWriteStoreV1(memPageStore,
+      ParquetProperties.builder()
+        .withPageSize(2048)
+        .withDictionaryEncoding(false)
+        .withBloomFilterEnabled(true)
+        .withBloomFilterColumnNames("foo")
+        .build());
+    ColumnWriter columnWriter = memColumnsStore.getColumnWriter(path);
+    for (int i=0; i<10; i++) {
+      columnWriter.write(i, 0, 0);
+    }
+    memColumnsStore.flush();
+
+    ColumnReader columnReader = getColumnReader(memPageStore, path, schema);
+    for(int i=0; i<columnReader.getTotalValueCount(); i++) {
+      assertEquals(i, columnReader.getInteger());
       columnReader.consume();
     }
   }

--- a/parquet-column/src/test/java/org/apache/parquet/column/page/mem/MemBloomDataReader.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/page/mem/MemBloomDataReader.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,26 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.parquet.column.page;
+package org.apache.parquet.column.page.mem;
 
-import org.apache.parquet.column.values.bloom.BloomDataWriter;
+import org.apache.parquet.column.values.bloom.Bloom;
+import org.apache.parquet.column.values.bloom.BloomDataReadStore;
 import org.apache.parquet.column.ColumnDescriptor;
 
 /**
- * contains all the writers for the columns in the corresponding row group
- *
- * @author Julien Le Dem
- *
+ * Created by root on 8/16/17.
  */
-public interface PageWriteStore {
+public class MemBloomDataReader implements BloomDataReadStore {
 
-  /**
-   *
-   * @param path the descriptor for the column
-   * @return the corresponding page writer
-   */
-  PageWriter getPageWriter(ColumnDescriptor path);
-
-  BloomDataWriter getBloomDataWriter(ColumnDescriptor path);
-
+  @Override
+  public Bloom readBloomData(ColumnDescriptor path) {
+    return null;
+  }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/page/mem/MemBloomDataWriter.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/page/mem/MemBloomDataWriter.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,26 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.parquet.column.page;
+package org.apache.parquet.column.page.mem;
 
+import org.apache.parquet.column.values.bloom.Bloom;
 import org.apache.parquet.column.values.bloom.BloomDataWriter;
-import org.apache.parquet.column.ColumnDescriptor;
 
-/**
- * contains all the writers for the columns in the corresponding row group
- *
- * @author Julien Le Dem
- *
- */
-public interface PageWriteStore {
+class MemBloomDataWriter implements BloomDataWriter {
+  @Override
+  public void writeBloomData(Bloom bloom) {
 
-  /**
-   *
-   * @param path the descriptor for the column
-   * @return the corresponding page writer
-   */
-  PageWriter getPageWriter(ColumnDescriptor path);
-
-  BloomDataWriter getBloomDataWriter(ColumnDescriptor path);
-
+  }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/page/mem/MemPageStore.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/page/mem/MemPageStore.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.column.page.mem;
 
+import org.apache.parquet.column.values.bloom.BloomDataWriter;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.UnknownColumnException;
 import org.apache.parquet.column.page.DataPage;
@@ -54,6 +55,11 @@ public class MemPageStore implements PageReadStore, PageWriteStore {
       pageWriters.put(path, pageWriter);
     }
     return pageWriter;
+  }
+
+  @Override
+  public BloomDataWriter getBloomDataWriter(ColumnDescriptor path) {
+    return new MemBloomDataWriter();
   }
 
   @Override

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bloom/TestBloom.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bloom/TestBloom.java
@@ -27,6 +27,7 @@ import org.apache.parquet.column.values.RandomStr;
 import org.apache.parquet.io.api.Binary;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -46,7 +47,7 @@ public class TestBloom {
   }
 
   @Test
-  public void testBinaryBloom () throws IOException {
+  public void testBinaryBloom() throws IOException {
     Bloom.BinaryBloom binaryBloom = new Bloom.BinaryBloom(0);
     List<String> strings = new ArrayList<>();
     RandomStr randomStr = new RandomStr();
@@ -66,4 +67,10 @@ public class TestBloom {
     assertFalse(exist);
   }
 
+  @Test
+  public void testMurmur3() throws IOException {
+    byte[] bytes = {0x12, 0x34, 0x56, 0x78};
+    long hash = Murmur3.hash64(bytes);
+    assertEquals(hash, -420773712042568267l);
+  }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bloom/TestBloom.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bloom/TestBloom.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.column.values.bloom;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.parquet.column.values.RandomStr;
+import org.apache.parquet.io.api.Binary;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class TestBloom {
+  @Test
+  public void testIntBloom () throws IOException {
+    Bloom.IntBloom intBloom = new Bloom.IntBloom(0);
+    for(int i = 0; i<10; i++) {
+      intBloom.insert(i);
+    }
+
+    intBloom.flush();
+    for(int i = 0; i<10; i++) {
+      assertTrue(intBloom.find(i));
+    }
+  }
+
+  @Test
+  public void testBinaryBloom () throws IOException {
+    Bloom.BinaryBloom binaryBloom = new Bloom.BinaryBloom(0);
+    List<String> strings = new ArrayList<>();
+    RandomStr randomStr = new RandomStr();
+    for(int i = 0; i<10000; i++) {
+      String str = randomStr.get(10);
+      strings.add(str);
+      binaryBloom.insert(Binary.fromString(str));
+    }
+
+    binaryBloom.flush();
+    for(int i = 0; i<strings.size(); i++) {
+      assertTrue(binaryBloom.find(Binary.fromString(strings.get(i))));
+    }
+
+    // exist can be true in a very low probability.
+    boolean exist = binaryBloom.find(Binary.fromString("not exist"));
+    assertFalse(exist);
+  }
+
+}

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bloom/TestBloom.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bloom/TestBloom.java
@@ -20,6 +20,8 @@
 package org.apache.parquet.column.values.bloom;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 public class TestBloom {
   @Test
   public void testIntBloom () throws IOException {
-    Bloom.IntBloom intBloom = new Bloom.IntBloom(0);
+    Bloom.IntBloom intBloom = new Bloom.IntBloom(0, Bloom.HASH.MURMUR3_X64_128, Bloom.ALGORITHM.BLOCK);
     for(int i = 0; i<10; i++) {
       intBloom.insert(i);
     }
@@ -48,7 +50,7 @@ public class TestBloom {
 
   @Test
   public void testBinaryBloom() throws IOException {
-    Bloom.BinaryBloom binaryBloom = new Bloom.BinaryBloom(0);
+    Bloom.BinaryBloom binaryBloom = new Bloom.BinaryBloom(0, Bloom.HASH.MURMUR3_X64_128, Bloom.ALGORITHM.BLOCK);
     List<String> strings = new ArrayList<>();
     RandomStr randomStr = new RandomStr();
     for(int i = 0; i<10000; i++) {
@@ -72,5 +74,6 @@ public class TestBloom {
     byte[] bytes = {0x12, 0x34, 0x56, 0x78};
     long hash = Murmur3.hash64(bytes);
     assertEquals(hash, -420773712042568267l);
+
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/BloomFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/BloomFilter.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.filter2;
+
+
+import org.apache.parquet.column.values.bloom.Bloom;
+import org.apache.parquet.column.values.bloom.BloomDataReadStore;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.filter2.predicate.Operators;
+import org.apache.parquet.filter2.predicate.UserDefinedPredicate;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.parquet.Preconditions.checkNotNull;
+
+public class BloomFilter implements FilterPredicate.Visitor<Boolean>{
+  private static final boolean BLOCK_MIGHT_MATCH = false;
+  private static final boolean BLOCK_CANNOT_MATCH = true;
+
+  private final Map<ColumnPath, ColumnChunkMetaData> columns = new HashMap<ColumnPath, ColumnChunkMetaData>();
+
+  public static boolean canDrop(FilterPredicate pred, List<ColumnChunkMetaData> columns, BloomDataReadStore bloomFilterReader) {
+    checkNotNull(pred, "pred");
+    checkNotNull(columns, "columns");
+    return pred.accept(new BloomFilter(columns, bloomFilterReader));
+  }
+
+  private BloomFilter(List<ColumnChunkMetaData> columnsList, BloomDataReadStore bloomFilterReader) {
+    for (ColumnChunkMetaData chunk : columnsList) {
+      columns.put(chunk.getPath(), chunk);
+    }
+
+    this.bloomFilterReader = bloomFilterReader;
+  }
+
+  private BloomDataReadStore bloomFilterReader;
+
+  private ColumnChunkMetaData getColumnChunk(ColumnPath columnPath) {
+    return columns.get(columnPath);
+  }
+
+  // is this column chunk composed entirely of nulls?
+  // assumes the column chunk's statistics is not empty
+  private boolean isAllNulls(ColumnChunkMetaData column) {
+    return column.getStatistics().getNumNulls() == column.getValueCount();
+  }
+
+  // are there any nulls in this column chunk?
+  // assumes the column chunk's statistics is not empty
+  private boolean hasNulls(ColumnChunkMetaData column) {
+    return column.getStatistics().getNumNulls() > 0;
+  }
+
+  @Override
+  public <T extends Comparable<T>> Boolean visit(Operators.Eq<T> eq) {
+    T value = eq.getValue();
+
+    if (value == null) {
+      // the bloom filter bitset contains only non-null values so isn't helpful. this
+      // could check the column stats, but the StatisticsFilter is responsible
+      return BLOCK_MIGHT_MATCH;
+    }
+
+    Operators.Column<T> filterColumn = eq.getColumn();
+    ColumnChunkMetaData meta = getColumnChunk(filterColumn.getColumnPath());
+    ColumnDescriptor col = new ColumnDescriptor(meta.getPath().toArray(), meta.getType(), -1, -1);
+    if (meta == null) {
+      // the column isn't in this file so all values are null, but the value
+      // must be non-null because of the above check.
+      return BLOCK_CANNOT_MATCH;
+    }
+
+    Bloom bloom = bloomFilterReader.readBloomData(col);
+    if (bloom != null && bloom.find(value) == false) {
+      return BLOCK_CANNOT_MATCH;
+    }
+
+    return BLOCK_MIGHT_MATCH;
+  }
+
+  @Override
+  public <T extends Comparable<T>> Boolean visit(Operators.NotEq<T> notEq) {
+    Operators.Column<T> filterColumn = notEq.getColumn();
+    ColumnChunkMetaData meta = getColumnChunk(filterColumn.getColumnPath());
+
+    T value = notEq.getValue();
+
+    if (meta == null) {
+      if (value == null) {
+        // null is always equal to null
+        return BLOCK_CANNOT_MATCH;
+      }
+      return BLOCK_MIGHT_MATCH;
+    }
+
+    if (value == null) {
+      // we are looking for records where v notEq(null)
+      // so, if this is a column of all nulls, we can drop it
+      return isAllNulls(meta);
+    }
+
+    return BLOCK_MIGHT_MATCH;
+  }
+
+  @Override
+  public <T extends Comparable<T>> Boolean visit(Operators.Lt<T> lt) {
+    return BLOCK_MIGHT_MATCH;
+  }
+
+  @Override
+  public <T extends Comparable<T>> Boolean visit(Operators.LtEq<T> ltEq) {
+    return BLOCK_MIGHT_MATCH;
+  }
+
+  @Override
+  public <T extends Comparable<T>> Boolean visit(Operators.Gt<T> gt) {
+    return BLOCK_MIGHT_MATCH;
+  }
+
+  @Override
+  public <T extends Comparable<T>> Boolean visit(Operators.GtEq<T> gtEq) {
+    return BLOCK_MIGHT_MATCH;
+  }
+
+  @Override
+  public Boolean visit(Operators.And and) {
+    return and.getLeft().accept(this) || and.getRight().accept(this);
+  }
+
+  @Override
+  public Boolean visit(Operators.Or or) {
+    return or.getLeft().accept(this) && or.getRight().accept(this);
+  }
+
+  @Override
+  public Boolean visit(Operators.Not not) {
+    throw new IllegalArgumentException(
+      "This predicate contains a not! Did you forget to run this predicate through LogicalInverseRewriter? " + not);
+  }
+
+
+  private <T extends Comparable<T>, U extends UserDefinedPredicate<T>> Boolean visit(Operators.UserDefined<T, U> ud, boolean inverted) {
+    Operators.Column<T> filterColumn = ud.getColumn();
+    ColumnChunkMetaData columnChunk = getColumnChunk(filterColumn.getColumnPath());
+    U udp = ud.getUserDefinedPredicate();
+
+    if (columnChunk == null) {
+      // the column isn't in this file so all values are null.
+      // lets run the udp with null value to see if it keeps null or not.
+      if (inverted) {
+        return udp.keep(null);
+      } else {
+        return !udp.keep(null);
+      }
+    }
+
+    if (isAllNulls(columnChunk)) {
+      // lets run the udp with null value to see if it keeps null or not.
+      if (inverted) {
+        return udp.keep(null);
+      } else {
+        return !udp.keep(null);
+      }
+    }
+
+     return BLOCK_MIGHT_MATCH;
+  }
+
+
+  @Override
+  public <T extends Comparable<T>, U extends UserDefinedPredicate<T>> Boolean visit(Operators.UserDefined<T, U> udp) {
+    return visit(udp, false);
+  }
+
+  @Override
+  public <T extends Comparable<T>, U extends UserDefinedPredicate<T>> Boolean visit(Operators.LogicalNotUserDefined<T, U> udp) {
+    return visit(udp.getUserDefined(), true);
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/BloomFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/BloomFilter.java
@@ -93,7 +93,7 @@ public class BloomFilter implements FilterPredicate.Visitor<Boolean>{
     }
 
     Bloom bloom = bloomFilterReader.readBloomData(col);
-    if (bloom != null && bloom.find(value) == false) {
+    if (bloom != null && !bloom.find(value)) {
       return BLOCK_CANNOT_MATCH;
     }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -199,6 +199,7 @@ public class ParquetMetadataConverter {
           columnMetaData.getTotalSize(),
           columnMetaData.getFirstDataPageOffset());
       columnChunk.meta_data.dictionary_page_offset = columnMetaData.getDictionaryPageOffset();
+      columnChunk.meta_data.setBloom_filter_offset(columnMetaData.getBloomFilterDataOffset());
       if (!columnMetaData.getStatistics().isEmpty()) {
         columnChunk.meta_data.setStatistics(toParquetStatistics(columnMetaData.getStatistics()));
       }
@@ -829,6 +830,7 @@ public class ParquetMetadataConverter {
                   messageType.getType(path.toArray()).asPrimitiveType()),
               metaData.data_page_offset,
               metaData.dictionary_page_offset,
+              metaData.bloom_filter_offset,
               metaData.num_values,
               metaData.total_compressed_size,
               metaData.total_uncompressed_size);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/BloomDataReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/BloomDataReader.java
@@ -30,6 +30,12 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * A {@link BloomDataReadStore} implementation that reads bloom data from
+ * an open {@link ParquetFileReader}.
+ *
+ */
+
 public class BloomDataReader implements BloomDataReadStore {
   private final ParquetFileReader reader;
   private final Map<String, ColumnChunkMetaData> columns;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/BloomDataReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/BloomDataReader.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import org.apache.parquet.Strings;
+import org.apache.parquet.column.values.bloom.Bloom;
+import org.apache.parquet.column.values.bloom.BloomDataReadStore;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.io.ParquetDecodingException;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BloomDataReader implements BloomDataReadStore {
+  private final ParquetFileReader reader;
+  private final Map<String, ColumnChunkMetaData> columns;
+  private final Map<String, Bloom> cache = new HashMap<>();
+
+  public BloomDataReader(ParquetFileReader fileReader, BlockMetaData block) {
+    this.reader = fileReader;
+    this.columns = new HashMap<>();
+    for (ColumnChunkMetaData column : block.getColumns()) {
+      columns.put(column.getPath().toDotString(), column);
+    }
+  }
+
+  @Override
+  public Bloom readBloomData(ColumnDescriptor descriptor) {
+    String dotPath = Strings.join(descriptor.getPath(), ".");
+    ColumnChunkMetaData column = columns.get(dotPath);
+    if (column == null) {
+      throw new ParquetDecodingException(
+        "Cannot load Bloom data, unknown column: " + dotPath);
+    }
+
+    if (cache.containsKey(dotPath)) {
+      return cache.get(dotPath);
+    }
+
+    try {
+      synchronized (cache) {
+        if (!cache.containsKey(dotPath)) {
+          Bloom bloom = reader.readBloomData(column);
+          if (bloom == null) return null;
+          cache.put(dotPath, bloom);
+        }
+      }
+
+      return cache.get(dotPath);
+    } catch (IOException e) {
+      throw new ParquetDecodingException(
+        "Failed to read Bloom data", e);
+    }
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
@@ -31,6 +31,8 @@ import java.util.Set;
 
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.ConcatenatingByteArrayCollector;
+import org.apache.parquet.column.values.bloom.Bloom;
+import org.apache.parquet.column.values.bloom.BloomDataWriter;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DictionaryPage;
@@ -50,7 +52,7 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
 
   private static ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();
 
-  private static final class ColumnChunkPageWriter implements PageWriter {
+  private static final class ColumnChunkPageWriter implements PageWriter, BloomDataWriter {
 
     private final ColumnDescriptor path;
     private final BytesCompressor compressor;
@@ -58,6 +60,7 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
     private final ByteArrayOutputStream tempOutputStream = new ByteArrayOutputStream();
     private final ConcatenatingByteArrayCollector buf;
     private DictionaryPage dictionaryPage;
+    private Bloom bloomData;
 
     private long uncompressedLength;
     private long compressedLength;
@@ -190,6 +193,13 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
       }
       writer.writeDataPages(buf, uncompressedLength, compressedLength, totalStatistics,
           rlEncodings, dlEncodings, dataEncodings);
+
+      // update bloom filter offset.
+      // TODO: should we skip when dictionary page exist?
+      if (bloomData != null) {
+        writer.writeBloomFilter(bloomData);
+      }
+
       writer.endColumn();
       if (LOG.isDebugEnabled()) {
         LOG.debug(
@@ -228,6 +238,11 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
       return buf.memUsageString(prefix + " ColumnChunkPageWriter");
     }
 
+    @Override
+    public void writeBloomData(Bloom bloom) {
+      this.bloomData = bloom;
+    }
+
   }
 
   private final Map<ColumnDescriptor, ColumnChunkPageWriter> writers = new HashMap<ColumnDescriptor, ColumnChunkPageWriter>();
@@ -242,6 +257,11 @@ class ColumnChunkPageWriteStore implements PageWriteStore {
 
   @Override
   public PageWriter getPageWriter(ColumnDescriptor path) {
+    return writers.get(path);
+  }
+
+  @Override
+  public BloomDataWriter getBloomDataWriter(ColumnDescriptor path) {
     return writers.get(path);
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -21,6 +21,7 @@ package org.apache.parquet.hadoop;
 import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndian;
 import static org.apache.parquet.filter2.compat.RowGroupFilter.FilterLevel.DICTIONARY;
 import static org.apache.parquet.filter2.compat.RowGroupFilter.FilterLevel.STATISTICS;
+import static org.apache.parquet.filter2.compat.RowGroupFilter.FilterLevel.BLOOM;
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.SKIP_ROW_GROUPS;
 import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
@@ -30,11 +31,15 @@ import static org.apache.parquet.hadoop.ParquetInputFormat.DICTIONARY_FILTERING_
 import static org.apache.parquet.hadoop.ParquetInputFormat.DICTIONARY_FILTERING_ENABLED_DEFAULT;
 import static org.apache.parquet.hadoop.ParquetInputFormat.STATS_FILTERING_ENABLED;
 import static org.apache.parquet.hadoop.ParquetInputFormat.STATS_FILTERING_ENABLED_DEFAULT;
+import static org.apache.parquet.hadoop.ParquetInputFormat.BLOOM_FILTER_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.BLOOM_FILTER_ENABLED_DEFAULT;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.SequenceInputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,7 +56,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -60,6 +64,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.bloom.Bloom;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DictionaryPageReadStore;
 import org.apache.parquet.filter2.compat.FilterCompat;
@@ -658,6 +663,10 @@ public class ParquetFileReader implements Closeable {
       levels.add(DICTIONARY);
     }
 
+    if (conf.getBoolean(BLOOM_FILTER_ENABLED, BLOOM_FILTER_ENABLED_DEFAULT)) {
+      levels.add(BLOOM);
+    }
+
     this.blocks = RowGroupFilter.filterRowGroups(levels, filter, blocks, this);
   }
 
@@ -759,6 +768,9 @@ public class ParquetFileReader implements Closeable {
     return new DictionaryPageReader(this, block);
   }
 
+  public BloomDataReader getBloomDataReader(BlockMetaData block) {
+    return new BloomDataReader(this, block);
+  }
   /**
    * Reads and decompresses a dictionary page for the given column chunk.
    *
@@ -808,6 +820,28 @@ public class ParquetFileReader implements Closeable {
     return new DictionaryPage(
         bin, uncompressedPageSize, dictHeader.getNum_values(),
         converter.getEncoding(dictHeader.getEncoding()));
+  }
+
+  public Bloom readBloomData(ColumnChunkMetaData meta) throws IOException {
+    long bloomDataOffset = meta.getBloomFilterDataOffset();
+
+    // Bloom data is stored at end of row group, so offset can not be null.
+    if (bloomDataOffset == 0) return null;
+    f.seek(bloomDataOffset);
+
+    // Read bloom data header.
+    byte[] bytes = new byte[Bloom.BLOOM_HEADER_SIZE];
+    f.read(bytes);
+    ByteBuffer bloomHeader = ByteBuffer.wrap(bytes);
+    int numBytes = bloomHeader.order(ByteOrder.LITTLE_ENDIAN).asIntBuffer().get(0);
+
+    byte[] bitset = new byte[numBytes];
+    f.readFully(bitset);
+
+    Bloom bloom = Bloom.getBloomOnType(meta.getType(), 0);
+    bloom.initBitset(bitset);
+
+    return bloom;
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -45,6 +45,7 @@ import org.apache.parquet.Strings;
 import org.apache.parquet.Version;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.column.values.bloom.Bloom;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.EncodingStats;
@@ -134,6 +135,7 @@ public class ParquetFileWriter {
   private long currentChunkValueCount;            // set in startColumn
   private long currentChunkFirstDataPage;         // set in startColumn (out.pos())
   private long currentChunkDictionaryPageOffset;  // set in writeDictionaryPage
+  private long currentChunkBloomFilterDataOffset; // set in writeBloomData
 
   /**
    * Captures the order in which methods should be called
@@ -345,6 +347,14 @@ public class ParquetFileWriter {
   }
 
 
+  public void writeBloomFilter(Bloom bloom) throws IOException {
+    state = state.write();
+    LOG.debug("{}: write bloom filter data : {} values", out.getPos(), bloom.getBloomSize());
+    currentChunkBloomFilterDataOffset = out.getPos();
+    bloom.getBytes().writeAllTo(out);
+  }
+
+
   /**
    * writes a single page
    * @param valueCount count of values
@@ -470,6 +480,7 @@ public class ParquetFileWriter {
         currentStatistics,
         currentChunkFirstDataPage,
         currentChunkDictionaryPageOffset,
+        currentChunkBloomFilterDataOffset,
         currentChunkValueCount,
         compressedLength,
         uncompressedLength));
@@ -579,6 +590,7 @@ public class ParquetFileWriter {
           chunk.getStatistics(),
           newChunkStart,
           newChunkStart,
+          chunk.getBloomFilterDataOffset(),
           chunk.getValueCount(),
           chunk.getTotalSize(),
           chunk.getTotalUncompressedSize()));

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -134,6 +134,9 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
   public static final String DICTIONARY_FILTERING_ENABLED = "parquet.filter.dictionary.enabled";
   static final boolean DICTIONARY_FILTERING_ENABLED_DEFAULT = false;
 
+  public static final String BLOOM_FILTER_ENABLED = "parquet.filter.bloom.enabled";
+  static final boolean BLOOM_FILTER_ENABLED_DEFAULT = false;
+
   /**
    * key to turn on or off task side metadata loading (default true)
    * if true then metadata is read on the task side and some tasks may finish immediately.

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -134,7 +134,8 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
   public static final String DICTIONARY_FILTERING_ENABLED = "parquet.filter.dictionary.enabled";
   static final boolean DICTIONARY_FILTERING_ENABLED_DEFAULT = false;
 
-  public static final String BLOOM_FILTER_ENABLED = "parquet.filter.bloom.enabled";
+  // TODO naming
+  public static final String BLOOM_FILTERING_ENABLED = "parquet.filter.bloom.enabled";
   static final boolean BLOOM_FILTER_ENABLED_DEFAULT = false;
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -144,6 +144,9 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static final String MIN_ROW_COUNT_FOR_PAGE_SIZE_CHECK = "parquet.page.size.row.check.min";
   public static final String MAX_ROW_COUNT_FOR_PAGE_SIZE_CHECK = "parquet.page.size.row.check.max";
   public static final String ESTIMATE_PAGE_SIZE_CHECK = "parquet.page.size.check.estimate";
+  public static final String BLOOM_FILTER_COLUMN_NAMES = "parquet.bloom.filter.column.names";
+  public static final String BLOOM_FILTER_SIZE = "parquet.bloom.filter.size";
+  public static final String ENABLE_BLOOM_FILTER = "parquet.enable.bloom.filter";
 
   public static JobSummaryLevel getJobSummaryLevel(Configuration conf) {
     String level = conf.get(JOB_SUMMARY_LEVEL);
@@ -209,6 +212,14 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
     return getEnableDictionary(getConfiguration(jobContext));
   }
 
+  public static void setBloomFilterColumnNames(Job job, String names) {
+    getConfiguration(job).set(BLOOM_FILTER_COLUMN_NAMES, names);
+  }
+
+  public static String getBloomFilterColumnNames(JobContext jobContext) {
+    return getBloomFilterColumnNames(getConfiguration(jobContext));
+  }
+
   public static int getBlockSize(JobContext jobContext) {
     return getBlockSize(getConfiguration(jobContext));
   }
@@ -240,6 +251,19 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static boolean getEnableDictionary(Configuration configuration) {
     return configuration.getBoolean(
         ENABLE_DICTIONARY, ParquetProperties.DEFAULT_IS_DICTIONARY_ENABLED);
+  }
+
+  public static String getBloomFilterColumnNames(Configuration conf) {
+    return conf.get(BLOOM_FILTER_COLUMN_NAMES);
+  }
+
+  public static boolean getEnableBloomFilter(Configuration configuration) {
+    return configuration.getBoolean(ENABLE_BLOOM_FILTER,
+      ParquetProperties.DEFAULT_BLOOM_FILTER_ENABLED);
+  }
+
+  public static int getBloomFilterSize(Configuration configuration) {
+    return configuration.getInt(BLOOM_FILTER_SIZE, 0);
   }
 
   public static int getMinRowCountForPageSizeCheck(Configuration configuration) {
@@ -358,6 +382,9 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
     ParquetProperties props = ParquetProperties.builder()
         .withPageSize(getPageSize(conf))
         .withDictionaryPageSize(getDictionaryPageSize(conf))
+        .withBloomFilterEnabled(getEnableBloomFilter(conf))
+        .withBloomFilterSize(getBloomFilterSize(conf))
+        .withBloomFilterColumnNames(getBloomFilterColumnNames(conf))
         .withDictionaryEncoding(getEnableDictionary(conf))
         .withWriterVersion(getWriterVersion(conf))
         .estimateRowCountForPageSizeCheck(getEstimatePageSizeCheck(conf))
@@ -380,6 +407,9 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
       LOG.info("Page size checking is: {}", (props.estimateNextSizeCheck() ? "estimated" : "constant"));
       LOG.info("Min row count for page size check is: {}", props.getMinRowCountForPageSizeCheck());
       LOG.info("Max row count for page size check is: {}", props.getMaxRowCountForPageSizeCheck());
+      LOG.info("Parquet Bloom Filter is {}", props.isBloomFilterEnabled()? "on": "off");
+      LOG.info("Parquet bloom filter size for one column is: {}", props.getBloomFilterSize());
+      LOG.info("Parquet bloom filter columns are: {}", props.getBloomFilterColumnNames());
     }
 
     WriteContext init = writeSupport.init(conf);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordReader.java
@@ -177,7 +177,6 @@ public class ParquetRecordReader<T> extends RecordReader<Void, T> {
       }
 
     } else {
-      // apply data filters
       reader.filterRowGroups(getFilter(configuration));
     }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java
@@ -40,12 +40,13 @@ abstract public class ColumnChunkMetaData {
       Set<Encoding> encodings,
       long firstDataPage,
       long dictionaryPageOffset,
+      long bloomFilterDataOffset,
       long valueCount,
       long totalSize,
       long totalUncompressedSize) {
     return get(
         path, type, codec, null, encodings, new BooleanStatistics(), firstDataPage,
-        dictionaryPageOffset, valueCount, totalSize, totalUncompressedSize);
+        dictionaryPageOffset, bloomFilterDataOffset, valueCount, totalSize, totalUncompressedSize);
   }
 
   @Deprecated
@@ -57,12 +58,13 @@ abstract public class ColumnChunkMetaData {
       Statistics statistics,
       long firstDataPage,
       long dictionaryPageOffset,
+      long bloomFilterDataOffset,
       long valueCount,
       long totalSize,
       long totalUncompressedSize) {
     return get(
         path, type, codec, null, encodings, statistics, firstDataPage, dictionaryPageOffset,
-        valueCount, totalSize, totalUncompressedSize);
+        bloomFilterDataOffset, valueCount, totalSize, totalUncompressedSize);
   }
 
   public static ColumnChunkMetaData get(
@@ -74,6 +76,7 @@ abstract public class ColumnChunkMetaData {
       Statistics statistics,
       long firstDataPage,
       long dictionaryPageOffset,
+      long bloomFilterDataOffset,
       long valueCount,
       long totalSize,
       long totalUncompressedSize) {
@@ -89,6 +92,7 @@ abstract public class ColumnChunkMetaData {
           statistics,
           firstDataPage,
           dictionaryPageOffset,
+          bloomFilterDataOffset,
           valueCount,
           totalSize,
           totalUncompressedSize);
@@ -99,6 +103,7 @@ abstract public class ColumnChunkMetaData {
           statistics,
           firstDataPage,
           dictionaryPageOffset,
+          bloomFilterDataOffset,
           valueCount,
           totalSize,
           totalUncompressedSize);
@@ -172,6 +177,11 @@ abstract public class ColumnChunkMetaData {
   abstract public long getDictionaryPageOffset();
 
   /**
+   * @return the location of the bloom filter data if any
+   */
+  abstract public long getBloomFilterDataOffset();
+
+  /**
    * @return count of values in this block of the column
    */
   abstract public long getValueCount();
@@ -190,6 +200,7 @@ abstract public class ColumnChunkMetaData {
    * @return the stats for this column
    */
   abstract public Statistics getStatistics();
+
 
   /**
    * @return all the encodings used in this column
@@ -212,6 +223,7 @@ class IntColumnChunkMetaData extends ColumnChunkMetaData {
 
   private final int firstDataPage;
   private final int dictionaryPageOffset;
+  private final int bloomFilterDataOffset;
   private final int valueCount;
   private final int totalSize;
   private final int totalUncompressedSize;
@@ -238,12 +250,14 @@ class IntColumnChunkMetaData extends ColumnChunkMetaData {
       Statistics statistics,
       long firstDataPage,
       long dictionaryPageOffset,
+      long bloomFilterDataOffset,
       long valueCount,
       long totalSize,
       long totalUncompressedSize) {
     super(encodingStats, ColumnChunkProperties.get(path, type, codec, encodings));
     this.firstDataPage = positiveLongToInt(firstDataPage);
     this.dictionaryPageOffset = positiveLongToInt(dictionaryPageOffset);
+    this.bloomFilterDataOffset = positiveLongToInt(bloomFilterDataOffset);
     this.valueCount = positiveLongToInt(valueCount);
     this.totalSize = positiveLongToInt(totalSize);
     this.totalUncompressedSize = positiveLongToInt(totalUncompressedSize);
@@ -285,6 +299,8 @@ class IntColumnChunkMetaData extends ColumnChunkMetaData {
     return intToPositiveLong(dictionaryPageOffset);
   }
 
+  public long getBloomFilterDataOffset() { return intToPositiveLong(bloomFilterDataOffset);}
+
   /**
    * @return count of values in this block of the column
    */
@@ -317,6 +333,7 @@ class LongColumnChunkMetaData extends ColumnChunkMetaData {
 
   private final long firstDataPageOffset;
   private final long dictionaryPageOffset;
+  private final long bloomFilterDataOffset;
   private final long valueCount;
   private final long totalSize;
   private final long totalUncompressedSize;
@@ -343,12 +360,14 @@ class LongColumnChunkMetaData extends ColumnChunkMetaData {
       Statistics statistics,
       long firstDataPageOffset,
       long dictionaryPageOffset,
+      long bloomFilterDataOffset,
       long valueCount,
       long totalSize,
       long totalUncompressedSize) {
     super(encodingStats, ColumnChunkProperties.get(path, type, codec, encodings));
     this.firstDataPageOffset = firstDataPageOffset;
     this.dictionaryPageOffset = dictionaryPageOffset;
+    this.bloomFilterDataOffset = bloomFilterDataOffset;
     this.valueCount = valueCount;
     this.totalSize = totalSize;
     this.totalUncompressedSize = totalUncompressedSize;
@@ -368,6 +387,8 @@ class LongColumnChunkMetaData extends ColumnChunkMetaData {
   public long getDictionaryPageOffset() {
     return dictionaryPageOffset;
   }
+
+  public long getBloomFilterDataOffset() {return bloomFilterDataOffset;}
 
   /**
    * @return count of values in this block of the column

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/statisticslevel/TestStatisticsFilter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/statisticslevel/TestStatisticsFilter.java
@@ -68,7 +68,7 @@ public class TestStatisticsFilter {
         CompressionCodecName.GZIP,
         new HashSet<Encoding>(Arrays.asList(Encoding.PLAIN)),
         stats,
-        0L, 0L, valueCount, 0L, 0L);
+        0L, 0L, 0L, valueCount, 0L, 0L);
   }
 
   private static ColumnChunkMetaData getDoubleColumnMeta(DoubleStatistics stats, long valueCount) {
@@ -77,7 +77,7 @@ public class TestStatisticsFilter {
         CompressionCodecName.GZIP,
         new HashSet<Encoding>(Arrays.asList(Encoding.PLAIN)),
         stats,
-        0L, 0L, valueCount, 0L, 0L);
+        0L, 0L, 0L, valueCount, 0L, 0L);
   }
 
   private static final IntColumn intColumn = intColumn("int.column");

--- a/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
@@ -327,7 +327,7 @@ public class TestParquetMetadataConverter {
     CompressionCodecName c = CompressionCodecName.GZIP;
     BinaryStatistics s = new BinaryStatistics();
     ColumnChunkMetaData md = ColumnChunkMetaData.get(p, t, c, e, s,
-            0, 0, 0, 0, 0);
+            0, 0, 0, 0, 0, 0);
     return md;
   }
   

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputFormat.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputFormat.java
@@ -340,7 +340,7 @@ public class TestInputFormat {
         CompressionCodecName.GZIP,
         new HashSet<Encoding>(Arrays.asList(Encoding.PLAIN)),
         stats,
-        100l, 100l, valueCount, 100l, 100l);
+        100l, 0l, 100l, valueCount, 100l, 100l);
     blockMetaData.addColumn(column);
     blockMetaData.setTotalByteSize(200l);
     blockMetaData.setRowCount(valueCount);
@@ -550,7 +550,7 @@ public class TestInputFormat {
                                                          CompressionCodecName.GZIP,
                                                          new HashSet<Encoding>(Arrays.asList(Encoding.PLAIN)),
                                                          new BinaryStatistics(),
-                                                         start, 0l, 0l, compressedBlockSize, uncompressedSize);
+                                                         start, 0l, 0l, 0l, compressedBlockSize, uncompressedSize);
     blockMetaData.addColumn(column);
     blockMetaData.setTotalByteSize(uncompressedSize);
     return blockMetaData;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/metadata/TestColumnChunkMetaData.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/metadata/TestColumnChunkMetaData.java
@@ -77,7 +77,7 @@ public class TestColumnChunkMetaData {
     CompressionCodecName c = CompressionCodecName.GZIP;
     BinaryStatistics s = new BinaryStatistics();
     ColumnChunkMetaData md = ColumnChunkMetaData.get(p, t, c, e, s,
-                                                     big, 0, 0, 0, 0);
+                                                     big, 0, 0, 0, 0, 0);
     return md;
   }
 }

--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <elephant-bird.version>4.4</elephant-bird.version>
-    <protobuf.version>3.2.0</protobuf.version>
+    <protobuf.version>3.3.0</protobuf.version>
     <!-- allow using protoc from an alternative path -->
     <protoc.path>protoc</protoc.path>
   </properties>

--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <elephant-bird.version>4.4</elephant-bird.version>
-    <protobuf.version>3.3.0</protobuf.version>
+    <protobuf.version>3.2.0</protobuf.version>
     <!-- allow using protoc from an alternative path -->
     <protoc.path>protoc</protoc.path>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <cascading.version>2.7.1</cascading.version>
     <cascading3.version>3.1.2</cascading3.version>
     <parquet.format.version>2.3.3-SNAPSHOT</parquet.format.version>
-    <previous.version>2.0.0</previous.version>
+    <previous.version>2.3.1</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <scala.version>2.10.6</scala.version>
     <!-- scala.binary.version is used for projects that fetch dependencies that are in scala -->

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
     <hadoop1.version>1.2.1</hadoop1.version>
     <cascading.version>2.7.1</cascading.version>
     <cascading3.version>3.1.2</cascading3.version>
-    <parquet.format.version>2.3.1</parquet.format.version>
-    <previous.version>1.7.0</previous.version>
+    <parquet.format.version>2.3.3-SNAPSHOT</parquet.format.version>
+    <previous.version>2.0.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <scala.version>2.10.6</scala.version>
     <!-- scala.binary.version is used for projects that fetch dependencies that are in scala -->


### PR DESCRIPTION
Add bloom filter for parquet

- Bloom filter is built upon column, and the data is stored after each row group.

- Bloom filter size can be set by user or automatically calculated.

- Row group filter can filter row group after evaluate predicate on bloom filter data.


Please see related code here: https://docs.google.com/document/d/1mIZ0W24Cr79QHJWN1sQ3dIUc4lAK5AVqozwSwtpFhW8/edit?usp=sharing

Notice that, this change depends on parquet-format change.