### PR TITLE
PARQUET-1441: Add unit test that throws SchemaParseException: Can't redefine: list.

### DIFF
--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
@@ -728,6 +728,55 @@ public class TestAvroSchemaConverter {
     }
   }
 
+  @Test
+  public void testConvertedSchemaToStringCantRedefineList() throws Exception {
+    String parquet = "message spark_schema {\n" +
+        "  optional group annotation {\n" +
+        "    optional group transcriptEffects (LIST) {\n" +
+        "      repeated group list {\n" +
+        "        optional group element {\n" +
+        "          optional group effects (LIST) {\n" +
+        "            repeated group list {\n" +
+        "              optional binary element (UTF8);\n" +
+        "            }\n" +
+        "          }\n" +
+        "        }\n" +
+        "      }\n" +
+        "    }\n" +
+        "  }\n" +
+        "}\n";
+
+    Configuration conf = new Configuration(false);
+    AvroSchemaConverter avroSchemaConverter = new AvroSchemaConverter(conf);
+    Schema schema = avroSchemaConverter.convert(MessageTypeParser.parseMessageType(parquet));
+    schema.toString();
+  }
+
+  @Test
+  public void testConvertedSchemaToString() throws Exception {
+    String parquet = "message spark_schema {\n" +
+        "  optional group annotation {\n" +
+        "    optional group transcriptEffects (LIST) {\n" +
+        "      repeated group list {\n" +
+        "        optional group element {\n" +
+        "          optional group effects (LIST) {\n" +
+        "            repeated group list {\n" +
+        "              optional binary element (UTF8);\n" +
+        "            }\n" +
+        "          }\n" +
+        "        }\n" +
+        "      }\n" +
+        "    }\n" +
+        "  }\n" +
+        "}\n";
+ 
+    Configuration conf = new Configuration(false);
+    conf.setBoolean("parquet.avro.add-list-element-records", false);
+    AvroSchemaConverter avroSchemaConverter = new AvroSchemaConverter(conf);
+    Schema schema = avroSchemaConverter.convert(MessageTypeParser.parseMessageType(parquet));
+    schema.toString();
+  }
+
   public static Schema optional(Schema original) {
     return Schema.createUnion(Lists.newArrayList(
         Schema.create(Schema.Type.NULL),

--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.10</version>
+        <version>2.22.0</version>
         <configuration>
           <argLine>-Xmx512m</argLine>
           <systemPropertyVariables>


### PR DESCRIPTION
Adding two unit tests, one that succeeds and one that throws `SchemaParseException`, as described in https://issues.apache.org/jira/browse/PARQUET-1441.