### PR TITLE
PARQUET-1390: Upgrade Arrow to 0.10.0

### DIFF
--- a/parquet-arrow/pom.xml
+++ b/parquet-arrow/pom.xml
@@ -33,7 +33,7 @@
   <url>https://parquet.apache.org</url>
 
   <properties>
-    <arrow.version>0.8.0</arrow.version>
+    <arrow.version>0.10.0</arrow.version>
   </properties>
 
   <dependencies>

--- a/parquet-arrow/src/main/java/org/apache/parquet/arrow/schema/SchemaConverter.java
+++ b/parquet-arrow/src/main/java/org/apache/parquet/arrow/schema/SchemaConverter.java
@@ -278,6 +278,11 @@ public class SchemaConverter {
         return primitiveFLBA(12, INTERVAL);
       }
 
+      @Override
+      public TypeMapping visit(ArrowType.FixedSizeBinary fixedSizeBinary) {
+        return primitive(BINARY);
+      }
+
       private TypeMapping mapping(PrimitiveType parquetType) {
         return new PrimitiveTypeMapping(field, parquetType);
       }
@@ -660,6 +665,11 @@ public class SchemaConverter {
 
       @Override
       public TypeMapping visit(Interval type) {
+        return primitive();
+      }
+
+      @Override
+      public TypeMapping visit(ArrowType.FixedSizeBinary fixedSizeBinary) {
         return primitive();
       }
 


### PR DESCRIPTION
This upgrades arrow from 0.8.0 to 0.10.0.

This required adding new SchemaConverter visitor methods for fixedSizeBinary data type and I pretty much guessed at how to implement those so would appreciate a review of that.