### PR TITLE
Add multi Group success when the type is not REPEATED

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/example/data/simple/SimpleGroup.java
+++ b/parquet-column/src/main/java/org/apache/parquet/example/data/simple/SimpleGroup.java
@@ -107,7 +107,7 @@ public class SimpleGroup extends Group {
     Type type = schema.getType(fieldIndex);
     List<Object> list = data[fieldIndex];
     if (!type.isRepetition(Type.Repetition.REPEATED)
-      && !list.isEmpty()) {
+        && !list.isEmpty()) {
       throw new IllegalStateException("field "+fieldIndex+" (" + type.getName() + ") can not have more than one value: " + list);
     }
   }

--- a/parquet-column/src/main/java/org/apache/parquet/example/data/simple/SimpleGroup.java
+++ b/parquet-column/src/main/java/org/apache/parquet/example/data/simple/SimpleGroup.java
@@ -99,13 +99,17 @@ public class SimpleGroup extends Group {
   }
 
   private void add(int fieldIndex, Primitive value) {
+    checkType(fieldIndex);
+    data[fieldIndex].add(value);
+  }
+
+  private void checkType(int fieldIndex) {
     Type type = schema.getType(fieldIndex);
     List<Object> list = data[fieldIndex];
     if (!type.isRepetition(Type.Repetition.REPEATED)
-        && !list.isEmpty()) {
+      && !list.isEmpty()) {
       throw new IllegalStateException("field "+fieldIndex+" (" + type.getName() + ") can not have more than one value: " + list);
     }
-    list.add(value);
   }
 
   @Override
@@ -216,6 +220,7 @@ public class SimpleGroup extends Group {
 
   @Override
   public void add(int fieldIndex, Group value) {
+    checkType(fieldIndex);
     data[fieldIndex].add(value);
   }
 


### PR DESCRIPTION
Fix that add multi Group success when the type is not REPEATED