### PR TITLE
PARQUET-383: Add config for propagating errors when writing metadata files

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -47,6 +47,7 @@ public class ParquetProperties {
   public static final boolean DEFAULT_ESTIMATE_ROW_COUNT_FOR_PAGE_SIZE_CHECK = true;
   public static final int DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK = 100;
   public static final int DEFAULT_MAXIMUM_RECORD_COUNT_FOR_CHECK = 10000;
+  public static final boolean DEFAULT_JOB_SUMMARY_PROPAGATE_ERRORS = false;
 
   public static final ValuesWriterFactory DEFAULT_VALUES_WRITER_FACTORY = new DefaultValuesWriterFactory();
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -129,6 +129,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
    * Must be one of the values in {@link JobSummaryLevel} (case insensitive)
    */
   public static final String JOB_SUMMARY_LEVEL = "parquet.summary.metadata.level";
+  public static final String JOB_SUMMARY_PROPAGATE_ERRORS = "parquet.summary.metadata.propagate-errors";
   public static final String BLOCK_SIZE           = "parquet.block.size";
   public static final String PAGE_SIZE            = "parquet.page.size";
   public static final String COMPRESSION          = "parquet.compression";
@@ -165,6 +166,11 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
     }
 
     return JobSummaryLevel.ALL;
+  }
+
+  public static boolean getJobSummaryPropagateErrors(Configuration conf) {
+    return conf.getBoolean(JOB_SUMMARY_PROPAGATE_ERRORS,
+      ParquetProperties.DEFAULT_JOB_SUMMARY_PROPAGATE_ERRORS);
   }
 
   public static void setWriteSupportClass(Job job,  Class<?> writeSupportClass) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/mapred/MapredParquetOutputCommitter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/mapred/MapredParquetOutputCommitter.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.*;
 import org.apache.parquet.hadoop.ParquetOutputCommitter;
+import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.hadoop.util.ContextUtil;
 
 import java.io.IOException;
@@ -37,6 +38,11 @@ public class MapredParquetOutputCommitter extends FileOutputCommitter {
     super.commitJob(jobContext);
     Configuration conf = ContextUtil.getConfiguration(jobContext);
     Path outputPath = FileOutputFormat.getOutputPath(new JobConf(conf));
-    ParquetOutputCommitter.writeMetaDataFile(conf, outputPath);
+    boolean propagateErrors = ParquetOutputFormat.getJobSummaryPropagateErrors(conf);
+    if (propagateErrors) {
+      ParquetOutputCommitter.writeMetaDataFilePropagateErrors(conf, outputPath);
+    } else {
+      ParquetOutputCommitter.writeMetaDataFile(conf, outputPath);
+    }
   }
 }


### PR DESCRIPTION
Allow for the option to not just eat errors when writing the metadata files. The code isn't as clean as it could be but I was optimizing for making sure it was 100% backwards compatible. The code would potentially be cleaner if we rethrow a runtime exception in the catches of the original method though that is not the most correct way to handle this.

Also I think it would be nice to not have another explicit config but rather propagate errors if the user explicitly set the job summary level (meaning it wasnt just the default) though that has the potential to break people who have it explicitly set but do not expect it to ever error out.