### PR TITLE
PARQUET-1555: Bump snappy-java to 1.1.7.3

### DIFF
--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.1.2.6</version>
+      <version>1.1.7.3</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
Just to make sure that it compiles well against the latest version for Java9+ compatibility

https://jira.apache.org/jira/browse/PARQUET-1555