### PR TITLE
PARQUET-1518: Bump Jackson2 version of parquet-cli

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
 
     <!-- parquet-cli dependencies -->
     <opencsv.version>2.3</opencsv.version>
-    <jackson2.version>2.3.1</jackson2.version>
+    <jackson2.version>2.9.8</jackson2.version>
     <jcommander.version>1.35</jcommander.version>
     <commons-codec.version>1.10</commons-codec.version>
   </properties>


### PR DESCRIPTION
https://jira.apache.org/jira/browse/PARQUET-1518

There are some vulnerabilities:
https://ossindex.sonatype.org/vuln/1205a1ec-0837-406f-b081-623b9fb02992
https://ossindex.sonatype.org/vuln/b85a00e3-7d9b-49cf-9b19-b73f8ee60275
https://ossindex.sonatype.org/vuln/4f7e98ad-2212-45d3-ac21-089b3b082e6c
https://ossindex.sonatype.org/vuln/ab9013f0-09a2-4f01-bce5-751dc7437494
https://ossindex.sonatype.org/vuln/3f596fc0-9615-4b93-b30a-d4e0532e667f
https://ossindex.sonatype.org/vuln/4f7e98ad-2212-45d3-ac21-089b3b082e6c