### PR TITLE
PARQUET-1338: Fix PrimitiveType.equals throw NPE

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
@@ -611,7 +611,7 @@ public final class PrimitiveType extends Type {
    */
   @Override
   protected boolean equals(Type other) {
-    if (!other.isPrimitive()) {
+    if (other == null || !other.isPrimitive()) {
       return false;
     }
     PrimitiveType otherPrimitive = other.asPrimitiveType();

--- a/parquet-column/src/main/java/org/apache/parquet/schema/Type.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/Type.java
@@ -283,7 +283,7 @@ abstract public class Type {
 
   @Override
   public boolean equals(Object other) {
-    if (other == null || !(other instanceof Type)) {
+    if (!(other instanceof Type) || other == null) {
       return false;
     }
     return equals((Type)other);

--- a/parquet-column/src/main/java/org/apache/parquet/schema/Type.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/Type.java
@@ -283,7 +283,7 @@ abstract public class Type {
 
   @Override
   public boolean equals(Object other) {
-    if (!(other instanceof Type) || other == null) {
+    if (other == null || !(other instanceof Type)) {
       return false;
     }
     return equals((Type)other);

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
@@ -31,6 +31,16 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.*;
 import static org.apache.parquet.schema.Type.Repetition.*;
 
 public class TestTypeBuilders {
+
+  @Test
+  public void testTypeEquals() {
+    PrimitiveType type1 = Types.required(INT32).named("type");
+    PrimitiveType type2 = Types.required(INT32).named("type");
+    PrimitiveType type3 = null;
+    Assert.assertTrue(type1.equals(type2));
+    Assert.assertFalse(type1.equals(type3));
+  }
+
   @Test
   public void testPaperExample() {
     MessageType expected =

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
@@ -31,7 +31,6 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.*;
 import static org.apache.parquet.schema.Type.Repetition.*;
 
 public class TestTypeBuilders {
-
   @Test
   public void testPaperExample() {
     MessageType expected =

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
@@ -33,15 +33,6 @@ import static org.apache.parquet.schema.Type.Repetition.*;
 public class TestTypeBuilders {
 
   @Test
-  public void testTypeEquals() {
-    PrimitiveType type1 = Types.required(INT32).named("type");
-    PrimitiveType type2 = Types.required(INT32).named("type");
-    PrimitiveType type3 = null;
-    Assert.assertTrue(type1.equals(type2));
-    Assert.assertFalse(type1.equals(type3));
-  }
-
-  @Test
   public void testPaperExample() {
     MessageType expected =
         new MessageType("Document",
@@ -1445,6 +1436,17 @@ public class TestTypeBuilders {
     Types.required(BINARY)
       .as(LogicalTypeAnnotation.decimalType(3, 4))
       .precision(5).named("aDecimal");
+  }
+
+  @Test
+  public void testTypeEquals() {
+    PrimitiveType type1 = Types.required(INT32).named("type");
+    PrimitiveType type2 = Types.required(INT32).named("type");
+    PrimitiveType type3 = null;
+    GroupType type4 = null;
+    Assert.assertTrue(type1.equals(type2));
+    Assert.assertFalse(type1.equals(type3));
+    Assert.assertFalse(type1.equals(type4));
   }
 
   /**


### PR DESCRIPTION
Fix `PrimitiveType.equals` throw NPE.