### PR TITLE
PARQUET-1485: Fix Snappy direct memory leak

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/CleanUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/CleanUtil.java
@@ -46,9 +46,10 @@ public class CleanUtil {
       cleanerField.setAccessible(true);
       Object cleaner = cleanerField.get(buf);
       cleanMethod = cleaner.getClass().getDeclaredMethod("clean");
-    } catch (Throwable e) {
-      clean(buf);
+    } catch (NoSuchFieldException | NoSuchMethodException | IllegalAccessException e) {
       logger.warn("Initialization failed for cleanerField or cleanMethod", e);
+    } finally {
+      clean(buf);
     }
     CLEANER_FIELD = cleanerField;
     CLEAN_METHOD = cleanMethod;
@@ -58,7 +59,7 @@ public class CleanUtil {
     try {
       Object cleaner = CLEANER_FIELD.get(buffer);
       CLEAN_METHOD.invoke(cleaner);
-    } catch (Throwable e) {
+    } catch (IllegalAccessException | InvocationTargetException | NullPointerException e) {
       // Ignore clean failure
       logger.warn("Clean failed for buffer " + buffer.getClass().getSimpleName(), e);
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/CleanUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/CleanUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop.codec;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CleanUtil {
+  private static final Logger logger = LoggerFactory.getLogger(CleanUtil.class);
+  private static final Field CLEANER_FIELD;
+  private static final Method CLEAN_METHOD;
+
+  static {
+    ByteBuffer buf = null;
+    try {
+      buf = ByteBuffer.allocateDirect(1);
+      CLEANER_FIELD = buf.getClass().getDeclaredField("cleaner");
+      CLEANER_FIELD.setAccessible(true);
+      Object cleaner = CLEANER_FIELD.get(buf);
+      CLEAN_METHOD = cleaner.getClass().getDeclaredMethod("clean");
+    } catch (NoSuchFieldException | NoSuchMethodException | IllegalAccessException e) {
+      clean(buf);
+      throw new IllegalStateException("No available cleaner found.", e);
+    }
+  }
+
+  public static void clean(ByteBuffer buffer) {
+    try {
+      Object cleaner = CLEANER_FIELD.get(buffer);
+      CLEAN_METHOD.invoke(cleaner);
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      // Ignore clean failure
+    }
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/CleanUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/CleanUtil.java
@@ -56,6 +56,9 @@ public class CleanUtil {
   }
 
   public static void clean(ByteBuffer buffer) {
+    if (CLEANER_FIELD == null || CLEAN_METHOD == null) {
+      return;
+    }
     try {
       Object cleaner = CLEANER_FIELD.get(buffer);
       CLEAN_METHOD.invoke(cleaner);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/CleanUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/CleanUtil.java
@@ -51,6 +51,7 @@ public class CleanUtil {
       CLEAN_METHOD.invoke(cleaner);
     } catch (IllegalAccessException | InvocationTargetException e) {
       // Ignore clean failure
+      logger.warn("Clean failed for buffer " + buffer.getClass().getSimpleName(), e);
     }
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyCompressor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyCompressor.java
@@ -32,13 +32,13 @@ import org.apache.parquet.Preconditions;
  * entire input in setInput and compresses it as one compressed block.
  */
 public class SnappyCompressor implements Compressor {
-  private static final int maxBufferSize = 64 * 1024 * 1024;
+  private static final int initialBufferSize = 64 * 1024 * 1024;
 
   // Buffer for compressed output. This buffer grows as necessary.
-  private ByteBuffer outputBuffer = ByteBuffer.allocateDirect(0);
+  private ByteBuffer outputBuffer = ByteBuffer.allocateDirect(initialBufferSize);
 
   // Buffer for uncompressed input. This buffer grows as necessary.
-  private ByteBuffer inputBuffer = ByteBuffer.allocateDirect(0);
+  private ByteBuffer inputBuffer = ByteBuffer.allocateDirect(initialBufferSize);
 
   private long bytesRead = 0L;
   private long bytesWritten = 0L;
@@ -152,15 +152,15 @@ public class SnappyCompressor implements Compressor {
 
   @Override
   public synchronized void reset() {
-    if (inputBuffer.capacity() > maxBufferSize) {
+    if (inputBuffer.capacity() > initialBufferSize) {
       ByteBuffer oldBuffer = inputBuffer;
-      inputBuffer = ByteBuffer.allocateDirect(maxBufferSize);
+      inputBuffer = ByteBuffer.allocateDirect(initialBufferSize);
       CleanUtil.clean(oldBuffer);
     }
 
-    if (outputBuffer.capacity() > maxBufferSize) {
+    if (outputBuffer.capacity() > initialBufferSize) {
       ByteBuffer oldBuffer = outputBuffer;
-      outputBuffer = ByteBuffer.allocateDirect(maxBufferSize);
+      outputBuffer = ByteBuffer.allocateDirect(initialBufferSize);
       CleanUtil.clean(oldBuffer);
     }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyCompressor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyCompressor.java
@@ -44,6 +44,11 @@ public class SnappyCompressor implements Compressor {
   private long bytesWritten = 0L;
   private boolean finishCalled = false;
 
+  public SnappyCompressor() {
+    inputBuffer.limit(0);
+    outputBuffer.limit(0);
+  }
+
   /**
    * Fills specified buffer with compressed data. Returns actual number
    * of bytes of compressed data. A return value of 0 indicates that

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyDecompressor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyDecompressor.java
@@ -37,6 +37,11 @@ public class SnappyDecompressor implements Decompressor {
 
   private boolean finished;
 
+  public SnappyDecompressor() {
+    inputBuffer.limit(0);
+    outputBuffer.limit(0);
+  }
+
   /**
    * Fills specified buffer with uncompressed data. Returns actual number
    * of bytes of uncompressed data. A return value of 0 indicates that

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyDecompressor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/SnappyDecompressor.java
@@ -27,13 +27,13 @@ import org.xerial.snappy.Snappy;
 import org.apache.parquet.Preconditions;
 
 public class SnappyDecompressor implements Decompressor {
-  private static final int maxBufferSize = 64 * 1024 * 1024;
+  private static final int initialBufferSize = 64 * 1024 * 1024;
 
   // Buffer for uncompressed output. This buffer grows as necessary.
-  private ByteBuffer outputBuffer = ByteBuffer.allocateDirect(0);
+  private ByteBuffer outputBuffer = ByteBuffer.allocateDirect(initialBufferSize);
 
   // Buffer for compressed input. This buffer grows as necessary.
-  private ByteBuffer inputBuffer = ByteBuffer.allocateDirect(0);
+  private ByteBuffer inputBuffer = ByteBuffer.allocateDirect(initialBufferSize);
 
   private boolean finished;
 
@@ -137,15 +137,15 @@ public class SnappyDecompressor implements Decompressor {
 
   @Override
   public synchronized void reset() {
-    if (inputBuffer.capacity() > maxBufferSize) {
+    if (inputBuffer.capacity() > initialBufferSize) {
       ByteBuffer oldBuffer = inputBuffer;
-      inputBuffer = ByteBuffer.allocateDirect(maxBufferSize);
+      inputBuffer = ByteBuffer.allocateDirect(initialBufferSize);
       CleanUtil.clean(oldBuffer);
     }
 
-    if (outputBuffer.capacity() > maxBufferSize) {
+    if (outputBuffer.capacity() > initialBufferSize) {
       ByteBuffer oldBuffer = outputBuffer;
-      outputBuffer = ByteBuffer.allocateDirect(maxBufferSize);
+      outputBuffer = ByteBuffer.allocateDirect(initialBufferSize);
       CleanUtil.clean(oldBuffer);
     }
 


### PR DESCRIPTION
### What's the problem?
Snappy compressor/decompressor will not release direct buffer in time, it might cause direct memory oom, especially for those application whose direct memory is limited while heap memory is redundant.

### What changes were proposed in this pull request?
This PR is to fix this issue by calling `cleaner.clean` to release directly memory in SnappyCompressor/SnappyDecompressor, it's implemented through reflection to solve incompatibility issues on java9+.

This PR also includes some minor changes: add initial buffer size to boost the memory allocation and avoid memory wasting in SnappyCompressor/SnappyDecompressor.