### PR TITLE
PARQUET-1246: Ignore float/double statistics in case of NaN

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/Statistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/Statistics.java
@@ -73,6 +73,70 @@ public abstract class Statistics<T extends Comparable<T>> {
     }
   }
 
+  // Builder for FLOAT type to handle special cases of min/max values like NaN, -0.0, and 0.0
+  private static class FloatBuilder extends Builder {
+    public FloatBuilder(PrimitiveType type) {
+      super(type);
+      assert type.getPrimitiveTypeName() == PrimitiveTypeName.FLOAT;
+    }
+
+    @Override
+    public Statistics<?> build() {
+      FloatStatistics stats = (FloatStatistics) super.build();
+      if (stats.hasNonNullValue()) {
+        Float min = stats.genericGetMin();
+        Float max = stats.genericGetMax();
+        // Drop min/max values in case of NaN as the sorting order of values is undefined for this case
+        if (min.isNaN() || max.isNaN()) {
+          stats.setMinMax(0.0f, 0.0f);
+          ((Statistics<?>) stats).hasNonNullValue = false;
+        } else {
+          // Updating min to -0.0 and max to +0.0 to ensure that no 0.0 values would be skipped
+          if (min == 0.0f) {
+            stats.setMinMax(-0.0f, max);
+            min = -0.0f;
+          }
+          if (max == -0.0f) {
+            stats.setMinMax(min, 0.0f);
+          }
+        }
+      }
+      return stats;
+    }
+  }
+
+  // Builder for DOUBLE type to handle special cases of min/max values like NaN, -0.0, and 0.0
+  private static class DoubleBuilder extends Builder {
+    public DoubleBuilder(PrimitiveType type) {
+      super(type);
+      assert type.getPrimitiveTypeName() == PrimitiveTypeName.DOUBLE;
+    }
+
+    @Override
+    public Statistics<?> build() {
+      DoubleStatistics stats = (DoubleStatistics) super.build();
+      if (stats.hasNonNullValue()) {
+        Double min = stats.genericGetMin();
+        Double max = stats.genericGetMax();
+        // Drop min/max values in case of NaN as the sorting order of values is undefined for this case
+        if (min.isNaN() || max.isNaN()) {
+          stats.setMinMax(0.0, 0.0);
+          ((Statistics<?>) stats).hasNonNullValue = false;
+        } else {
+          // Updating min to -0.0 and max to +0.0 to ensure that no 0.0 values would be skipped
+          if (min == 0.0) {
+            stats.setMinMax(-0.0, max);
+            min = -0.0;
+          }
+          if (max == -0.0) {
+            stats.setMinMax(min, 0.0);
+          }
+        }
+      }
+      return stats;
+    }
+  }
+
   private final PrimitiveType type;
   private final PrimitiveComparator<T> comparator;
   private boolean hasNonNullValue;
@@ -154,8 +218,15 @@ public abstract class Statistics<T extends Comparable<T>> {
    *          type of the column
    * @return builder to create new statistics object
    */
-  public static Builder getBuilder(PrimitiveType type) {
-    return new Builder(type);
+  public static Builder getBuilderForReading(PrimitiveType type) {
+    switch (type.getPrimitiveTypeName()) {
+      case FLOAT:
+        return new FloatBuilder(type);
+      case DOUBLE:
+        return new DoubleBuilder(type);
+      default:
+        return new Builder(type);
+    }
   }
 
   /**
@@ -266,7 +337,7 @@ public abstract class Statistics<T extends Comparable<T>> {
    * Abstract method to set min and max values from byte arrays.
    * @param minBytes byte array to set the min value to
    * @param maxBytes byte array to set the max value to
-   * @deprecated will be removed in 2.0.0. Use {@link #getBuilder(PrimitiveType)} instead.
+   * @deprecated will be removed in 2.0.0. Use {@link #getBuilderForReading(PrimitiveType)} instead.
    */
   @Deprecated
   abstract public void setMinMaxFromBytes(byte[] minBytes, byte[] maxBytes);
@@ -401,7 +472,7 @@ public abstract class Statistics<T extends Comparable<T>> {
    *
    * @param nulls
    *          null count to set the count to
-   * @deprecated will be removed in 2.0.0. Use {@link #getBuilder(PrimitiveType)} instead.
+   * @deprecated will be removed in 2.0.0. Use {@link #getBuilderForReading(PrimitiveType)} instead.
    */
   @Deprecated
   public void setNumNulls(long nulls) {

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/Statistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/Statistics.java
@@ -92,12 +92,13 @@ public abstract class Statistics<T extends Comparable<T>> {
           ((Statistics<?>) stats).hasNonNullValue = false;
         } else {
           // Updating min to -0.0 and max to +0.0 to ensure that no 0.0 values would be skipped
-          if (min == 0.0f) {
-            stats.setMinMax(-0.0f, max);
+          if (Float.compare(min, 0.0f) == 0) {
             min = -0.0f;
+            stats.setMinMax(min, max);
           }
-          if (max == -0.0f) {
-            stats.setMinMax(min, 0.0f);
+          if (Float.compare(max, -0.0f) == 0) {
+            max = 0.0f;
+            stats.setMinMax(min, max);
           }
         }
       }
@@ -124,12 +125,13 @@ public abstract class Statistics<T extends Comparable<T>> {
           ((Statistics<?>) stats).hasNonNullValue = false;
         } else {
           // Updating min to -0.0 and max to +0.0 to ensure that no 0.0 values would be skipped
-          if (min == 0.0) {
-            stats.setMinMax(-0.0, max);
+          if (Double.compare(min, 0.0) == 0) {
             min = -0.0;
+            stats.setMinMax(min, max);
           }
-          if (max == -0.0) {
-            stats.setMinMax(min, 0.0);
+          if (Double.compare(max, -0.0) == 0) {
+            max = 0.0;
+            stats.setMinMax(min, max);
           }
         }
       }

--- a/parquet-column/src/test/java/org/apache/parquet/column/statistics/TestStatistics.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/statistics/TestStatistics.java
@@ -724,6 +724,24 @@ public class TestStatistics {
     assertTrue(stats.isNumNullsSet());
     assertEquals(42, stats.getNumNulls());
     assertFalse(stats.hasNonNullValue());
+
+    builder = Statistics.getBuilderForReading(type);
+    stats = builder.withMin(intToBytes(floatToIntBits(0.0f)))
+        .withMax(intToBytes(floatToIntBits(42.0f))).build();
+    assertEquals(0, Float.compare(-0.0f, (Float) stats.genericGetMin()));
+    assertEquals(0, Float.compare(42.0f, (Float) stats.genericGetMax()));
+
+    builder = Statistics.getBuilderForReading(type);
+    stats = builder.withMin(intToBytes(floatToIntBits(-42.0f)))
+        .withMax(intToBytes(floatToIntBits(-0.0f))).build();
+    assertEquals(0, Float.compare(-42.0f, (Float) stats.genericGetMin()));
+    assertEquals(0, Float.compare(0.0f, (Float) stats.genericGetMax()));
+
+    builder = Statistics.getBuilderForReading(type);
+    stats = builder.withMin(intToBytes(floatToIntBits(0.0f)))
+        .withMax(intToBytes(floatToIntBits(-0.0f))).build();
+    assertEquals(0, Float.compare(-0.0f, (Float) stats.genericGetMin()));
+    assertEquals(0, Float.compare(0.0f, (Float) stats.genericGetMax()));
   }
 
   @Test
@@ -749,5 +767,23 @@ public class TestStatistics {
     assertTrue(stats.isNumNullsSet());
     assertEquals(42, stats.getNumNulls());
     assertFalse(stats.hasNonNullValue());
+
+    builder = Statistics.getBuilderForReading(type);
+    stats = builder.withMin(longToBytes(doubleToLongBits(0.0)))
+        .withMax(longToBytes(doubleToLongBits(42.0))).build();
+    assertEquals(0, Double.compare(-0.0, (Double) stats.genericGetMin()));
+    assertEquals(0, Double.compare(42.0, (Double) stats.genericGetMax()));
+
+    builder = Statistics.getBuilderForReading(type);
+    stats = builder.withMin(longToBytes(doubleToLongBits(-42.0)))
+        .withMax(longToBytes(doubleToLongBits(-0.0))).build();
+    assertEquals(0, Double.compare(-42.0, (Double) stats.genericGetMin()));
+    assertEquals(0, Double.compare(0.0, (Double) stats.genericGetMax()));
+
+    builder = Statistics.getBuilderForReading(type);
+    stats = builder.withMin(longToBytes(doubleToLongBits(0.0)))
+        .withMax(longToBytes(doubleToLongBits(-0.0))).build();
+    assertEquals(0, Double.compare(-0.0, (Double) stats.genericGetMin()));
+    assertEquals(0, Double.compare(0.0, (Double) stats.genericGetMax()));
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -402,7 +402,7 @@ public class ParquetMetadataConverter {
       (String createdBy, Statistics formatStats, PrimitiveType type, SortOrder typeSortOrder) {
     // create stats object based on the column type
     org.apache.parquet.column.statistics.Statistics.Builder statsBuilder =
-        org.apache.parquet.column.statistics.Statistics.getBuilder(type);
+        org.apache.parquet.column.statistics.Statistics.getBuilderForReading(type);
 
     if (formatStats != null) {
       // Use the new V2 min-max statistics over the former one if it is filled

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/statisticslevel/TestStatisticsFilter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/statisticslevel/TestStatisticsFilter.java
@@ -90,10 +90,10 @@ public class TestStatisticsFilter {
   private static final IntStatistics intStats = new IntStatistics();
   private static final IntStatistics nullIntStats = new IntStatistics();
   private static final org.apache.parquet.column.statistics.Statistics<?> emptyIntStats = org.apache.parquet.column.statistics.Statistics
-      .getBuilder(Types.required(PrimitiveTypeName.INT32).named("test_int32")).build();
+      .getBuilderForReading(Types.required(PrimitiveTypeName.INT32).named("test_int32")).build();
   private static final DoubleStatistics doubleStats = new DoubleStatistics();
   private static final org.apache.parquet.column.statistics.Statistics<?> missingMinMaxDoubleStats = org.apache.parquet.column.statistics.Statistics
-      .getBuilder(Types.required(PrimitiveTypeName.DOUBLE).named("test_double")).withNumNulls(100).build();
+      .getBuilderForReading(Types.required(PrimitiveTypeName.DOUBLE).named("test_double")).withNumNulls(100).build();
 
   static {
     intStats.setMinMax(10, 100);

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
@@ -93,7 +93,7 @@ public class TestColumnChunkPageWriteStore {
     int v = 3;
     BytesInput definitionLevels = BytesInput.fromInt(d);
     BytesInput repetitionLevels = BytesInput.fromInt(r);
-    Statistics<?> statistics = Statistics.getBuilder(Types.required(PrimitiveTypeName.BINARY).named("test_binary"))
+    Statistics<?> statistics = Statistics.getBuilderForReading(Types.required(PrimitiveTypeName.BINARY).named("test_binary"))
         .build();
     BytesInput data = BytesInput.fromInt(v);
     int rowCount = 5;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -96,7 +96,7 @@ public class TestParquetFileWriter {
   private static final CompressionCodecName CODEC = CompressionCodecName.UNCOMPRESSED;
 
   private static final org.apache.parquet.column.statistics.Statistics<?> EMPTY_STATS = org.apache.parquet.column.statistics.Statistics
-      .getBuilder(Types.required(PrimitiveTypeName.BINARY).named("test_binary")).build();
+      .getBuilderForReading(Types.required(PrimitiveTypeName.BINARY).named("test_binary")).build();
 
   private String writeSchema;
 


### PR DESCRIPTION
Because of the ambigous sorting order of float/double the following changes made at the reading path of the related statistics:
- Ignoring statistics in case of it contains a NaN value.
- Using -0.0 as min value and +0.0 as max value independently from which 0.0 value was saved in the statistics.