### PR TITLE
PARQUET-1141: Fix field ID handling

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/schema/Type.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/Type.java
@@ -20,6 +20,7 @@ package org.apache.parquet.schema;
 
 import static org.apache.parquet.Preconditions.checkNotNull;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.apache.parquet.io.InvalidRecordException;
@@ -43,6 +44,15 @@ abstract public class Type {
 
     public ID(int id) {
       this.id = id;
+    }
+
+    /**
+     * For bean serialization, used by Cascading 3.
+     * @deprecated use {@link #intValue()} instead.
+     */
+    @Deprecated
+    public int getId() {
+      return id;
     }
 
     public int intValue() {

--- a/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
@@ -1030,12 +1030,18 @@ public class Types {
       if (keyType == null) {
         keyType = STRING_KEY;
       }
+
+      GroupBuilder<GroupType> builder = buildGroup(repetition).as(OriginalType.MAP);
+      if (id != null) {
+        builder.id(id.intValue());
+      }
+
       if (valueType != null) {
-        return buildGroup(repetition).as(OriginalType.MAP)
+        return builder
             .repeatedGroup().addFields(keyType, valueType).named("map")
             .named(name);
       } else {
-        return buildGroup(repetition).as(OriginalType.MAP)
+        return builder
             .repeatedGroup().addFields(keyType).named("map")
             .named(name);
       }
@@ -1170,7 +1176,13 @@ public class Types {
       Preconditions.checkState(originalType == null,
           "LIST is already the logical type and can't be changed");
       Preconditions.checkNotNull(elementType, "List element type");
-      return buildGroup(repetition).as(OriginalType.LIST)
+
+      GroupBuilder<GroupType> builder = buildGroup(repetition).as(OriginalType.LIST);
+      if (id != null) {
+        builder.id(id.intValue());
+      }
+
+      return builder
           .repeatedGroup().addFields(elementType).named("list")
           .named(name);
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -162,12 +162,18 @@ public class ParquetMetadataConverter {
         if (primitiveType.getTypeLength() > 0) {
           element.setType_length(primitiveType.getTypeLength());
         }
+        if (primitiveType.getId() != null) {
+          element.setField_id(primitiveType.getId().intValue());
+        }
         result.add(element);
       }
 
       @Override
       public void visit(MessageType messageType) {
         SchemaElement element = new SchemaElement(messageType.getName());
+        if (messageType.getId() != null) {
+          element.setField_id(messageType.getId().intValue());
+        }
         visitChildren(result, messageType.asGroupType(), element);
       }
 
@@ -177,6 +183,9 @@ public class ParquetMetadataConverter {
         element.setRepetition_type(toParquetRepetition(groupType.getRepetition()));
         if (groupType.getOriginalType() != null) {
           element.setConverted_type(getConvertedType(groupType.getOriginalType()));
+        }
+        if (groupType.getId() != null) {
+          element.setField_id(groupType.getId().intValue());
         }
         visitChildren(result, groupType, element);
       }
@@ -881,6 +890,9 @@ public class ParquetMetadataConverter {
     Iterator<SchemaElement> iterator = schema.iterator();
     SchemaElement root = iterator.next();
     Types.MessageTypeBuilder builder = Types.buildMessage();
+    if (root.isSetField_id()) {
+      builder.id(root.field_id);
+    }
     buildChildren(builder, iterator, root.getNum_children());
     return builder.named(root.name);
   }


### PR DESCRIPTION
There are two places where field IDs are dropped:
* Map and list type builders were not passing IDs when building
* ParquetMetadataConverter was not writing field IDs or reading the ID for root schemas