### PR TITLE
PARQUET-1317: Fix ParquetMetadataConverter throw NPE

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -1170,9 +1170,11 @@ public class ParquetMetadataConverter {
       }
       if (schemaElement.isSetConverted_type()) {
         LogicalTypeAnnotation originalType = getOriginalType(schemaElement.converted_type, schemaElement);
-        LogicalTypeAnnotation newLogicalType = getOriginalType(schemaElement.logicalType);
-        if (!originalType.equals(newLogicalType)) {
-          childBuilder.as(getOriginalType(schemaElement.converted_type, schemaElement));
+        if (schemaElement.isSetLogicalType()) {
+          LogicalTypeAnnotation newLogicalType = getOriginalType(schemaElement.logicalType);
+          if (!originalType.equals(newLogicalType)) {
+            childBuilder.as(originalType);
+          }
         }
       }
       if (schemaElement.isSetField_id()) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -1170,11 +1170,9 @@ public class ParquetMetadataConverter {
       }
       if (schemaElement.isSetConverted_type()) {
         LogicalTypeAnnotation originalType = getOriginalType(schemaElement.converted_type, schemaElement);
-        if (schemaElement.isSetLogicalType()) {
-          LogicalTypeAnnotation newLogicalType = getOriginalType(schemaElement.logicalType);
-          if (!originalType.equals(newLogicalType)) {
-            childBuilder.as(originalType);
-          }
+        LogicalTypeAnnotation newLogicalType = schemaElement.isSetLogicalType() ? getOriginalType(schemaElement.logicalType) : null;
+        if (!originalType.equals(newLogicalType)) {
+          childBuilder.as(originalType);
         }
       }
       if (schemaElement.isSetField_id()) {


### PR DESCRIPTION
How to reproduce:
```shell
$ bin/spark-shell 
scala> spark.range(10).selectExpr("cast(id as string) as id").coalesce(1).write.parquet("/tmp/parquet-1317")
scala> 

java -jar ./parquet-tools/target/parquet-tools-1.10.1-SNAPSHOT.jar head --debug file:///tmp/parquet-1317/part-00000-6cfafbdd-fdeb-4861-8499-8583852ba437-c000.snappy.parquet
```

Exceptions:
```java
java.lang.NullPointerException
	at org.apache.parquet.format.converter.ParquetMetadataConverter.getOriginalType(ParquetMetadataConverter.java:828)
	at org.apache.parquet.format.converter.ParquetMetadataConverter.buildChildren(ParquetMetadataConverter.java:1173)
	at org.apache.parquet.format.converter.ParquetMetadataConverter.fromParquetSchema(ParquetMetadataConverter.java:1124)
	at org.apache.parquet.format.converter.ParquetMetadataConverter.fromParquetMetadata(ParquetMetadataConverter.java:1058)
	at org.apache.parquet.format.converter.ParquetMetadataConverter.readParquetMetadata(ParquetMetadataConverter.java:1052)
	at org.apache.parquet.hadoop.ParquetFileReader.readFooter(ParquetFileReader.java:532)
	at org.apache.parquet.hadoop.ParquetFileReader.<init>(ParquetFileReader.java:689)
	at org.apache.parquet.hadoop.ParquetFileReader.open(ParquetFileReader.java:595)
	at org.apache.parquet.hadoop.ParquetReader.initReader(ParquetReader.java:152)
	at org.apache.parquet.hadoop.ParquetReader.read(ParquetReader.java:135)
	at org.apache.parquet.tools.command.HeadCommand.execute(HeadCommand.java:87)
	at org.apache.parquet.tools.Main.main(Main.java:223)
```
This pr fix this issue.
