### PR TITLE
[PARQUET-1506] Migrate maven-thrift-plugin to thrift-maven-plugin

### DIFF
--- a/parquet-format-structures/pom.xml
+++ b/parquet-format-structures/pom.xml
@@ -68,9 +68,9 @@
        </plugin>
       <!-- thrift -->
       <plugin>
-        <groupId>org.apache.thrift.tools</groupId>
-        <artifactId>maven-thrift-plugin</artifactId>
-        <version>0.1.11</version>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>thrift-maven-plugin</artifactId>
+        <version>${thrift-maven-plugin.version}</version>        
         <configuration>
           <thriftSourceRoot>${parquet.thrift.path}</thriftSourceRoot>
           <thriftExecutable>${format.thrift.executable}</thriftExecutable>


### PR DESCRIPTION
The maven-thrift-plugin is the old one which has been migrated to the ASF and continued as thrift-maven-plugin: https://issues.apache.org/jira/browse/THRIFT-4083

I'm investigating bumping the Apache Thift version to make it Java 11 compatible. But having a newer version of the maven plugin is a requirement.

maven-thrift-plugin (Aug 13, 2013) https://mvnrepository.com/artifact/org.apache.thrift.tools/maven-thrift-plugin/0.1.11
thrift-maven-plugin (Jan 18, 2017) https://mvnrepository.com/artifact/org.apache.thrift/thrift-maven-plugin/0.10.0

https://issues.apache.org/jira/browse/PARQUET-1506