### PR TITLE
bump to parquet-scala to 2.12

### DIFF
--- a/parquet-scala/pom.xml
+++ b/parquet-scala/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <version>2.2.1</version>
+      <version>3.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,9 @@
     <parquet.format.version>2.3.1</parquet.format.version>
     <previous.version>1.7.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
-    <scala.version>2.10.4</scala.version>
+    <scala.version>2.12.8</scala.version>
     <!-- scala.binary.version is used for projects that fetch dependencies that are in scala -->
-    <scala.binary.version>2.10</scala.binary.version>
+    <scala.binary.version>2.12</scala.binary.version>
     <scala.maven.test.skip>false</scala.maven.test.skip>
     <pig.version>0.13.0</pig.version>
     <pig.classifier>h2</pig.classifier>


### PR DESCRIPTION
parquet-scala has only been released for Scala 2.10 (which has been EOL'd for a few years).

Scala 2.11 is almost EOL as well; Spark held a lot of the ecosystem on 2.11 but now supports 2.12.

Scala 2.13.0 will also land soon.

So, I think bumping parquet-scala directly to 2.12 makes the most sense. Additionally, it would be good to go back release 2.12 (and probably 2.11) artifacts for some of the recent releases. I'm not sure what the process would have to be for that; it's not really a new release, but rather some new artifacts that were arguably missing the first time around 😀

I've already [released most of `parquet-scala_{2.11,2.12}` x `{1.8.3,1.10.0}` under my own group ID](https://search.maven.org/search?q=g:org.lasersonlab.apache.parquet%20parquet-scala), to address pressing needs in some downstream projects (cf. https://github.com/bigdatagenomics/adam/pull/2108); the changes are fairly trivial (see below, or [this equivalent patch for 2.11](https://github.com/apache/parquet-mr/compare/parquet-1.8.x...lasersonlab:2.11)).

One caveat is that I couldn't get any of the scrooge-core_2.12 versions working against 1.8.x (at least, not without upgrading thrift; maybe that means we could only push e.g. 1.10.0 artifacts, but not 1.8.3?). Two relevant branches:
- [`scrooge-2.12-1.8.3-wip`](https://github.com/lasersonlab/parquet-mr/tree/scrooge-2.12-1.8.3-wip): some progress toward scrooge 18.12.0
- [`scrooge-2.12-1.12.0`](https://github.com/lasersonlab/parquet-mr/tree/scrooge-2.12-1.12.0) successfully builds+tests scrooge_2.12:18.12.0 against HEAD and thrift 0.11.0

Maybe a more practical thing would be to leave parquet-scrooge on 2.10 for now; I don't think there's any reason it needs to be published for the same scala version as parquet-scala.