### PR TITLE
PARQUET-1497: Add javax.annotation-api dependency for JDK >= 9

### DIFF
--- a/parquet-format-structures/pom.xml
+++ b/parquet-format-structures/pom.xml
@@ -158,6 +158,11 @@
       <artifactId>libthrift</artifactId>
       <version>${format.thrift.version}</version>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+     </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
cc @Fokko 