### PR TITLE
PARQUET-1440: Convert int32 or int64 decimal values to BigDecimals

### DIFF
--- a/parquet-tools/src/main/java/org/apache/parquet/tools/read/SimpleRecordConverter.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/read/SimpleRecordConverter.java
@@ -172,6 +172,16 @@ public class SimpleRecordConverter extends GroupConverter {
     public void addBinary(Binary value) {
       record.add(name, new BigDecimal(new BigInteger(value.getBytes()), scale));
     }
+
+    @Override
+    public void addInt(int value) {
+      record.add(name, BigDecimal.valueOf(value).movePointLeft(scale));
+    }
+
+    @Override
+    public void addLong(long value) {
+      record.add(name, BigDecimal.valueOf(value).movePointLeft(scale));
+    }
   }
 }
 


### PR DESCRIPTION
This pull requests updates the `DecimalConverter` to override the `addInt` and `addLong` methods so it will return a BigDecimal with the proper scale when reading an `int32` or `int64` that is a `DECIMAL` with a specific scale. 

Without this override in place, the scale factor is ignored and the `int32 DECIMAL` values are displayed inaccurately