### PR TITLE
PARQUET-1280: [parquet-protobuf] Use maven protoc plugin

### DIFF
--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -32,7 +32,6 @@
   <properties>
     <elephant-bird.version>4.4</elephant-bird.version>
     <protobuf.version>3.5.1</protobuf.version>
-    <!-- allow using protoc from an alternative path -->
   </properties>
 
 

--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -32,8 +32,8 @@
   <properties>
     <elephant-bird.version>4.4</elephant-bird.version>
     <protobuf.version>3.5.1</protobuf.version>
+    <protoc.version>3.5.1</protoc.version>
     <!-- allow using protoc from an alternative path -->
-    <protoc.path>protoc</protoc.path>
   </properties>
 
 
@@ -148,28 +148,24 @@
       </plugin>
 
       <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.6.0.1</version>
         <executions>
           <execution>
             <id>generate-sources</id>
             <phase>generate-test-sources</phase>
-            <configuration>
-              <tasks>
-                <mkdir dir="${project.build.directory}/generated-test-sources" />
-                <mkdir dir="${project.build.directory}/generated-test-sources/java" />
-                <exec failonerror="true" executable="${protoc.path}">
-                  <arg value="--java_out=${project.build.directory}/generated-test-sources/java" />
-                  <arg value="src/test/resources/TestProtobuf.proto" />
-                  <arg value="src/test/resources/TestProto3.proto" />
-                  <arg value="-I." />
-                </exec>
-              </tasks>
-              <sourceRoot>src/main/java</sourceRoot>
-              <sourceRoot>target/generated-sources/java</sourceRoot>
-            </configuration>
             <goals>
               <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>${protoc.version}</protocVersion>
+              <addProtoSources>all</addProtoSources>
+              <outputDirectory>${project.build.directory}/generated-test-sources/java</outputDirectory>
+              <inputDirectories>
+                <include>src/test/resources</include>
+              </inputDirectories>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -32,7 +32,6 @@
   <properties>
     <elephant-bird.version>4.4</elephant-bird.version>
     <protobuf.version>3.5.1</protobuf.version>
-    <protoc.version>3.5.1</protoc.version>
     <!-- allow using protoc from an alternative path -->
   </properties>
 
@@ -159,7 +158,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <protocVersion>${protoc.version}</protocVersion>
+              <protocVersion>${protobuf.version}</protocVersion>
               <addProtoSources>all</addProtoSources>
               <outputDirectory>${project.build.directory}/generated-test-sources/java</outputDirectory>
               <inputDirectories>


### PR DESCRIPTION
Use Maven plugin to generate test sources for Protobuf. Unfortunately I couldn't find any "official" plugin for this, not sure if the one I picked is the best choice.