### PR TITLE
PARQUET-1557: Replace deprecated Apache Avro methods

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroIndexedRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroIndexedRecordConverter.java
@@ -104,7 +104,7 @@ class AvroIndexedRecordConverter<T extends IndexedRecord> extends GroupConverter
       if (field.schema().getType() == Schema.Type.NULL) {
         continue; // skip null since Parquet does not write nulls
       }
-      if (field.defaultValue() == null || model.getDefaultValue(field) == null) {
+      if (field.defaultVal() == null || model.getDefaultValue(field) == null) {
         continue; // field has no default
       }
       recordDefaults.put(field, model.getDefaultValue(field));

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -165,7 +165,7 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
       if (field.schema().getType() == Schema.Type.NULL) {
         continue; // skip null since Parquet does not write nulls
       }
-      if (field.defaultValue() == null || this.model.getDefaultValue(field) == null) {
+      if (field.defaultVal() == null || this.model.getDefaultValue(field) == null) {
         continue; // field has no default
       }
       // use this.model because model may be null

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectInputOutputFormat.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectInputOutputFormat.java
@@ -380,7 +380,7 @@ public class TestReflectInputOutputFormat {
     for (Schema.Field field : ReflectData.get().getSchema(Car.class).getFields()) {
       if (!"optionalExtra".equals(field.name())) {
         fields.add(new Schema.Field(field.name(), field.schema(), field.doc(),
-            field.defaultValue(), field.order()));
+            field.defaultVal(), field.order()));
       }
     }
     projection.setFields(fields);
@@ -441,7 +441,7 @@ public class TestReflectInputOutputFormat {
       // No make!
       if ("engine".equals(field.name()) || "year".equals(field.name()) || "vin".equals(field.name())) {
         fields.add(new Schema.Field(field.name(), field.schema(), field.doc(),
-            field.defaultValue(), field.order()));
+            field.defaultVal(), field.order()));
       }
     }
     projection.setFields(fields);

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificInputOutputFormat.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificInputOutputFormat.java
@@ -172,7 +172,7 @@ public class TestSpecificInputOutputFormat {
     for (Schema.Field field : Car.SCHEMA$.getFields()) {
       if (!"optionalExtra".equals(field.name())) {
         fields.add(new Schema.Field(field.name(), field.schema(), field.doc(),
-            field.defaultValue(), field.order()));
+            field.defaultVal(), field.order()));
       }
     }
     projection.setFields(fields);
@@ -232,7 +232,7 @@ public class TestSpecificInputOutputFormat {
       // No make!
       if ("engine".equals(field.name()) || "year".equals(field.name()) || "vin".equals(field.name())) {
         fields.add(new Schema.Field(field.name(), field.schema(), field.doc(),
-            field.defaultValue(), field.order()));
+            field.defaultVal(), field.order()));
       }
     }
     projection.setFields(fields);

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificReadWrite.java
@@ -188,7 +188,7 @@ public class TestSpecificReadWrite {
       }
 
       //Schema schemaClone = parser.parse(field.schema().toString(false));
-      Schema.Field fieldClone = new Schema.Field(name, field.schema(), field.doc(), field.defaultValue());
+      Schema.Field fieldClone = new Schema.Field(name, field.schema(), field.doc(), field.defaultVal());
       projectedFields.add(fieldClone);
     }
 


### PR DESCRIPTION
These fields are removed in Avro 1.9

https://jira.apache.org/jira/browse/PARQUET-1557