### PR TITLE
PARQUET-1336: PrimitiveComparator should implements Serializable

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
@@ -28,8 +28,9 @@ import java.util.Comparator;
  * {@link Comparator} implementation that also supports the comparison of the related primitive type to avoid the
  * performance penalty of boxing/unboxing. The {@code compare} methods for the not supported primitive types throw
  * {@link UnsupportedOperationException}.
+ * {@link Serializable} implementation that may be a UserDefinedPredicate defined this Comparator is their member variable.
  */
-public abstract class PrimitiveComparator<T> implements Comparator<T> {
+public abstract class PrimitiveComparator<T> implements Comparator<T>, Serializable {
 
   public int compare(boolean b1, boolean b2) {
     throw new UnsupportedOperationException(
@@ -179,7 +180,7 @@ public abstract class PrimitiveComparator<T> implements Comparator<T> {
     }
   };
 
-  private static abstract class BinaryComparator extends PrimitiveComparator<Binary> implements Serializable {
+  private static abstract class BinaryComparator extends PrimitiveComparator<Binary> {
     @Override
     int compareNotNulls(Binary o1, Binary o2) {
       return compare(o1.toByteBuffer(), o2.toByteBuffer());

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
@@ -20,6 +20,7 @@ package org.apache.parquet.schema;
 
 import org.apache.parquet.io.api.Binary;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Comparator;
 
@@ -178,7 +179,7 @@ public abstract class PrimitiveComparator<T> implements Comparator<T> {
     }
   };
 
-  private static abstract class BinaryComparator extends PrimitiveComparator<Binary> {
+  private static abstract class BinaryComparator extends PrimitiveComparator<Binary> implements Serializable {
     @Override
     int compareNotNulls(Binary o1, Binary o2) {
       return compare(o1.toByteBuffer(), o2.toByteBuffer());


### PR DESCRIPTION
`PrimitiveComparator` should implements `Serializable`. Otherwise, the following `UserDefinedPredicate` will throw `NotSerializableException`:
```scala
new UserDefinedPredicate[Binary] with Serializable {
  private val strToBinary = Binary.fromReusedByteArray(v.getBytes)
  private val size = strToBinary.length
  val comparator = PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR

  override def canDrop(statistics: Statistics[Binary]): Boolean = {
    val max = statistics.getMax
    val min = statistics.getMin
    comparator.compare(max.slice(0, math.min(size, max.length)), strToBinary) < 0 ||
      comparator.compare(min.slice(0, math.min(size, min.length)), strToBinary) > 0
  }

  override def inverseCanDrop(statistics: Statistics[Binary]): Boolean = false

  override def keep(value: Binary): Boolean =
    UTF8String.fromBytes(value.getBytes).startsWith(UTF8String.fromString(v))
}
```