### PR TITLE
*FOR DISCUSSION* Flag to control snappy decompression on/off heap

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyCodec.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyCodec.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,6 +41,7 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   private Configuration conf;
   // Hadoop config for how big to make intermediate buffers.
   private final String BUFFER_SIZE_CONFIG = "io.file.buffer.size";
+  private final String BUFFER_DIRECT_CONFIG = "decompress.direct.buffers";
 
   @Override
   public void setConf(Configuration conf) {
@@ -59,7 +60,7 @@ public class SnappyCodec implements Configurable, CompressionCodec {
 
   @Override
   public Decompressor createDecompressor() {
-    return new SnappyDecompressor();
+    return new SnappyDecompressor(conf.getBoolean(BUFFER_DIRECT_CONFIG, true));
   }
 
   @Override
@@ -84,7 +85,7 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   @Override
   public CompressionOutputStream createOutputStream(OutputStream stream,
       Compressor compressor) throws IOException {
-    return new NonBlockedCompressorStream(stream, compressor, 
+    return new NonBlockedCompressorStream(stream, compressor,
         conf.getInt(BUFFER_SIZE_CONFIG, 4*1024));
   }
 
@@ -101,5 +102,5 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   @Override
   public String getDefaultExtension() {
     return ".snappy";
-  }  
+  }
 }


### PR DESCRIPTION
This is in response to https://issues.apache.org/jira/browse/PARQUET-118

We are running into issues with containers being killed due to excessive off heap memory usage that we cannot control.

For us, adding this flag is a good solution even if it doesn't provide the best performance. Stability > performance.

I'm open to working on a more complete solution to control how much off-heap is used too, as a longer term fix.