### PR TITLE
PARQUET-1534:  [parquet-cli] Argument error: Illegal character in opaque part at index 2 on Windows

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/BaseCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/BaseCommand.java
@@ -50,6 +50,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
@@ -175,12 +176,13 @@ public abstract class BaseCommand implements Command, Configurable {
    * @throws IOException if there is an error creating a qualified URI
    */
   public URI qualifiedURI(String filename) throws IOException {
-    URI fileURI = URI.create(filename);
-    if (RESOURCE_URI_SCHEME.equals(fileURI.getScheme())) {
-      return fileURI;
-    } else {
-      return qualifiedPath(filename).toUri();
-    }
+    try {
+      URI fileURI = new URI(filename);
+      if (RESOURCE_URI_SCHEME.equals(fileURI.getScheme())) {
+        return fileURI;
+      }
+    } catch (URISyntaxException ignore) {}
+    return qualifiedPath(filename).toUri();
   }
 
   /**
@@ -392,5 +394,4 @@ public abstract class BaseCommand implements Command, Configurable {
           "Could not determine file format of %s.", source));
     }
   }
-
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/BaseCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/BaseCommandTest.java
@@ -21,6 +21,7 @@ package org.apache.parquet.cli;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -45,24 +46,32 @@ public class BaseCommandTest {
 
   @Test
   public void qualifiedPathOnLinuxTest() throws IOException {
+    Assume.assumeFalse
+             (System.getProperty("os.name").toLowerCase().startsWith("win"));
     Path path = this.command.qualifiedPath(LINUX_FILE_PATH);
     Assert.assertEquals("test.parquet", path.getName());
   }
 
   @Test
   public void qualifiedPathOnWinTest() throws IOException {
+    Assume.assumeFalse
+             (System.getProperty("os.name").toLowerCase().startsWith("linux"));
     Path path = this.command.qualifiedPath(WIN_FILE_PATH);
     Assert.assertEquals("test.parquet", path.getName());
   }
 
   @Test
   public void qualifiedURILinuxFileTest() throws IOException {
+    Assume.assumeFalse
+             (System.getProperty("os.name").toLowerCase().startsWith("win"));
     URI uri = this.command.qualifiedURI(LINUX_FILE_PATH);
     Assert.assertEquals("/var/tmp/test.parquet", uri.getPath());
   }
 
   @Test
   public void qualifiedURIWinFileTest() throws IOException {
+    Assume.assumeFalse
+             (System.getProperty("os.name").toLowerCase().startsWith("linux"));
     URI uri = this.command.qualifiedURI(WIN_FILE_PATH);
     Assert.assertEquals("/C:/Test/Downloads/test.parquet", uri.getPath());
   }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/BaseCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/BaseCommandTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+public class BaseCommandTest {
+
+  private static final String WIN_FILE_PATH = "C:\\Test\\Downloads\\test.parquet";
+  private static final String LINUX_FILE_PATH = "/var/tmp/test.parquet";
+
+  private Logger console = LoggerFactory.getLogger(BaseCommandTest.class);
+  private TestCommand command;
+
+  @Before
+  public void setUp() {
+    this.command = new TestCommand(this.console);
+  }
+
+  @Test
+  public void qualifiedPathOnLinuxTest() throws IOException {
+    Path path = this.command.qualifiedPath(LINUX_FILE_PATH);
+    Assert.assertEquals("test.parquet", path.getName());
+  }
+
+  @Test
+  public void qualifiedPathOnWinTest() throws IOException {
+    Path path = this.command.qualifiedPath(WIN_FILE_PATH);
+    Assert.assertEquals("test.parquet", path.getName());
+  }
+
+  @Test
+  public void qualifiedURILinuxFileTest() throws IOException {
+    URI uri = this.command.qualifiedURI(LINUX_FILE_PATH);
+    Assert.assertEquals("/var/tmp/test.parquet", uri.getPath());
+  }
+
+  @Test
+  public void qualifiedURIWinFileTest() throws IOException {
+    URI uri = this.command.qualifiedURI(WIN_FILE_PATH);
+    Assert.assertEquals("/C:/Test/Downloads/test.parquet", uri.getPath());
+  }
+
+  @Test
+  public void qualifiedURIResourceURITest() throws IOException {
+    URI uri = this.command.qualifiedURI("resource:/a");
+    Assert.assertEquals("/a", uri.getPath());
+  }
+
+  class TestCommand extends BaseCommand {
+
+    public TestCommand(Logger console) {
+      super(console);
+      setConf(new Configuration());
+    }
+
+    @Override
+    public int run() throws IOException {
+      return 0;
+    }
+
+    @Override
+    public List<String> getExamples() {
+      return null;
+    }
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/BaseCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/BaseCommandTest.java
@@ -33,8 +33,8 @@ import java.util.List;
 
 public class BaseCommandTest {
 
+  private static final String FILE_PATH = "/var/tmp/test.parquet";
   private static final String WIN_FILE_PATH = "C:\\Test\\Downloads\\test.parquet";
-  private static final String LINUX_FILE_PATH = "/var/tmp/test.parquet";
 
   private Logger console = LoggerFactory.getLogger(BaseCommandTest.class);
   private TestCommand command;
@@ -44,42 +44,40 @@ public class BaseCommandTest {
     this.command = new TestCommand(this.console);
   }
 
+  // For All OS
   @Test
-  public void qualifiedPathOnLinuxTest() throws IOException {
-    Assume.assumeFalse
-             (System.getProperty("os.name").toLowerCase().startsWith("win"));
-    Path path = this.command.qualifiedPath(LINUX_FILE_PATH);
+  public void qualifiedPathTest() throws IOException {
+    Path path = this.command.qualifiedPath(FILE_PATH);
     Assert.assertEquals("test.parquet", path.getName());
   }
 
   @Test
-  public void qualifiedPathOnWinTest() throws IOException {
-    Assume.assumeFalse
-             (System.getProperty("os.name").toLowerCase().startsWith("linux"));
-    Path path = this.command.qualifiedPath(WIN_FILE_PATH);
-    Assert.assertEquals("test.parquet", path.getName());
-  }
-
-  @Test
-  public void qualifiedURILinuxFileTest() throws IOException {
-    Assume.assumeFalse
-             (System.getProperty("os.name").toLowerCase().startsWith("win"));
-    URI uri = this.command.qualifiedURI(LINUX_FILE_PATH);
+  public void qualifiedURITest() throws IOException {
+    URI uri = this.command.qualifiedURI(FILE_PATH);
     Assert.assertEquals("/var/tmp/test.parquet", uri.getPath());
-  }
-
-  @Test
-  public void qualifiedURIWinFileTest() throws IOException {
-    Assume.assumeFalse
-             (System.getProperty("os.name").toLowerCase().startsWith("linux"));
-    URI uri = this.command.qualifiedURI(WIN_FILE_PATH);
-    Assert.assertEquals("/C:/Test/Downloads/test.parquet", uri.getPath());
   }
 
   @Test
   public void qualifiedURIResourceURITest() throws IOException {
     URI uri = this.command.qualifiedURI("resource:/a");
     Assert.assertEquals("/a", uri.getPath());
+  }
+
+  // For Windows
+  @Test
+  public void qualifiedPathTestForWindows() throws IOException {
+    Assume.assumeTrue
+             (System.getProperty("os.name").toLowerCase().startsWith("win"));
+    Path path = this.command.qualifiedPath(WIN_FILE_PATH);
+    Assert.assertEquals("test.parquet", path.getName());
+  }
+
+  @Test
+  public void qualifiedURITestForWindows() throws IOException {
+    Assume.assumeTrue
+             (System.getProperty("os.name").toLowerCase().startsWith("win"));
+    URI uri = this.command.qualifiedURI(WIN_FILE_PATH);
+    Assert.assertEquals("/C:/Test/Downloads/test.parquet", uri.getPath());
   }
 
   class TestCommand extends BaseCommand {


### PR DESCRIPTION
Some commands of parquet-cli don't work on Windows.

```
$ java -cp target/classes;target/dependency/* org.apache.parquet.cli.Main schema C:\Users\masayuki\Downloads\test.parquet                                                               Argument error: Illegal character in opaque part at index 2: C:\Users\masayuki\Downloads\test.parquet          
                                    
$ java -cp target/classes;target/dependency/* org.apache.parquet.cli.Main csv-schema C:\Users\masayuki\Downloads\test.csv --record-name Test                                              
Argument error: Illegal character in opaque part at index 2: C:\Users\masayuki\Downloads\test.csv              

$ java -cp target/classes;target/dependency/* org.apache.parquet.cli.Main convert-csv C:\Users\masayuki\Downlo ads\test.csv -o C:\Users\masayuki\Downloads\test-csv.parquet
Argument error: Illegal character in opaque part at index 2: C:\Users\masayuki\Downloads\test.csv

$ java -cp target/classes;target/dependency/* org.apache.parquet.cli.Main convert C:\Users\masayuki\Downloads\ userdata1.avro -o C:\Users\masayuki\Downloads\userdata1.parquet
Argument error: Illegal character in opaque part at index 2: C:\Users\masayuki\Downloads\userdata1.avro

$ java -cp target/classes;target/dependency/* org.apache.parquet.cli.Main to-avro C:\Users\masayuki\Downloads\ test.parquet -o C:\Users\masayuki\Downloads\test.avro
Argument error: Illegal character in opaque part at index 2: C:\Users\masayuki\Downloads\test.parquet

$ java -cp target/classes;target/dependency/* org.apache.parquet.cli.Main cat C:\Users\masayuki\Downloads\test.parquet
Argument error: Illegal character in opaque part at index 2: C:\Users\masayuki\Downloads\test.parquet

$ java -cp target/classes;target/dependency/* org.apache.parquet.cli.Main head -n 10 C:\Users\masayuki\Downloa ds\test.parquet
Argument error: Illegal character in opaque part at index 2: C:\Users\masayuki\Downloads\test.parquet
```

Calling BaseCommand#qualifiedURI with Windows file path,  java.net.URI.create throws IllegalArgumentException and the command execution is aborted.

This PR fixes the issue. With this PR, parquet-cli will work all commands on Windows.

parquet-cli has no tests. I created PR to add simple tests for each command at https://github.com/apache/parquet-mr/pull/625. Could you review that first?