### PR TITLE
Adding constructors to ProtoParquetWriter with writeSpecsCompliant flag

### DIFF
--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
@@ -20,6 +20,7 @@ package org.apache.parquet.proto;
 
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
@@ -79,6 +80,65 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
   public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage) throws IOException {
     this(file, protoMessage, CompressionCodecName.UNCOMPRESSED,
             DEFAULT_BLOCK_SIZE, DEFAULT_PAGE_SIZE);
+  }
+
+  /**
+   * Create a new {@link ProtoParquetWriter}.
+   *
+   * @param file                 The file name to write to.
+   * @param protoMessage         Protobuf message class
+   * @param compressionCodecName Compression code to use, or CompressionCodecName.UNCOMPRESSED
+   * @param blockSize            HDFS block size
+   * @param pageSize             See parquet write up. Blocks are subdivided into pages for alignment and other purposes.
+   * @param enableDictionary     Whether to use a dictionary to compress columns.
+   * @param validating           to turn on validation using the schema
+   * @param writeSpecsCompliant  Enable writing specs compliant schemas with parquet-protobuf
+   * @throws IOException if there is an error while writing
+   */
+  public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage,
+          CompressionCodecName compressionCodecName, int blockSize, int pageSize, boolean enableDictionary,
+          boolean validating, boolean writeSpecsCompliant) throws IOException {
+      super(file, new ProtoWriteSupport(protoMessage), compressionCodecName, blockSize, pageSize, pageSize,
+              enableDictionary, validating, DEFAULT_WRITER_VERSION,
+              getConfigWithWriteSpecsCompliant(writeSpecsCompliant));
+  }
+
+  /**
+   * Create a new {@link ProtoParquetWriter}.
+   *
+   * @param file                 The file name to write to.
+   * @param protoMessage         Protobuf message class
+   * @param compressionCodecName Compression code to use, or CompressionCodecName.UNCOMPRESSED
+   * @param blockSize            HDFS block size
+   * @param pageSize             See parquet write up. Blocks are subdivided into pages for alignment and other purposes.
+   * @param writeSpecsCompliant  Enable writing specs compliant schemas with parquet-protobuf
+   * @throws IOException if there is an error while writing
+   */
+  public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage,
+                            CompressionCodecName compressionCodecName, int blockSize,
+                            int pageSize, boolean writeSpecsCompliant) throws IOException {
+    this(file, protoMessage, compressionCodecName, blockSize, pageSize, DEFAULT_IS_DICTIONARY_ENABLED, 
+            DEFAULT_IS_VALIDATING_ENABLED, writeSpecsCompliant);
+  }
+
+  /**
+   * Create a new {@link ProtoParquetWriter}. The default block size is 50 MB.The default
+   * page size is 1 MB.  Default compression is no compression. (Inherited from {@link ParquetWriter})
+   *
+   * @param file                 The file name to write to.
+   * @param protoMessage         Protobuf message class
+   * @param writeSpecsCompliant  Enable writing specs compliant schemas with parquet-protobuf
+   * @throws IOException if there is an error while writing
+   */
+  public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage, boolean writeSpecsCompliant) throws IOException {
+    this(file, protoMessage, CompressionCodecName.UNCOMPRESSED,
+            DEFAULT_BLOCK_SIZE, DEFAULT_PAGE_SIZE, writeSpecsCompliant);
+  }
+  
+  private static Configuration getConfigWithWriteSpecsCompliant(boolean writeSpecsCompliant) {
+      Configuration config = new Configuration();
+      ProtoWriteSupport.setWriteSpecsCompliant(config, writeSpecsCompliant);
+      return config;
   }
 
 }


### PR DESCRIPTION
This PR adds constructors to ProtoParquetWriter with flags for specs compliant writer (based on #411). Now a specs compliant ProtoParquetWriter can be created as
```
new ProtoParquetWriter(file, protoMessageClass, true);
```