### PR TITLE
PARQUET-1285: [Java] SchemaConverter should not convert from TimeUnit.SECOND and TimeUnit.NANOSECOND of Arrow

### DIFF
--- a/parquet-arrow/src/main/java/org/apache/parquet/arrow/schema/SchemaConverter.java
+++ b/parquet-arrow/src/main/java/org/apache/parquet/arrow/schema/SchemaConverter.java
@@ -19,20 +19,7 @@
 package org.apache.parquet.arrow.schema;
 
 import static java.util.Arrays.asList;
-import static org.apache.parquet.schema.OriginalType.DATE;
-import static org.apache.parquet.schema.OriginalType.DECIMAL;
-import static org.apache.parquet.schema.OriginalType.INTERVAL;
-import static org.apache.parquet.schema.OriginalType.INT_16;
-import static org.apache.parquet.schema.OriginalType.INT_32;
-import static org.apache.parquet.schema.OriginalType.INT_64;
-import static org.apache.parquet.schema.OriginalType.INT_8;
-import static org.apache.parquet.schema.OriginalType.TIMESTAMP_MILLIS;
-import static org.apache.parquet.schema.OriginalType.TIME_MILLIS;
-import static org.apache.parquet.schema.OriginalType.UINT_16;
-import static org.apache.parquet.schema.OriginalType.UINT_32;
-import static org.apache.parquet.schema.OriginalType.UINT_64;
-import static org.apache.parquet.schema.OriginalType.UINT_8;
-import static org.apache.parquet.schema.OriginalType.UTF8;
+import static org.apache.parquet.schema.OriginalType.*;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
@@ -245,7 +232,14 @@ public class SchemaConverter {
 
       @Override
       public TypeMapping visit(Time type) {
-        return primitive(INT32, TIME_MILLIS);
+        int bitWidth = type.getBitWidth();
+        org.apache.arrow.vector.types.TimeUnit timeUnit = type.getUnit();
+        if (bitWidth == 32 && timeUnit == org.apache.arrow.vector.types.TimeUnit.MILLISECOND) {
+          return primitive(INT32, TIME_MILLIS);
+        } else if (bitWidth == 64 && timeUnit == org.apache.arrow.vector.types.TimeUnit.MICROSECOND) {
+          return primitive(INT64, TIME_MICROS);
+        }
+        throw new UnsupportedOperationException("Unsupported type " + type);
       }
 
       @Override

--- a/parquet-arrow/src/main/java/org/apache/parquet/arrow/schema/SchemaConverter.java
+++ b/parquet-arrow/src/main/java/org/apache/parquet/arrow/schema/SchemaConverter.java
@@ -468,8 +468,9 @@ public class SchemaConverter {
             return field(new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC"));
           case TIMESTAMP_MILLIS:
             return field(new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC"));
-          default:
           case TIME_MICROS:
+            return field(new ArrowType.Time(TimeUnit.MICROSECOND, 64));
+          default:
           case UTF8:
           case ENUM:
           case BSON:

--- a/parquet-arrow/src/main/java/org/apache/parquet/arrow/schema/SchemaConverter.java
+++ b/parquet-arrow/src/main/java/org/apache/parquet/arrow/schema/SchemaConverter.java
@@ -19,7 +19,21 @@
 package org.apache.parquet.arrow.schema;
 
 import static java.util.Arrays.asList;
-import static org.apache.parquet.schema.OriginalType.*;
+import static org.apache.parquet.schema.OriginalType.DATE;
+import static org.apache.parquet.schema.OriginalType.DECIMAL;
+import static org.apache.parquet.schema.OriginalType.INTERVAL;
+import static org.apache.parquet.schema.OriginalType.INT_16;
+import static org.apache.parquet.schema.OriginalType.INT_32;
+import static org.apache.parquet.schema.OriginalType.INT_64;
+import static org.apache.parquet.schema.OriginalType.INT_8;
+import static org.apache.parquet.schema.OriginalType.TIMESTAMP_MILLIS;
+import static org.apache.parquet.schema.OriginalType.TIME_MILLIS;
+import static org.apache.parquet.schema.OriginalType.TIME_MICROS;
+import static org.apache.parquet.schema.OriginalType.UINT_16;
+import static org.apache.parquet.schema.OriginalType.UINT_32;
+import static org.apache.parquet.schema.OriginalType.UINT_64;
+import static org.apache.parquet.schema.OriginalType.UINT_8;
+import static org.apache.parquet.schema.OriginalType.UTF8;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;

--- a/parquet-arrow/src/main/java/org/apache/parquet/arrow/schema/SchemaConverter.java
+++ b/parquet-arrow/src/main/java/org/apache/parquet/arrow/schema/SchemaConverter.java
@@ -50,6 +50,7 @@ import java.util.List;
 
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.ArrowType.ArrowTypeVisitor;
 import org.apache.arrow.vector.types.pojo.ArrowType.Binary;
@@ -247,10 +248,10 @@ public class SchemaConverter {
       @Override
       public TypeMapping visit(Time type) {
         int bitWidth = type.getBitWidth();
-        org.apache.arrow.vector.types.TimeUnit timeUnit = type.getUnit();
-        if (bitWidth == 32 && timeUnit == org.apache.arrow.vector.types.TimeUnit.MILLISECOND) {
+        TimeUnit timeUnit = type.getUnit();
+        if (bitWidth == 32 && timeUnit == TimeUnit.MILLISECOND) {
           return primitive(INT32, TIME_MILLIS);
-        } else if (bitWidth == 64 && timeUnit == org.apache.arrow.vector.types.TimeUnit.MICROSECOND) {
+        } else if (bitWidth == 64 && timeUnit == TimeUnit.MICROSECOND) {
           return primitive(INT64, TIME_MICROS);
         }
         throw new UnsupportedOperationException("Unsupported type " + type);
@@ -415,11 +416,11 @@ public class SchemaConverter {
           case DATE:
             return field(new ArrowType.Date(DateUnit.DAY));
           case TIMESTAMP_MICROS:
-            return field(new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MICROSECOND, "UTC"));
+            return field(new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC"));
           case TIMESTAMP_MILLIS:
-            return field(new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, "UTC"));
+            return field(new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC"));
           case TIME_MILLIS:
-            return field(new ArrowType.Time(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, 32));
+            return field(new ArrowType.Time(TimeUnit.MILLISECOND, 32));
           default:
           case TIME_MICROS:
           case INT_64:
@@ -464,9 +465,9 @@ public class SchemaConverter {
           case DATE:
             return field(new ArrowType.Date(DateUnit.DAY));
           case TIMESTAMP_MICROS:
-            return field(new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MICROSECOND, "UTC"));
+            return field(new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC"));
           case TIMESTAMP_MILLIS:
-            return field(new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, "UTC"));
+            return field(new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC"));
           default:
           case TIME_MICROS:
           case UTF8:

--- a/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
+++ b/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
@@ -44,11 +44,12 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 
 import java.io.IOException;
 import java.util.List;
-import org.apache.arrow.vector.types.IntervalUnit;
 
-import org.apache.arrow.vector.types.UnionMode;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.IntervalUnit;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.UnionMode;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -87,7 +88,7 @@ public class TestSchemaConverter {
     field("e", new ArrowType.List(), field(null, new ArrowType.Date(DateUnit.DAY))),
     field("f", new ArrowType.FixedSizeList(1), field(null, new ArrowType.Date(DateUnit.DAY))),
     field("g", new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)),
-    field("h", new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, "UTC")),
+    field("h", new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC")),
     field("i", new ArrowType.Interval(IntervalUnit.DAY_TIME))
   ));
   private final MessageType complexParquetSchema = Types.buildMessage()
@@ -130,8 +131,8 @@ public class TestSchemaConverter {
     field("k1", new ArrowType.Decimal(15, 5)),
     field("k2", new ArrowType.Decimal(25, 5)),
     field("l", new ArrowType.Date(DateUnit.DAY)),
-    field("m", new ArrowType.Time(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, 32)),
-    field("n", new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, "UTC")),
+    field("m", new ArrowType.Time(TimeUnit.MILLISECOND, 32)),
+    field("n", new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC")),
     field("o", new ArrowType.Interval(IntervalUnit.DAY_TIME)),
     field("o1", new ArrowType.Interval(IntervalUnit.YEAR_MONTH))
   ));
@@ -193,8 +194,8 @@ public class TestSchemaConverter {
     field("j1", new ArrowType.Decimal(15, 5)),
     field("j2", new ArrowType.Decimal(25, 5)),
     field("k", new ArrowType.Date(DateUnit.DAY)),
-    field("l", new ArrowType.Time(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, 32)),
-    field("m", new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, "UTC"))
+    field("l", new ArrowType.Time(TimeUnit.MILLISECOND, 32)),
+    field("m", new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC"))
   ));
 
   private final MessageType supportedTypesParquetSchema = Types.buildMessage()
@@ -354,14 +355,14 @@ public class TestSchemaConverter {
   @Test(expected = UnsupportedOperationException.class)
   public void testArrowTimeSecondToParquet() {
     converter.fromArrow(new Schema(asList(
-      field("a", new ArrowType.Time(org.apache.arrow.vector.types.TimeUnit.SECOND, 32))
+      field("a", new ArrowType.Time(TimeUnit.SECOND, 32))
     ))).getParquetSchema();
   }
 
   @Test
   public void testArrowTimeMillisecondToParquet() {
     MessageType parquet = converter.fromArrow(new Schema(asList(
-      field("a", new ArrowType.Time(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, 32))
+      field("a", new ArrowType.Time(TimeUnit.MILLISECOND, 32))
     ))).getParquetSchema();
     Assert.assertEquals(Types.buildMessage().addField(Types.optional(INT32).as(TIME_MILLIS).named("a")).named("root"), parquet);
   }
@@ -369,7 +370,7 @@ public class TestSchemaConverter {
   @Test
   public void testArrowTimeMicrosecondToParquet() {
     MessageType parquet = converter.fromArrow(new Schema(asList(
-      field("a", new ArrowType.Time(org.apache.arrow.vector.types.TimeUnit.MICROSECOND, 64))
+      field("a", new ArrowType.Time(TimeUnit.MICROSECOND, 64))
     ))).getParquetSchema();
     Assert.assertEquals(Types.buildMessage().addField(Types.optional(INT64).as(TIME_MICROS).named("a")).named("root"), parquet);
   }
@@ -377,7 +378,7 @@ public class TestSchemaConverter {
   @Test(expected = UnsupportedOperationException.class)
   public void testArrowTimeNanosecondToParquet() {
     converter.fromArrow(new Schema(asList(
-      field("a", new ArrowType.Time(org.apache.arrow.vector.types.TimeUnit.NANOSECOND, 64))
+      field("a", new ArrowType.Time(TimeUnit.NANOSECOND, 64))
     ))).getParquetSchema();
   }
 }

--- a/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
+++ b/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
@@ -381,4 +381,26 @@ public class TestSchemaConverter {
       field("a", new ArrowType.Time(TimeUnit.NANOSECOND, 64))
     ))).getParquetSchema();
   }
+
+  @Test
+  public void testParquetInt32TimeMillisToArrow() {
+    MessageType parquet = Types.buildMessage()
+      .addField(Types.optional(INT32).as(TIME_MILLIS).named("a")).named("root");
+    Schema expected = new Schema(asList(
+      field("a", new ArrowType.Time(TimeUnit.MILLISECOND, 32))
+    ));
+    Assert.assertEquals(expected, converter.fromParquet(parquet).getArrowSchema());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testParquetInt64TimeMillisToArrow() {
+    converter.fromParquet(Types.buildMessage()
+      .addField(Types.optional(INT64).as(TIME_MILLIS).named("a")).named("root"));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testParquetInt32TimeMicrosToArrow() {
+    converter.fromParquet(Types.buildMessage()
+      .addField(Types.optional(INT32).as(TIME_MICROS).named("a")).named("root"));
+  }
 }

--- a/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
+++ b/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
@@ -19,7 +19,21 @@
 package org.apache.parquet.arrow.schema;
 
 import static java.util.Arrays.asList;
-import static org.apache.parquet.schema.OriginalType.*;
+import static org.apache.parquet.schema.OriginalType.DATE;
+import static org.apache.parquet.schema.OriginalType.DECIMAL;
+import static org.apache.parquet.schema.OriginalType.INTERVAL;
+import static org.apache.parquet.schema.OriginalType.INT_16;
+import static org.apache.parquet.schema.OriginalType.INT_32;
+import static org.apache.parquet.schema.OriginalType.INT_64;
+import static org.apache.parquet.schema.OriginalType.INT_8;
+import static org.apache.parquet.schema.OriginalType.TIMESTAMP_MILLIS;
+import static org.apache.parquet.schema.OriginalType.TIME_MILLIS;
+import static org.apache.parquet.schema.OriginalType.TIME_MICROS;
+import static org.apache.parquet.schema.OriginalType.UINT_16;
+import static org.apache.parquet.schema.OriginalType.UINT_32;
+import static org.apache.parquet.schema.OriginalType.UINT_64;
+import static org.apache.parquet.schema.OriginalType.UINT_8;
+import static org.apache.parquet.schema.OriginalType.UTF8;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;

--- a/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
+++ b/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
@@ -392,6 +392,16 @@ public class TestSchemaConverter {
     Assert.assertEquals(expected, converter.fromParquet(parquet).getArrowSchema());
   }
 
+  @Test
+  public void testParquetInt64TimeMicrosToArrow() {
+    MessageType parquet = Types.buildMessage()
+      .addField(Types.optional(INT64).as(TIME_MICROS).named("a")).named("root");
+    Schema expected = new Schema(asList(
+      field("a", new ArrowType.Time(TimeUnit.MICROSECOND, 64))
+    ));
+    Assert.assertEquals(expected, converter.fromParquet(parquet).getArrowSchema());
+  }
+
   @Test(expected = IllegalStateException.class)
   public void testParquetInt64TimeMillisToArrow() {
     converter.fromParquet(Types.buildMessage()

--- a/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
+++ b/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
@@ -112,7 +112,7 @@ public class TestSchemaConverter {
     field("b", new ArrowType.Struct(), field("ba", new ArrowType.Null())),
     field("c", new ArrowType.List(), field("ca", new ArrowType.Null())),
     field("d", new ArrowType.FixedSizeList(1), field("da", new ArrowType.Null())),
-    field("e", new ArrowType.Union(UnionMode.Sparse, new int[]{1, 2, 3}), field("ea", new ArrowType.Null())),
+    field("e", new ArrowType.Union(UnionMode.Sparse, new int[] {1, 2, 3}), field("ea", new ArrowType.Null())),
     field("f", new ArrowType.Int(8, true)),
     field("f1", new ArrowType.Int(16, true)),
     field("f2", new ArrowType.Int(32, true)),
@@ -279,7 +279,6 @@ public class TestSchemaConverter {
 
   /**
    * for more pinpointed error on what is different
-   *
    * @param left
    * @param right
    */

--- a/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
+++ b/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
@@ -361,18 +361,18 @@ public class TestSchemaConverter {
 
   @Test
   public void testArrowTimeMillisecondToParquet() {
-    MessageType parquet = converter.fromArrow(new Schema(asList(
+    MessageType expected = converter.fromArrow(new Schema(asList(
       field("a", new ArrowType.Time(TimeUnit.MILLISECOND, 32))
     ))).getParquetSchema();
-    Assert.assertEquals(Types.buildMessage().addField(Types.optional(INT32).as(TIME_MILLIS).named("a")).named("root"), parquet);
+    Assert.assertEquals(expected, Types.buildMessage().addField(Types.optional(INT32).as(TIME_MILLIS).named("a")).named("root"));
   }
 
   @Test
   public void testArrowTimeMicrosecondToParquet() {
-    MessageType parquet = converter.fromArrow(new Schema(asList(
+    MessageType expected = converter.fromArrow(new Schema(asList(
       field("a", new ArrowType.Time(TimeUnit.MICROSECOND, 64))
     ))).getParquetSchema();
-    Assert.assertEquals(Types.buildMessage().addField(Types.optional(INT64).as(TIME_MICROS).named("a")).named("root"), parquet);
+    Assert.assertEquals(expected, Types.buildMessage().addField(Types.optional(INT64).as(TIME_MICROS).named("a")).named("root"));
   }
 
   @Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
Arrow's 'Time' definition is below:
```
{ "name" : "time", "unit" : "SECOND|MILLISECOND|MICROSECOND|NANOSECOND", "bitWidth": /* integer: 32 or 64 */ }
```
http://arrow.apache.org/docs/metadata.html

But Parquet only supports 'TIME_MILLIS' and 'TIME_MICROS'.
https://github.com/Apache/parquet-format/blob/master/LogicalTypes.md

Therefore SchemaConverter should not convert from TimeUnit.SECOND and TimeUnit.NANOSECOND of Arrow to Parquet.