### PR TITLE
PARQUET-1593: Improve parquet-cli's example usage

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/Help.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/Help.java
@@ -111,11 +111,14 @@ public class Help implements Command {
       console.info("    {}\n\t{}",
           command, jc.getCommandDescription(command));
     }
-    console.info("\n  Examples:");
-    console.info("\n    # print information for create\n    {} help create",
-        programName);
-    console.info("\n  See '{} help <command>' for more information on a " +
+
+    jc.getCommands().keySet().stream().filter(s -> !s.equals("help")).findFirst().ifPresent(command -> {
+      console.info("\n  Examples:");
+      console.info("\n    # print information for {}\n    {} help {}",
+        command, programName, command);
+      console.info("\n  See '{} help <command>' for more information on a " +
         "specific command.", programName);
+    });
   }
 
   private boolean printOption(Logger console, ParameterDescription param) {


### PR DESCRIPTION
The following description is a bit weird since there's no command
called "create" actually. This PR replaces the subcommand with an
actually existent one.

```
  Examples:

    # print information for create
    parquet help create
```

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1593
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I think no additional test is required since this PR only changes the help message and its implementation is simple and straightforward. I ran the revised version manually and confirmed that it worked as expected.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
