### PR TITLE
PARQUET-1491: Conditional debug logging

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
@@ -132,7 +132,8 @@ class InternalParquetRecordReader<T> {
       totalTimeSpentReadingBytes += timeSpentReading;
       BenchmarkCounter.incrementTime(timeSpentReading);
       if (LOG.isInfoEnabled()) LOG.info("block read in memory in {} ms. row count = {}", timeSpentReading, pages.getRowCount());
-      LOG.debug("initializing Record assembly with requested schema {}", requestedSchema);
+      if (LOG.isDebugEnabled()) LOG.debug("initializing Record assembly with requested schema {}", requestedSchema);
+
       MessageColumnIO columnIO = columnIOFactory.getColumnIO(requestedSchema, fileSchema, strictTypeChecking);
       recordReader = columnIO.getRecordReader(pages, recordConverter,
           filterRecords ? filter : FilterCompat.NOOP);
@@ -227,26 +228,26 @@ class InternalParquetRecordReader<T> {
         } catch (RecordMaterializationException e) {
           // this might throw, but it's fatal if it does.
           unmaterializableRecordCounter.incErrors(e);
-          LOG.debug("skipping a corrupt record");
+          if (LOG.isDebugEnabled()) LOG.debug("skipping a corrupt record");
           continue;
         }
 
         if (recordReader.shouldSkipCurrentRecord()) {
           // this record is being filtered via the filter2 package
-          LOG.debug("skipping record");
+          if (LOG.isDebugEnabled()) LOG.debug("skipping record");
           continue;
         }
 
         if (currentValue == null) {
           // only happens with FilteredRecordReader at end of block
           current = totalCountLoadedSoFar;
-          LOG.debug("filtered record reader reached end of block");
+          if (LOG.isDebugEnabled()) LOG.debug("filtered record reader reached end of block");
           continue;
         }
 
         recordFound = true;
 
-        LOG.debug("read value: {}", currentValue);
+        if (LOG.isDebugEnabled()) LOG.debug("read value: {}", currentValue);
       } catch (RuntimeException e) {
         throw new ParquetDecodingException(format("Can not read value at %d in block %d in file %s", current, currentBlock, reader.getPath()), e);
       }


### PR DESCRIPTION
To reduce GC pressure and performance degradation. Used next code to measure execution time:
```
import org.apache.avro.generic.GenericRecord
import org.apache.hadoop.conf.Configuration
import org.apache.hadoop.fs.{FileSystem, Path}
import org.apache.parquet.avro.AvroParquetReader

case class ParcelAttribute(x: Double, y: Double)

object AvroReader {
  def main(args: Array[String]): Unit = {
    val s = System.currentTimeMillis()
    // FIXME: Set correct path
    val path = new Path("parcel_attr.parquet")
    val conf = new Configuration()
    val fs = FileSystem.getLocal(conf);
    val reader = AvroParquetReader.builder[GenericRecord](path).build()

    val iter = Iterator.continually(reader.read).takeWhile(_ != null).map { row =>
      val primaryId = row.get("primary_id").asInstanceOf[Long]
      val x = row.get("x").asInstanceOf[Double]
      val y = row.get("y").asInstanceOf[Double]
      primaryId -> ParcelAttribute(x, y)
    }
    val size = iter.size
    println(s"Read in ${System.currentTimeMillis() - s} ms, its size is $size elements")
  }
}
```