### PR TITLE
PARQUET-1215: Add getFooter to ParquetWriter.

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
@@ -32,6 +32,7 @@ import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.hadoop.CodecFactory.BytesCompressor;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.api.WriteSupport.FinalizedWriteContext;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.ColumnIOFactory;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.io.api.RecordConsumer;
@@ -94,6 +95,10 @@ class InternalParquetRecordWriter<T> {
     this.validating = validating;
     this.props = props;
     initStore();
+  }
+
+  public ParquetMetadata getFooter() {
+    return parquetFileWriter.getFooter();
   }
 
   private void initStore() {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -28,6 +28,7 @@ import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.ParquetProperties.WriterVersion;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.util.HadoopOutputFile;
 import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.schema.MessageType;
@@ -308,6 +309,13 @@ public class ParquetWriter<T> implements Closeable {
       // release after the writer closes in case it is used for a last flush
       codecFactory.release();
     }
+  }
+
+  /**
+   * @return the ParquetMetadata written to the (closed) file.
+   */
+  public ParquetMetadata getFooter() {
+    return writer.getFooter();
   }
 
   /**


### PR DESCRIPTION
This adds getFooter to ParquetWriter, which will return the file footer that was written after the file is closed.