### PR TITLE
PARQUET-1341: Fix null count stats in unsigned-sort columns.

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -621,9 +621,6 @@ public class ParquetMetadataConverter {
           statsBuilder.withMin(min);
           statsBuilder.withMax(max);
         }
-        if (formatStats.isSetNull_count()) {
-          statsBuilder.withNumNulls(formatStats.null_count);
-        }
       } else {
         boolean isSet = formatStats.isSetMax() && formatStats.isSetMin();
         boolean maxEqualsMin = isSet ? Arrays.equals(formatStats.getMin(), formatStats.getMax()) : false;
@@ -639,10 +636,11 @@ public class ParquetMetadataConverter {
             statsBuilder.withMin(formatStats.min.array());
             statsBuilder.withMax(formatStats.max.array());
           }
-          if (formatStats.isSetNull_count()) {
-            statsBuilder.withNumNulls(formatStats.null_count);
-          }
         }
+      }
+
+      if (formatStats.isSetNull_count()) {
+        statsBuilder.withNumNulls(formatStats.null_count);
       }
     }
     return statsBuilder.build();


### PR DESCRIPTION
When a column is all nulls, it has no min and max values, causing it to be handled with the conversion from min and max (not the newer min_value and max_value). In that path, stats are suppressed if the column's expected sort order is not a signed order because the old code only used signed ordering.

This PR always adds the null count, regardless of the handling for min and max or min_value and max_value.