### PR TITLE
PARQUET-1536: [parquet-cli] Add simple tests for each command

### DIFF
--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/AvroFileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/AvroFileTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class AvroFileTest extends ParquetFileTest {
+
+  protected File toAvro(File parquetFile) throws IOException {
+    ToAvroCommand command = new ToAvroCommand(createLogger());
+    command.targets = Arrays.asList(parquetFile.getAbsolutePath());
+    File output = new File(getTempFolder(), getClass().getSimpleName() + ".avro");
+    command.outputPath = output.getAbsolutePath();
+    command.setConf(new Configuration());
+    int exitCode = command.run();
+    assert(exitCode == 0);
+    return output;
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVFileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVFileTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.junit.Before;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public abstract class CSVFileTest extends FileTest {
+
+  @Before
+  public void setUp() throws IOException {
+    createTestCSVFile();
+  }
+
+  protected File csvFile() {
+    File tmpDir = getTempFolder();
+    return new File(tmpDir, getClass().getSimpleName() + ".csv");
+  }
+
+  private void createTestCSVFile() throws IOException {
+    File file = csvFile();
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+      writer.write(String.format("%s,%s,%s\n",
+        INT32_FIELD, INT64_FIELD, BINARY_FIELD));
+      writer.write(String.format("%d,%d,\"%s\"\n",
+        Integer.MIN_VALUE, Long.MIN_VALUE, COLORS[0]));
+      writer.write(String.format("%d,%d,\"%s\"\n",
+        Integer.MAX_VALUE, Long.MAX_VALUE, COLORS[1]));
+    }
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVSchemaCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVSchemaCommandTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class CSVSchemaCommandTest extends CSVFileTest {
+  @Test
+  public void testCSVSchemaCommand() throws IOException {
+    File file = csvFile();
+    CSVSchemaCommand command = new CSVSchemaCommand(createLogger());
+    command.samplePaths = Arrays.asList(file.getAbsolutePath());
+    command.recordName = "Test";
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CatCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CatCommandTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class CatCommandTest extends ParquetFileTest {
+  @Test
+  public void testCatCommand() throws IOException {
+    File file = parquetFile();
+    CatCommand command = new CatCommand(createLogger(), 0);
+    command.sourceFiles = Arrays.asList(file.getAbsolutePath());
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CheckParquet251CommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CheckParquet251CommandTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class CheckParquet251CommandTest extends ParquetFileTest {
+  @Test
+  public void testCheckParquet251Command() throws IOException {
+    File file = parquetFile();
+    CheckParquet251Command command = new CheckParquet251Command(createLogger());
+    command.files = Arrays.asList(file.getAbsolutePath());
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCSVCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCSVCommandTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class ConvertCSVCommandTest extends CSVFileTest {
+  @Test
+  public void testConvertCSVCommand() throws IOException {
+    File file = csvFile();
+    ConvertCSVCommand command = new ConvertCSVCommand(createLogger());
+    command.targets = Arrays.asList(file.getAbsolutePath());
+    File output = new File(getTempFolder(), getClass().getSimpleName() + ".parquet");
+    command.outputPath = output.getAbsolutePath();
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+    Assert.assertTrue(output.exists());
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCommandTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class ConvertCommandTest extends AvroFileTest {
+  @Test
+  public void testConvertCommand() throws IOException {
+    File file = toAvro(parquetFile());
+    ConvertCommand command = new ConvertCommand(createLogger());
+    command.targets = Arrays.asList(file.getAbsolutePath());
+    File output = new File(getTempFolder(), "converted.avro");
+    command.outputPath = output.getAbsolutePath();
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+    Assert.assertTrue(output.exists());
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/FileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/FileTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.log4j.PropertyConfigurator;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+public abstract class FileTest {
+
+  static final String INT32_FIELD = "int32_field";
+  static final String INT64_FIELD = "int64_field";
+  static final String FLOAT_FIELD = "float_field";
+  static final String DOUBLE_FIELD = "double_field";
+  static final String BINARY_FIELD = "binary_field";
+  static final String FIXED_LEN_BYTE_ARRAY_FIELD = "flba_field";
+
+  static final String[] COLORS = {"RED", "BLUE", "YELLOW", "GREEN", "WHITE"};
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  protected File getTempFolder() {
+    return this.tempFolder.getRoot();
+  }
+
+  protected static Logger createLogger() {
+    PropertyConfigurator.configure(
+      ParquetFileTest.class.getResource("/cli-logging.properties"));
+    Logger console = LoggerFactory.getLogger(ParquetFileTest.class);
+    LogFactory.getFactory().setAttribute(
+      "org.apache.commons.logging.Log",
+      "org.apache.commons.logging.impl.Log4JLogger");
+    return console;
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetFileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetFileTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.junit.Before;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.parquet.schema.Type.Repetition.*;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+
+public abstract class ParquetFileTest extends FileTest {
+
+  @Before
+  public void setUp() throws IOException {
+    createTestParquetFile();
+  }
+
+  protected File parquetFile() {
+    File tmpDir = getTempFolder();
+    return new File(tmpDir, getClass().getSimpleName() + ".parquet");
+  }
+
+  private static MessageType createSchema() {
+    return new MessageType("schema",
+      new PrimitiveType(REQUIRED, PrimitiveTypeName.INT32, INT32_FIELD),
+      new PrimitiveType(REQUIRED, PrimitiveTypeName.INT64, INT64_FIELD),
+      new PrimitiveType(REQUIRED, PrimitiveTypeName.FLOAT, FLOAT_FIELD),
+      new PrimitiveType(REQUIRED, PrimitiveTypeName.DOUBLE, DOUBLE_FIELD),
+      new PrimitiveType(REQUIRED, PrimitiveTypeName.BINARY, BINARY_FIELD),
+      new PrimitiveType(REQUIRED, PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+        12, FIXED_LEN_BYTE_ARRAY_FIELD)
+    );
+  }
+
+  private void createTestParquetFile() throws IOException {
+    File file = parquetFile();
+    Path fsPath = new Path(file.getPath());
+    Configuration conf = new Configuration();
+
+    MessageType schema = createSchema();
+    SimpleGroupFactory fact = new SimpleGroupFactory(schema);
+    GroupWriteSupport.setSchema(schema, conf);
+
+    try (
+      ParquetWriter<Group> writer = new ParquetWriter<>(
+        fsPath,
+        new GroupWriteSupport(),
+        CompressionCodecName.UNCOMPRESSED,
+        1024,
+        1024,
+        512,
+        true,
+        false,
+        ParquetProperties.WriterVersion.PARQUET_2_0,
+        conf)) {
+      for (int i = 0; i < 10; i++) {
+        final byte[] bytes = new byte[12];
+        ThreadLocalRandom.current().nextBytes(bytes);
+
+        writer.write(fact.newGroup()
+         .append(INT32_FIELD, 32 + i)
+         .append(INT64_FIELD, 64L + i)
+         .append(FLOAT_FIELD, 1.0f + i)
+         .append(DOUBLE_FIELD, 2.0d + i)
+         .append(BINARY_FIELD, Binary.fromString(COLORS[i % COLORS.length]))
+         .append(FIXED_LEN_BYTE_ARRAY_FIELD,
+           Binary.fromConstantByteArray(bytes)));
+      }
+    }
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetMetadataCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetMetadataCommandTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class ParquetMetadataCommandTest extends ParquetFileTest {
+  @Test
+  public void testParquetMetadataCommand() throws IOException {
+    File file = parquetFile();
+    ParquetMetadataCommand command = new ParquetMetadataCommand(createLogger());
+    command.targets = Arrays.asList(file.getAbsolutePath());
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/SchemaCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/SchemaCommandTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class SchemaCommandTest extends ParquetFileTest {
+  @Test
+  public void testSchemaCommand() throws IOException {
+    File file = parquetFile();
+    SchemaCommand command = new SchemaCommand(createLogger());
+    command.targets = Arrays.asList(file.getAbsolutePath());
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowColumnIndexTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowColumnIndexTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class ShowColumnIndexTest extends ParquetFileTest {
+  @Test
+  public void testShowColumnIndexCommand() throws IOException {
+    File file = parquetFile();
+    ShowColumnIndexCommand command = new ShowColumnIndexCommand(createLogger());
+    command.files = Arrays.asList(file.getAbsolutePath());
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowDictionaryCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowDictionaryCommandTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class ShowDictionaryCommandTest extends ParquetFileTest {
+  @Test
+  public void testShowDirectoryCommand() throws IOException {
+    File file = parquetFile();
+    ShowDictionaryCommand command = new ShowDictionaryCommand(createLogger());
+    command.targets = Arrays.asList(file.getAbsolutePath());
+    command.column = BINARY_FIELD;
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowPagesCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowPagesCommandTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class ShowPagesCommandTest extends ParquetFileTest {
+  @Test
+  public void testShowPagesCommand() throws IOException {
+    File file = parquetFile();
+    ShowPagesCommand command = new ShowPagesCommand(createLogger());
+    command.targets = Arrays.asList(file.getAbsolutePath());
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ToAvroCommandTest extends AvroFileTest {
+  @Test
+  public void testToAvroCommand() throws IOException {
+    File avroFile = toAvro(parquetFile());
+    Assert.assertTrue(avroFile.exists());
+  }
+}


### PR DESCRIPTION
parquet-cli has no tests. At first, adding simple tests for each command.
Currently, some of these tests fail on Windows. The issue registered as PARQUET-1534.