### PR TITLE
PARQUET-1492: Remove protobuf build

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,7 @@ You can find some details about the format and intended use cases in our [Hadoop
 
 ## Building
 
-Parquet-MR uses Maven to build and depends on both the thrift and protoc compilers.
-
-### Install Protobuf
-
-To build and install the protobuf compiler, run:
-
-```
-wget https://github.com/google/protobuf/archive/v3.5.1.tar.gz -O protobuf-3.5.1.tar.gz
-tar xzf protobuf-3.5.1.tar.gz
-cd protobuf-3.5.1
-./configure
-make
-sudo make install
-sudo ldconfig
-```
+Parquet-MR uses Maven to build and depends on the thrift compiler (protoc is now managed by maven plugin).
 
 ### Install Thrift
 

--- a/dev/travis-before_install.sh
+++ b/dev/travis-before_install.sh
@@ -26,19 +26,6 @@ sudo apt-get install -qq build-essential pv autoconf automake libtool curl make 
    g++ unzip libboost-dev libboost-test-dev libboost-program-options-dev \
    libevent-dev automake libtool flex bison pkg-config g++ libssl-dev xmlstarlet
 date
-mkdir protobuf_install
-pushd protobuf_install
-wget https://github.com/google/protobuf/archive/v3.5.1.tar.gz -O protobuf-3.5.1.tar.gz
-tar xzf protobuf-3.5.1.tar.gz
-cd protobuf-3.5.1
-./autogen.sh
-./configure
-make
-sudo make install
-sudo ldconfig
-protoc --version
-popd
-date
 pwd
 wget -nv http://archive.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz
 tar zxf thrift-0.9.3.tar.gz


### PR DESCRIPTION
We do not need to build protobuf (protoc) oursevles since we rely on maven protoc plugin to compile protobuf.
This should save about 10 minutes travis build time (time for building protobuf itself).