### PR TITLE
PARQUET-1386: Fix issues of NaN and +-0.0 in case of float/double column indexes

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/ColumnIndexBuilder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/ColumnIndexBuilder.java
@@ -557,6 +557,10 @@ public abstract class ColumnIndexBuilder {
       return null;
     }
     ColumnIndexBase<?> columnIndex = createColumnIndex(type);
+    if (columnIndex == null) {
+      // Might happen if the specialized builder discovers invalid min/max values
+      return null;
+    }
     columnIndex.nullPages = nullPages.toBooleanArray();
     // Null counts is optional so keep it null if the builder has no values
     if (!nullCounts.isEmpty()) {


### PR DESCRIPTION
Because of the ambigous sorting order of float/double the following changes were made at building column indexes (write path):
- Not writing column index for a column where any of the min/max values contain a NaN value.
- Using -0.0 as min value and +0.0 as max value independently from which 0.0 was in the values.
