### PR TITLE
PARQUET-1375: Upgrade to Jackson 2.9.9

### DIFF
--- a/parquet-cli/pom.xml
+++ b/parquet-cli/pom.xml
@@ -54,6 +54,11 @@
       <version>${opencsv.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-jackson</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>${jackson.groupId}</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>

--- a/parquet-cli/pom.xml
+++ b/parquet-cli/pom.xml
@@ -54,16 +54,15 @@
       <version>${opencsv.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>${jackson.groupId}</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson2.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
       <version>${jcommander.version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>

--- a/parquet-cli/pom.xml
+++ b/parquet-cli/pom.xml
@@ -55,6 +55,11 @@
     </dependency>
     <dependency>
       <groupId>${jackson.groupId}</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${jackson.groupId}</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
     </dependency>

--- a/parquet-cli/pom.xml
+++ b/parquet-cli/pom.xml
@@ -54,16 +54,6 @@
       <version>${opencsv.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-jackson</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${jackson.groupId}</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
       <groupId>${jackson.groupId}</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>

--- a/parquet-cli/pom.xml
+++ b/parquet-cli/pom.xml
@@ -54,6 +54,11 @@
       <version>${opencsv.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-jackson</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>${jackson.groupId}</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/json/AvroJson.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/json/AvroJson.java
@@ -60,12 +60,10 @@ import java.util.Set;
 
 public class AvroJson {
 
-  private static final JsonFactory FACTORY = new JsonFactory();
+  private static final JsonFactory FACTORY = new JsonFactory(new ObjectMapper());
 
   public static Iterator<JsonNode> parser(final InputStream stream) {
-    try {
-      JsonParser parser = FACTORY.createParser(stream);
-      parser.setCodec(new ObjectMapper());
+    try(JsonParser parser = FACTORY.createParser(stream)) {
       return parser.readValuesAs(JsonNode.class);
     } catch (IOException e) {
       throw new RuntimeIOException("Cannot read from stream", e);

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/json/AvroJson.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/json/AvroJson.java
@@ -60,7 +60,8 @@ import java.util.Set;
 
 public class AvroJson {
 
-  private static final JsonFactory FACTORY = new JsonFactory(new ObjectMapper());
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final JsonFactory FACTORY = new JsonFactory(MAPPER);
 
   public static Iterator<JsonNode> parser(final InputStream stream) {
     try(JsonParser parser = FACTORY.createParser(stream)) {
@@ -75,9 +76,8 @@ public class AvroJson {
   }
 
   public static <T> T parse(String json, Class<T> returnType) {
-    ObjectMapper mapper = new ObjectMapper();
     try {
-      return mapper.readValue(json, returnType);
+      return MAPPER.readValue(json, returnType);
     } catch (JsonParseException e) {
       throw new IllegalArgumentException("Invalid JSON", e);
     } catch (JsonMappingException e) {
@@ -92,9 +92,8 @@ public class AvroJson {
   }
 
   public static <T> T parse(InputStream json, Class<T> returnType) {
-    ObjectMapper mapper = new ObjectMapper();
     try {
-      return mapper.readValue(json, returnType);
+      return MAPPER.readValue(json, returnType);
     } catch (JsonParseException e) {
       throw new IllegalArgumentException("Invalid JSON stream", e);
     } catch (JsonMappingException e) {

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/json/AvroJsonReader.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/json/AvroJsonReader.java
@@ -19,17 +19,15 @@
 
 package org.apache.parquet.cli.json;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Function;
-import com.google.common.collect.Iterators;
-import org.apache.parquet.cli.util.RuntimeIOException;
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
-import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
+
+import com.google.common.collect.Iterators;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.parquet.cli.util.RuntimeIOException;
 
 public class AvroJsonReader<E> implements Iterator<E>, Iterable<E>, Closeable {
 
@@ -38,19 +36,13 @@ public class AvroJsonReader<E> implements Iterator<E>, Iterable<E>, Closeable {
   private final InputStream stream;
   private Iterator<E> iterator;
 
+  @SuppressWarnings("unchecked")
   public AvroJsonReader(InputStream stream, Schema schema) {
     this.stream = stream;
     this.schema = schema;
     this.model = GenericData.get();
     this.iterator = Iterators.transform(AvroJson.parser(stream),
-        new Function<JsonNode, E>() {
-          @Override
-          @SuppressWarnings("unchecked")
-          public E apply(@Nullable JsonNode node) {
-            return (E) AvroJson.convertToAvro(
-                model, node, AvroJsonReader.this.schema);
-          }
-        });
+      node -> (E) AvroJson.convertToAvro(model, node, AvroJsonReader.this.schema));
   }
 
   @Override

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/util/Schemas.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/util/Schemas.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.avro.AvroSchemaConverter;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
-import org.codehaus.jackson.node.NullNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -65,12 +65,17 @@
     </dependency>
     <dependency>
       <groupId>${jackson.groupId}</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
+      <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>${jackson.groupId}</groupId>
-      <artifactId>jackson-core-asl</artifactId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
       <version>${jackson.version}</version>
     </dependency>
     <dependency>

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -74,11 +74,6 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
       <version>1.1.2.6</version>

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ParquetMetadata.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ParquetMetadata.java
@@ -23,11 +23,12 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.List;
 
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
 
 /**
  * Meta Data block stored in the footer of the file
@@ -40,7 +41,7 @@ public class ParquetMetadata {
   // Enable FAIL_ON_EMPTY_BEANS on objectmapper. Without this feature parquet-casdacing tests fail,
   // because LogicalTypeAnnotation implementations are classes without any property.
   static {
-    objectMapper.configure(SerializationConfig.Feature.FAIL_ON_EMPTY_BEANS, false);
+    objectMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
   }
 
   /**

--- a/parquet-jackson/README.md
+++ b/parquet-jackson/README.md
@@ -20,7 +20,7 @@
 Parquet Jackson 
 ======
 
-Parquet-Jackson is just a dummy module to shade [Jackson](http://jackson.codehaus.org/) artifacts.
+Parquet-Jackson is just a dummy module to shade [Jackson](https://github.com/FasterXML/jackson/) artifacts.
 
 ## Rationale
 
@@ -37,6 +37,7 @@ parquet-jackson module will create a new jar artifact containing all Jackson cla
 
 Other Parquet modules which requires Jackson are configured to depend on parquet-jackson module and still perform shading. The difference is that all Jackson classes are excluded from inclusion, but references from Parquet to Jackson classes are still relocated. The shade plugin will also remove any reference to Jackson dependency but will preserve the parquet-jackson dependency which contains the relocated classes.
 
-### Why still refering directly to org.codehaus.jackson:\* in Parquet modules
+### Why still referring directly to com.fasterxml.jackson:\* in Parquet modules
+
 Because of the way Maven handles multi-modules project. Let's assume that parquet-foo module uses Jackson. When executing *mvn package*, parquet-jackson module will be built first and artifact will be packaged, and a new pom.xml without Jackson dependency is created and used by parquet-foo module. Since Jackson dependencies have been removed by the shade plugin, compilation of parquet-foo will fail.
 

--- a/parquet-jackson/README.md
+++ b/parquet-jackson/README.md
@@ -27,13 +27,13 @@ Parquet-Jackson is just a dummy module to shade [Jackson](http://jackson.codehau
 Parquet internally uses the well-known JSON processor Jackson. Because Apache Hadoop (amongst others) sometimes uses an older version of Jackson, Parquet "shades" its copy of Jackson to prevent any side-effect. 
 Originally a copy of Jackson was embedded in each Parquet artifact requiring Jackson, but to prevent duplication, a shared module "Parquet-Jackson" has been created.
 
-Note that this is not a fork of Jackson but the same classes as provided by Jackson artifacts, relocated under the *parquet.org.codehaus.jackson* namespace.
+Note that this is not a fork of Jackson but the same classes as provided by Jackson artifacts, relocated under the *parquet.com.fasterxml.jackson.core* namespace.
 
 ## Detailed explanations
 
-Shading is performed by the [Apache Maven Shade plugin](http://maven.apache.org/plugins/maven-shade-plugin/index.html). It is done during the *package* lifecycle phase, right after the original jar creation. The plugin will replace both the jar and the pom files with new versions with specified dependencies embeded and pom.xml file updated to not refer to those dependencies.
+Shading is performed by the [Apache Maven Shade plugin](http://maven.apache.org/plugins/maven-shade-plugin/index.html). It is done during the *package* lifecycle phase, right after the original jar creation. The plugin will replace both the jar and the pom files with new versions with specified dependencies embedded and pom.xml file updated to not refer to those dependencies.
 
-parquet-jackson module will create a new jar artifact containing all Jackson classes, relocated under *parquet.org.codehaus.jackson* package. The shade plugin will transform *pom.xml* too to remove any reference to Jackson dependency.
+parquet-jackson module will create a new jar artifact containing all Jackson classes, relocated under *parquet.com.fasterxml.jackson.core* package. The shade plugin will transform *pom.xml* too to remove any reference to Jackson dependency.
 
 Other Parquet modules which requires Jackson are configured to depend on parquet-jackson module and still perform shading. The difference is that all Jackson classes are excluded from inclusion, but references from Parquet to Jackson classes are still relocated. The shade plugin will also remove any reference to Jackson dependency but will preserve the parquet-jackson dependency which contains the relocated classes.
 

--- a/parquet-jackson/pom.xml
+++ b/parquet-jackson/pom.xml
@@ -34,13 +34,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
     </dependency>
   </dependencies>

--- a/parquet-pig/pom.xml
+++ b/parquet-pig/pom.xml
@@ -71,12 +71,12 @@
     </dependency>
     <dependency>
       <groupId>${jackson.groupId}</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
+      <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>${jackson.groupId}</groupId>
-      <artifactId>jackson-core-asl</artifactId>
+      <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
     </dependency>
     <dependency>

--- a/parquet-pig/src/main/java/org/apache/parquet/pig/summary/StringSummaryData.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/summary/StringSummaryData.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,15 +24,15 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import org.codehaus.jackson.annotate.JsonWriteNullProperties;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.parquet.pig.summary.EnumStat.EnumValueCount;
 
 
 /**
  * Summary data for a String
  */
-@JsonWriteNullProperties(value = false)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class StringSummaryData extends SummaryData {
 
   private ValueStat size = new ValueStat();

--- a/parquet-pig/src/main/java/org/apache/parquet/pig/summary/Summary.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/summary/Summary.java
@@ -34,8 +34,6 @@ import org.apache.pig.data.DataType;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
 
 /**
  * computes a summary of the input to a json string
@@ -176,8 +174,6 @@ public class Summary extends EvalFunc<String> implements Algebraic {
    * @param t
    * @return
    * @throws ExecException
-   * @throws JsonParseException
-   * @throws JsonMappingException
    * @throws IOException
    */
   private static TupleSummaryData merge(Tuple t) throws IOException {

--- a/parquet-pig/src/main/java/org/apache/parquet/pig/summary/SummaryData.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/summary/SummaryData.java
@@ -22,26 +22,26 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
 import org.apache.pig.impl.logicalLayer.schema.Schema.FieldSchema;
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.annotate.JsonWriteNullProperties;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig.Feature;
 
 /**
  * Base class for a node of the data summary tree
  */
-@JsonWriteNullProperties(value = false)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class SummaryData {
 
   private static ObjectMapper objectMapper = new ObjectMapper();
   private static ObjectMapper prettyObjectMapper = new ObjectMapper();
   static {
-    prettyObjectMapper.getSerializationConfig().set(Feature.INDENT_OUTPUT, true);
+    prettyObjectMapper.enable(SerializationFeature.INDENT_OUTPUT);
   }
 
   private long count;

--- a/parquet-pig/src/test/java/org/apache/parquet/pig/summary/TestSummary.java
+++ b/parquet-pig/src/test/java/org/apache/parquet/pig/summary/TestSummary.java
@@ -35,8 +35,6 @@ import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
 import org.junit.Test;
 
 public class TestSummary {
@@ -107,7 +105,7 @@ public class TestSummary {
 
   }
 
-  private void validate(String result, int factor) throws JsonParseException, JsonMappingException, IOException {
+  private void validate(String result, int factor) throws IOException {
     TupleSummaryData s = SummaryData.fromJSON(result, TupleSummaryData.class);
 //          System.out.println(SummaryData.toPrettyJSON(s));
     assertEquals(9 * factor, s.getCount());

--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -64,11 +64,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-jackson</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -68,11 +68,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${jackson.groupId}</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
       <version>${project.version}</version>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -76,12 +76,12 @@
     </dependency>
     <dependency>
       <groupId>${jackson.groupId}</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
+      <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>${jackson.groupId}</groupId>
-      <artifactId>jackson-core-asl</artifactId>
+      <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
     </dependency>
     <dependency>

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityRunner.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/CompatibilityRunner.java
@@ -19,8 +19,8 @@
 package org.apache.parquet.thrift.struct;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.thrift.TBase;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.apache.parquet.thrift.ThriftSchemaConverter;
 
 import java.io.File;

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/JSON.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/JSON.java
@@ -21,14 +21,14 @@ package org.apache.parquet.thrift.struct;
 import java.io.IOException;
 import java.io.StringWriter;
 
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig.Feature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 class JSON {
 
   private static ObjectMapper om = new ObjectMapper();
   static {
-    om.configure(Feature.INDENT_OUTPUT, true);
+    om.enable(SerializationFeature.INDENT_OUTPUT);
   }
 
   static <T> T fromJSON(String json, Class<T> clzz) {

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/JSON.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/JSON.java
@@ -40,12 +40,11 @@ class JSON {
   }
 
   static String toJSON(Object o) {
-    final StringWriter sw = new StringWriter();
-    try {
-      om.writeValue(sw, o);
+    try(final StringWriter sw = new StringWriter()) {
+        om.writeValue(sw, o);
+      return sw.toString();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    return sw.toString();
   }
 }

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/JSON.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/JSON.java
@@ -41,7 +41,7 @@ class JSON {
 
   static String toJSON(Object o) {
     try(final StringWriter sw = new StringWriter()) {
-        om.writeValue(sw, o);
+      om.writeValue(sw, o);
       return sw.toString();
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/ThriftField.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/ThriftField.java
@@ -18,9 +18,9 @@
  */
 package org.apache.parquet.thrift.struct;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.thrift.TFieldRequirementType;
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonProperty;
 
 public class ThriftField {
   public static enum Requirement {

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/ThriftType.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/ThriftType.java
@@ -37,19 +37,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.annotate.JsonSubTypes;
-import org.codehaus.jackson.annotate.JsonTypeInfo;
-import org.codehaus.jackson.annotate.JsonTypeInfo.As;
-import org.codehaus.jackson.annotate.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.*;
+
 
 /**
  * Descriptor for a Thrift class.
  * Used to persist the thrift schema
  */
-@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "id")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "id")
 @JsonSubTypes({
     @JsonSubTypes.Type(value=ThriftType.BoolType.class, name="BOOL"),
     @JsonSubTypes.Type(value=ThriftType.ByteType.class, name="BYTE"),

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/ThriftType.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/ThriftType.java
@@ -37,7 +37,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 
 /**

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/json/JsonRecordFormatter.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/json/JsonRecordFormatter.java
@@ -19,11 +19,11 @@
 
 package org.apache.parquet.tools.json;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.tools.read.SimpleRecord;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.*;

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/read/SimpleMapRecord.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/read/SimpleMapRecord.java
@@ -18,8 +18,8 @@
  */
 package org.apache.parquet.tools.read;
 
+import com.fasterxml.jackson.databind.node.BinaryNode;
 import com.google.common.collect.Maps;
-import org.codehaus.jackson.node.BinaryNode;
 
 import java.util.Arrays;
 import java.util.Map;

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/read/SimpleRecord.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/read/SimpleRecord.java
@@ -26,10 +26,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.BinaryNode;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.BinaryNode;
 
 public class SimpleRecord {
   protected final List<NameValue> values;

--- a/parquet-tools/src/test/java/org/apache/parquet/tools/read/TestJsonRecordFormatter.java
+++ b/parquet-tools/src/test/java/org/apache/parquet/tools/read/TestJsonRecordFormatter.java
@@ -19,12 +19,12 @@
 
 package org.apache.parquet.tools.read;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.tools.json.JsonRecordFormatter;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
     <jackson.groupId>com.fasterxml.jackson.core</jackson.groupId>
     <jackson.package>com.fasterxml.jackson</jackson.package>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.9.9</jackson.version>
     <shade.prefix>shaded.parquet</shade.prefix>
     <hadoop.version>2.7.3</hadoop.version>
     <hadoop1.version>1.2.1</hadoop1.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <github.global.server>github</github.global.server>
     <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
-    <jackson.groupId>org.codehaus.jackson</jackson.groupId>
-    <jackson.version>1.9.13</jackson.version>
-    <jackson.package>org.codehaus.jackson</jackson.package>
+    <jackson.groupId>com.fasterxml.jackson.core</jackson.groupId>
+    <jackson.package>com.fasterxml.jackson.core</jackson.package>
+    <jackson.version>2.9.8</jackson.version>
     <shade.prefix>shaded.parquet</shade.prefix>
     <hadoop.version>2.7.3</hadoop.version>
     <hadoop1.version>1.2.1</hadoop1.version>
@@ -104,7 +104,6 @@
 
     <!-- parquet-cli dependencies -->
     <opencsv.version>2.3</opencsv.version>
-    <jackson2.version>2.9.8</jackson2.version>
     <jcommander.version>1.35</jcommander.version>
     <commons-codec.version>1.10</commons-codec.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <github.global.server>github</github.global.server>
     <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
     <jackson.groupId>com.fasterxml.jackson.core</jackson.groupId>
-    <jackson.package>com.fasterxml.jackson.core</jackson.package>
+    <jackson.package>com.fasterxml.jackson</jackson.package>
     <jackson.version>2.9.8</jackson.version>
     <shade.prefix>shaded.parquet</shade.prefix>
     <hadoop.version>2.7.3</hadoop.version>
@@ -303,7 +303,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.2.1</version>
           <executions>
             <execution>
               <phase>package</phase>


### PR DESCRIPTION
The old Jackson 1.x is deprecated a while ago, and there are many outstanding security issues. Therefore I would like to move Parquet to Jackson 2.9.9.

https://jira.apache.org/jira/browse/PARQUET-1375