### PR TITLE
PARQUET-1368: ParquetFileReader should close its input stream for the failure in constructor

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -686,7 +686,14 @@ public class ParquetFileReader implements Closeable {
     this.file = file;
     this.f = file.newStream();
     this.options = options;
-    this.footer = readFooter(file, options, f, converter);
+    try {
+      this.footer = readFooter(file, options, f, converter);
+    } catch (Exception e) {
+      // In case that reading footer throws an exception in the constructor, the new stream
+      // should be closed. Otherwise, there's no way to close this outside.
+      f.close();
+      throw e;
+    }
     this.fileMetaData = footer.getFileMetaData();
     this.blocks = filterRowGroups(footer.getBlocks());
     for (ColumnDescriptor col : footer.getFileMetaData().getSchema().getColumns()) {


### PR DESCRIPTION
This PR proposes to close the stream open in ParquetFileReader's constructor when it throws an error when it is used (`readFooter`), which causes a resource leak. Otherwise, looks there's no way to close it outside.

For more details, please see the JIRA ticket https://issues.apache.org/jira/browse/PARQUET-1368.
