### PR TITLE
[PARQUET-1135][FOLLOW-UP] Update thrift and protoc version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Parquet-MR uses Maven to build and depends on both the thrift and protoc compile
 To build and install the protobuf compiler, run:
 
 ```
-wget https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-2.5.0.tar.gz
-tar xzf protobuf-2.5.0.tar.gz
-cd  protobuf-2.5.0
+wget https://github.com/google/protobuf/archive/v3.5.1.tar.gz -O protobuf-3.5.1.tar.gz
+tar xzf protobuf-3.5.1.tar.gz
+cd protobuf-3.5.1
 ./configure
 make
 sudo make install
@@ -49,9 +49,9 @@ sudo ldconfig
 To build and install the thrift compiler, run:
 
 ```
-wget -nv http://archive.apache.org/dist/thrift/0.7.0/thrift-0.7.0.tar.gz
-tar xzf thrift-0.7.0.tar.gz
-cd thrift-0.7.0
+wget -nv http://archive.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz
+tar zxf thrift-0.9.3.tar.gz
+cd thrift-0.9.3
 chmod +x ./configure
 ./configure --disable-gen-erl --disable-gen-hs --without-ruby --without-haskell --without-erlang
 sudo make install


### PR DESCRIPTION
## What changes were proposed in this pull request?
If still use the previous version:
```shell
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.7:run (generate-sources) on project parquet-protobuf: An Ant BuildException has occured: exec returned: 1
[ERROR] around Ant part ...<exec failonerror="true" executable="protoc">... @ 6:48 in /Users/yumwang/opensource/parquet-mr/parquet-protobuf/target/antrun/build-main.xml
[ERROR] -> [Help 1]
```
## How was this patch tested?
Test on Mac:
```shell
brew uninstall protobuf@2.5
brew install protobuf@3.5
brew install thrift@0.9
```
