### PR TITLE
PARQUET-1496: Update Scala to 2.12

### DIFF
--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -38,7 +38,7 @@
       <url>http://conjars.org/repo</url>
     </repository>
   </repositories>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.apache.parquet</groupId>
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>scrooge-core_${scala.binary.version}</artifactId>
-      <version>4.7.0</version>
+      <version>19.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
@@ -164,7 +164,7 @@
         <plugin>
             <groupId>net.alchim31.maven</groupId>
             <artifactId>scala-maven-plugin</artifactId>
-            <version>3.1.6</version>
+            <version>3.4.4</version>
             <executions>
                 <execution>
                     <id>scala-compile-first</id>
@@ -203,7 +203,7 @@
         <plugin>
             <groupId>com.twitter</groupId>
             <artifactId>scrooge-maven-plugin</artifactId>
-            <version>3.17.0</version>
+            <version>19.1.0</version>
             <configuration>
                 <outputDirectory>${project.build.directory}/generated-test-sources/scrooge</outputDirectory>
                 <thriftNamespaceMappings>

--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,9 @@
     <previous.version>1.7.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <format.thrift.executable>thrift</format.thrift.executable>
-    <scala.version>2.10.6</scala.version>
+    <scala.version>2.12.8</scala.version>
     <!-- scala.binary.version is used for projects that fetch dependencies that are in scala -->
-    <scala.binary.version>2.10</scala.binary.version>
+    <scala.binary.version>2.12</scala.binary.version>
     <scala.maven.test.skip>false</scala.maven.test.skip>
     <pig.version>0.16.0</pig.version>
     <pig.classifier>h2</pig.classifier>


### PR DESCRIPTION
This sadly fails in `parquet-scrooge` with:

```
Exception parsing: /Users/uwe/Development/parquet-mr/parquet-scrooge/target/generated-resources/parquet.thrift: [510.1] failure: string matching regex `[A-Za-z_][A-Za-z0-9\._]*' expected but `}' found
```

This is because scrooge seems to be unable to parse the unfinished `IndexPageHeader` Thrift definition.