### PR TITLE
PARQUET-1580: Page-level CRC checksum verfication for DataPageV1

### DIFF
--- a/parquet-benchmarks/run_checksums.sh
+++ b/parquet-benchmarks/run_checksums.sh
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# !/usr/bin/env bash
+
+SCRIPT_PATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+echo "Page level CRC checksum benchmarks"
+echo "Running write benchmarks"
+java -jar ${SCRIPT_PATH}/target/parquet-benchmarks.jar p*PageChecksumWriteBenchmarks -bm ss "$@"
+echo "Running read benchmarks"
+java -jar ${SCRIPT_PATH}/target/parquet-benchmarks.jar p*PageChecksumReadBenchmarks -bm ss "$@"

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/BenchmarkFiles.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/BenchmarkFiles.java
@@ -37,4 +37,26 @@ public class BenchmarkFiles {
 //  public final Path parquetFile_1M_LZO = new Path("target/tests/ParquetBenchmarks/PARQUET-1M-LZO");
   public static final Path file_1M_SNAPPY = new Path(TARGET_DIR + "/PARQUET-1M-SNAPPY");
   public static final Path file_1M_GZIP = new Path(TARGET_DIR + "/PARQUET-1M-GZIP");
+
+  // Page checksum files
+  public static final Path file_100K_CHECKSUMS_UNCOMPRESSED = new Path(TARGET_DIR + "/PARQUET-100K-CHECKSUMS-UNCOMPRESSED");
+  public static final Path file_100K_NOCHECKSUMS_UNCOMPRESSED = new Path(TARGET_DIR + "/PARQUET-100K-NOCHECKSUMS-UNCOMPRESSED");
+  public static final Path file_1M_CHECKSUMS_UNCOMPRESSED = new Path(TARGET_DIR + "/PARQUET-1M-CHECKSUMS-UNCOMPRESSED");
+  public static final Path file_1M_NOCHECKSUMS_UNCOMPRESSED = new Path(TARGET_DIR + "/PARQUET-1M-NOCHECKSUMS-UNCOMPRESSED");
+  public static final Path file_10M_CHECKSUMS_UNCOMPRESSED = new Path(TARGET_DIR + "/PARQUET-10M-CHECKSUMS-UNCOMPRESSED");
+  public static final Path file_10M_NOCHECKSUMS_UNCOMPRESSED = new Path(TARGET_DIR + "/PARQUET-10M-NOCHECKSUMS-UNCOMPRESSED");
+
+  public static final Path file_100K_CHECKSUMS_GZIP = new Path(TARGET_DIR + "/PARQUET-100K-CHECKSUMS-GZIP");
+  public static final Path file_100K_NOCHECKSUMS_GZIP = new Path(TARGET_DIR + "/PARQUET-100K-NOCHECKSUMS-GZIP");
+  public static final Path file_1M_CHECKSUMS_GZIP = new Path(TARGET_DIR + "/PARQUET-1M-CHECKSUMS-GZIP");
+  public static final Path file_1M_NOCHECKSUMS_GZIP = new Path(TARGET_DIR + "/PARQUET-1M-NOCHECKSUMS-GZIP");
+  public static final Path file_10M_CHECKSUMS_GZIP = new Path(TARGET_DIR + "/PARQUET-10M-CHECKSUMS-GZIP");
+  public static final Path file_10M_NOCHECKSUMS_GZIP = new Path(TARGET_DIR + "/PARQUET-10M-NOCHECKSUMS-GZIP");
+
+  public static final Path file_100K_CHECKSUMS_SNAPPY = new Path(TARGET_DIR + "/PARQUET-100K-CHECKSUMS-SNAPPY");
+  public static final Path file_100K_NOCHECKSUMS_SNAPPY = new Path(TARGET_DIR + "/PARQUET-100K-NOCHECKSUMS-SNAPPY");
+  public static final Path file_1M_CHECKSUMS_SNAPPY = new Path(TARGET_DIR + "/PARQUET-1M-CHECKSUMS-SNAPPY");
+  public static final Path file_1M_NOCHECKSUMS_SNAPPY = new Path(TARGET_DIR + "/PARQUET-1M-NOCHECKSUMS-SNAPPY");
+  public static final Path file_10M_CHECKSUMS_SNAPPY = new Path(TARGET_DIR + "/PARQUET-10M-CHECKSUMS-SNAPPY");
+  public static final Path file_10M_NOCHECKSUMS_SNAPPY = new Path(TARGET_DIR + "/PARQUET-10M-NOCHECKSUMS-SNAPPY");
 }

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/PageChecksumDataGenerator.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/PageChecksumDataGenerator.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.benchmarks;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.GroupFactory;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+
+import static java.util.UUID.randomUUID;
+import static org.apache.parquet.benchmarks.BenchmarkConstants.*;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.*;
+
+import java.io.IOException;
+import java.util.Random;
+
+import static org.apache.parquet.benchmarks.BenchmarkUtils.deleteIfExists;
+import static org.apache.parquet.benchmarks.BenchmarkUtils.exists;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.*;
+
+public class PageChecksumDataGenerator {
+
+  private final MessageType SCHEMA = MessageTypeParser.parseMessageType(
+    "message m {" +
+      "  required int64 long_field;" +
+      "  required binary binary_field;" +
+      "  required group group {" +
+      "    repeated int32 int_field;" +
+      "  }" +
+      "}");
+
+  public void generateData(Path outFile, int nRows, boolean writeChecksums,
+                           CompressionCodecName compression) throws IOException {
+    if (exists(configuration, outFile)) {
+      System.out.println("File already exists " + outFile);
+      return;
+    }
+
+    ParquetWriter<Group> writer = ExampleParquetWriter.builder(outFile)
+      .withConf(configuration)
+      .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
+      .withCompressionCodec(compression)
+      .withDictionaryEncoding(true)
+      .withType(SCHEMA)
+      .withPageWriteChecksumEnabled(writeChecksums)
+      .build();
+
+    GroupFactory groupFactory = new SimpleGroupFactory(SCHEMA);
+    Random rand = new Random(42);
+    for (int i = 0; i < nRows; i++) {
+      Group group = groupFactory.newGroup();
+      group
+        .append("long_field", (long) i)
+        .append("binary_field", randomUUID().toString())
+        .addGroup("group")
+        // Force dictionary encoding by performing modulo
+        .append("int_field", rand.nextInt() % 100)
+        .append("int_field", rand.nextInt() % 100)
+        .append("int_field", rand.nextInt() % 100)
+        .append("int_field", rand.nextInt() % 100);
+      writer.write(group);
+    }
+
+    writer.close();
+  }
+
+  public void generateAll() {
+    try {
+      // No need to generate the non-checksum versions, as the files generated here are only used in
+      // the read benchmarks
+      generateData(file_100K_CHECKSUMS_UNCOMPRESSED, 100 * ONE_K, true, UNCOMPRESSED);
+      generateData(file_100K_CHECKSUMS_GZIP, 100 * ONE_K, true, GZIP);
+      generateData(file_100K_CHECKSUMS_SNAPPY, 100 * ONE_K, true, SNAPPY);
+      generateData(file_1M_CHECKSUMS_UNCOMPRESSED, ONE_MILLION, true, UNCOMPRESSED);
+      generateData(file_1M_CHECKSUMS_GZIP, ONE_MILLION, true, GZIP);
+      generateData(file_1M_CHECKSUMS_SNAPPY, ONE_MILLION, true, SNAPPY);
+      generateData(file_10M_CHECKSUMS_UNCOMPRESSED, 10 * ONE_MILLION, true, UNCOMPRESSED);
+      generateData(file_10M_CHECKSUMS_GZIP, 10 * ONE_MILLION, true, GZIP);
+      generateData(file_10M_CHECKSUMS_SNAPPY, 10 * ONE_MILLION, true, SNAPPY);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void cleanup() {
+    deleteIfExists(configuration, file_100K_NOCHECKSUMS_UNCOMPRESSED);
+    deleteIfExists(configuration, file_100K_CHECKSUMS_UNCOMPRESSED);
+    deleteIfExists(configuration, file_100K_NOCHECKSUMS_GZIP);
+    deleteIfExists(configuration, file_100K_CHECKSUMS_GZIP);
+    deleteIfExists(configuration, file_100K_NOCHECKSUMS_SNAPPY);
+    deleteIfExists(configuration, file_100K_CHECKSUMS_SNAPPY);
+    deleteIfExists(configuration, file_1M_NOCHECKSUMS_UNCOMPRESSED);
+    deleteIfExists(configuration, file_1M_CHECKSUMS_UNCOMPRESSED);
+    deleteIfExists(configuration, file_1M_NOCHECKSUMS_GZIP);
+    deleteIfExists(configuration, file_1M_CHECKSUMS_GZIP);
+    deleteIfExists(configuration, file_1M_NOCHECKSUMS_SNAPPY);
+    deleteIfExists(configuration, file_1M_CHECKSUMS_SNAPPY);
+    deleteIfExists(configuration, file_10M_NOCHECKSUMS_UNCOMPRESSED);
+    deleteIfExists(configuration, file_10M_CHECKSUMS_UNCOMPRESSED);
+    deleteIfExists(configuration, file_10M_NOCHECKSUMS_GZIP);
+    deleteIfExists(configuration, file_10M_CHECKSUMS_GZIP);
+    deleteIfExists(configuration, file_10M_NOCHECKSUMS_SNAPPY);
+    deleteIfExists(configuration, file_10M_CHECKSUMS_SNAPPY);
+  }
+}

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/PageChecksumReadBenchmarks.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/PageChecksumReadBenchmarks.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.benchmarks;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.hadoop.*;
+import org.apache.parquet.hadoop.example.GroupReadSupport;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static org.apache.parquet.benchmarks.BenchmarkConstants.*;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.*;
+
+import java.io.IOException;
+
+@State(Scope.Thread)
+public class PageChecksumReadBenchmarks {
+
+  private PageChecksumDataGenerator pageChecksumDataGenerator = new PageChecksumDataGenerator();
+
+  @Setup(Level.Trial)
+  public void setup() throws IOException {
+    pageChecksumDataGenerator.generateAll();
+  }
+
+  @Setup(Level.Trial)
+  public void cleanup() {
+    pageChecksumDataGenerator.cleanup();
+  }
+
+  private void readFile(Path file, int nRows, boolean verifyChecksums, Blackhole blackhole)
+    throws IOException {
+    ParquetReader<Group> reader = ParquetReader.builder(new GroupReadSupport(), file)
+      .withConf(configuration)
+      .usePageChecksumVerification(verifyChecksums)
+      .build();
+    for (int i = 0; i < nRows; i++) {
+      Group group = reader.read();
+      blackhole.consume(group.getLong("long_field", 0));
+      blackhole.consume(group.getBinary("binary_field", 0));
+      Group subgroup = group.getGroup("group", 0);
+      blackhole.consume(subgroup.getInteger("int_field", 0));
+      blackhole.consume(subgroup.getInteger("int_field", 1));
+      blackhole.consume(subgroup.getInteger("int_field", 2));
+      blackhole.consume(subgroup.getInteger("int_field", 3));
+    }
+    reader.close();
+  }
+
+  // 100k rows, uncompressed, GZIP, Snappy
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read100KRowsUncompressedWithoutVerification(Blackhole blackhole) throws IOException {
+    readFile(file_100K_CHECKSUMS_UNCOMPRESSED, 100 * ONE_K, false, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read100KRowsUncompressedWithVerification(Blackhole blackhole) throws IOException {
+    readFile(file_100K_CHECKSUMS_UNCOMPRESSED, 100 * ONE_K, true, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read100KRowsGzipWithoutVerification(Blackhole blackhole) throws IOException {
+    readFile(file_100K_CHECKSUMS_GZIP, 100 * ONE_K, false, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read100KRowsGzipWithVerification(Blackhole blackhole) throws IOException {
+    readFile(file_100K_CHECKSUMS_GZIP, 100 * ONE_K, true, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read100KRowsSnappyWithoutVerification(Blackhole blackhole) throws IOException {
+    readFile(file_100K_CHECKSUMS_SNAPPY, 100 * ONE_K, false, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read100KRowsSnappyWithVerification(Blackhole blackhole) throws IOException {
+    readFile(file_100K_CHECKSUMS_SNAPPY, 100 * ONE_K, true, blackhole);
+  }
+
+  // 1M rows, uncompressed, GZIP, Snappy
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read1MRowsUncompressedWithoutVerification(Blackhole blackhole) throws IOException {
+    readFile(file_1M_CHECKSUMS_UNCOMPRESSED, ONE_MILLION, false, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read1MRowsUncompressedWithVerification(Blackhole blackhole) throws IOException {
+    readFile(file_1M_CHECKSUMS_UNCOMPRESSED, ONE_MILLION, true, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read1MRowsGzipWithoutVerification(Blackhole blackhole) throws IOException {
+    readFile(file_1M_CHECKSUMS_GZIP, ONE_MILLION, false, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read1MRowsGzipWithVerification(Blackhole blackhole) throws IOException {
+    readFile(file_1M_CHECKSUMS_GZIP, ONE_MILLION, true, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read1MRowsSnappyWithoutVerification(Blackhole blackhole) throws IOException {
+    readFile(file_1M_CHECKSUMS_SNAPPY, ONE_MILLION, false, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read1MRowsSnappyWithVerification(Blackhole blackhole) throws IOException {
+    readFile(file_1M_CHECKSUMS_SNAPPY, ONE_MILLION, true, blackhole);
+  }
+
+  // 10M rows, uncompressed, GZIP, Snappy
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read10MRowsUncompressedWithoutVerification(Blackhole blackhole) throws IOException {
+    readFile(file_10M_CHECKSUMS_UNCOMPRESSED, 10 * ONE_MILLION, false, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read10MRowsUncompressedWithVerification(Blackhole blackhole) throws IOException {
+    readFile(file_10M_CHECKSUMS_UNCOMPRESSED, 10 * ONE_MILLION, true, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read10MRowsGzipWithoutVerification(Blackhole blackhole) throws IOException {
+    readFile(file_10M_CHECKSUMS_GZIP, 10 * ONE_MILLION, false, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read10MRowsGzipWithVerification(Blackhole blackhole) throws IOException {
+    readFile(file_10M_CHECKSUMS_GZIP, 10 * ONE_MILLION, true, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read10MRowsSnappyWithoutVerification(Blackhole blackhole) throws IOException {
+    readFile(file_10M_CHECKSUMS_SNAPPY, 10 * ONE_MILLION, false, blackhole);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void read10MRowsSnappyWithVerification(Blackhole blackhole) throws IOException {
+    readFile(file_10M_CHECKSUMS_SNAPPY, 10 * ONE_MILLION, true, blackhole);
+  }
+
+}

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/PageChecksumWriteBenchmarks.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/PageChecksumWriteBenchmarks.java
@@ -18,10 +18,34 @@
  */
 package org.apache.parquet.benchmarks;
 
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
 
-import static org.apache.parquet.benchmarks.BenchmarkConstants.*;
-import static org.apache.parquet.benchmarks.BenchmarkFiles.*;
+import static org.apache.parquet.benchmarks.BenchmarkConstants.ONE_K;
+import static org.apache.parquet.benchmarks.BenchmarkConstants.ONE_MILLION;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_100K_CHECKSUMS_UNCOMPRESSED;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_100K_NOCHECKSUMS_UNCOMPRESSED;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_100K_CHECKSUMS_GZIP;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_100K_NOCHECKSUMS_GZIP;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_100K_CHECKSUMS_SNAPPY;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_100K_NOCHECKSUMS_SNAPPY;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_1M_CHECKSUMS_UNCOMPRESSED;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_1M_NOCHECKSUMS_UNCOMPRESSED;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_1M_CHECKSUMS_GZIP;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_1M_NOCHECKSUMS_GZIP;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_1M_CHECKSUMS_SNAPPY;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_1M_NOCHECKSUMS_SNAPPY;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_10M_CHECKSUMS_UNCOMPRESSED;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_10M_NOCHECKSUMS_UNCOMPRESSED;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_10M_CHECKSUMS_GZIP;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_10M_NOCHECKSUMS_GZIP;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_10M_CHECKSUMS_SNAPPY;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.file_10M_NOCHECKSUMS_SNAPPY;
 
 import java.io.IOException;
 

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/PageChecksumWriteBenchmarks.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/PageChecksumWriteBenchmarks.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.benchmarks;
+
+import org.openjdk.jmh.annotations.*;
+
+import static org.apache.parquet.benchmarks.BenchmarkConstants.*;
+import static org.apache.parquet.benchmarks.BenchmarkFiles.*;
+
+import java.io.IOException;
+
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.*;
+
+@State(Scope.Thread)
+public class PageChecksumWriteBenchmarks {
+
+  private PageChecksumDataGenerator pageChecksumDataGenerator = new PageChecksumDataGenerator();
+
+  @Setup(Level.Iteration)
+  public void cleanup() {
+    pageChecksumDataGenerator.cleanup();
+  }
+
+  // 100k rows, uncompressed, GZIP, Snappy
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write100KRowsUncompressedWithoutChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_100K_NOCHECKSUMS_UNCOMPRESSED, 100 * ONE_K, false, UNCOMPRESSED);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write100KRowsUncompressedWithChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_100K_CHECKSUMS_UNCOMPRESSED, 100 * ONE_K, true, UNCOMPRESSED);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write100KRowsGzipWithoutChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_100K_NOCHECKSUMS_GZIP, 100 * ONE_K, false, GZIP);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write100KRowsGzipWithChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_100K_CHECKSUMS_GZIP, 100 * ONE_K, true, GZIP);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write100KRowsSnappyWithoutChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_100K_NOCHECKSUMS_SNAPPY, 100 * ONE_K, false, SNAPPY);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write100KRowsSnappyWithChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_100K_CHECKSUMS_SNAPPY, 100 * ONE_K, true, SNAPPY);
+  }
+
+  // 1M rows, uncompressed, GZIP, Snappy
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write1MRowsUncompressedWithoutChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_1M_NOCHECKSUMS_UNCOMPRESSED, ONE_MILLION, false, UNCOMPRESSED);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write1MRowsUncompressedWithChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_1M_CHECKSUMS_UNCOMPRESSED, ONE_MILLION, true, UNCOMPRESSED);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write1MRowsGzipWithoutChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_1M_NOCHECKSUMS_GZIP, ONE_MILLION, false, GZIP);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write1MRowsGzipWithChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_1M_CHECKSUMS_GZIP, ONE_MILLION, true, GZIP);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write1MRowsSnappyWithoutChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_1M_NOCHECKSUMS_SNAPPY, ONE_MILLION, false, SNAPPY);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write1MRowsSnappyWithChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_1M_CHECKSUMS_SNAPPY, ONE_MILLION, true, SNAPPY);
+  }
+
+  // 10M rows, uncompressed, GZIP, Snappy
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write10MRowsUncompressedWithoutChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_10M_NOCHECKSUMS_UNCOMPRESSED, 10 * ONE_MILLION, false, UNCOMPRESSED);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write10MRowsUncompressedWithChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_10M_CHECKSUMS_UNCOMPRESSED, 10 * ONE_MILLION, true, UNCOMPRESSED);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write10MRowsGzipWithoutChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_10M_NOCHECKSUMS_GZIP, 10 * ONE_MILLION, false, GZIP);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write10MRowsGzipWithChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_10M_CHECKSUMS_GZIP, 10 * ONE_MILLION, true, GZIP);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write10MRowsSnappyWithoutChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_10M_NOCHECKSUMS_SNAPPY, 10 * ONE_MILLION, false, SNAPPY);
+  }
+
+  @Benchmark @BenchmarkMode(Mode.SingleShotTime)
+  public void write10MRowsSnappyWithChecksums() throws IOException {
+    pageChecksumDataGenerator.generateData(file_10M_CHECKSUMS_SNAPPY, 10 * ONE_MILLION, true, SNAPPY);
+  }
+
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -109,7 +109,6 @@ public class ParquetProperties {
     this.valuesWriterFactory = writerFactory;
     this.columnIndexTruncateLength = columnIndexMinMaxTruncateLength;
     this.pageRowCountLimit = pageRowCountLimit;
-
     this.pageWriteChecksumEnabled = pageWriteChecksumEnabled;
   }
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -50,7 +50,7 @@ public class ParquetProperties {
   public static final int DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH = 64;
   public static final int DEFAULT_PAGE_ROW_COUNT_LIMIT = 20_000;
 
-  public static final boolean DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED = false;
+  public static final boolean DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED = true;
 
   public static final ValuesWriterFactory DEFAULT_VALUES_WRITER_FACTORY = new DefaultValuesWriterFactory();
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -50,7 +50,6 @@ public class ParquetProperties {
   public static final int DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH = 64;
   public static final int DEFAULT_PAGE_ROW_COUNT_LIMIT = 20_000;
 
-  public static final boolean DEFAULT_PAGE_VERIFY_CHECKSUM_ENABLED = false;
   public static final boolean DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED = false;
 
   public static final ValuesWriterFactory DEFAULT_VALUES_WRITER_FACTORY = new DefaultValuesWriterFactory();

--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -50,6 +50,9 @@ public class ParquetProperties {
   public static final int DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH = 64;
   public static final int DEFAULT_PAGE_ROW_COUNT_LIMIT = 20_000;
 
+  public static final boolean DEFAULT_PAGE_VERIFY_CHECKSUM_ENABLED = false;
+  public static final boolean DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED = false;
+
   public static final ValuesWriterFactory DEFAULT_VALUES_WRITER_FACTORY = new DefaultValuesWriterFactory();
 
   private static final int MIN_SLAB_SIZE = 64;
@@ -87,10 +90,12 @@ public class ParquetProperties {
   private final ValuesWriterFactory valuesWriterFactory;
   private final int columnIndexTruncateLength;
   private final int pageRowCountLimit;
+  private final boolean pageWriteChecksumEnabled;
 
   private ParquetProperties(WriterVersion writerVersion, int pageSize, int dictPageSize, boolean enableDict, int minRowCountForPageSizeCheck,
                             int maxRowCountForPageSizeCheck, boolean estimateNextSizeCheck, ByteBufferAllocator allocator,
-                            ValuesWriterFactory writerFactory, int columnIndexMinMaxTruncateLength, int pageRowCountLimit) {
+                            ValuesWriterFactory writerFactory, int columnIndexMinMaxTruncateLength, int pageRowCountLimit,
+                            boolean pageWriteChecksumEnabled) {
     this.pageSizeThreshold = pageSize;
     this.initialSlabSize = CapacityByteArrayOutputStream
       .initialSlabSizeHeuristic(MIN_SLAB_SIZE, pageSizeThreshold, 10);
@@ -105,6 +110,8 @@ public class ParquetProperties {
     this.valuesWriterFactory = writerFactory;
     this.columnIndexTruncateLength = columnIndexMinMaxTruncateLength;
     this.pageRowCountLimit = pageRowCountLimit;
+
+    this.pageWriteChecksumEnabled = pageWriteChecksumEnabled;
   }
 
   public ValuesWriter newRepetitionLevelWriter(ColumnDescriptor path) {
@@ -201,6 +208,10 @@ public class ParquetProperties {
     return pageRowCountLimit;
   }
 
+  public boolean getPageWriteChecksumEnabled() {
+    return pageWriteChecksumEnabled;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -221,6 +232,7 @@ public class ParquetProperties {
     private ValuesWriterFactory valuesWriterFactory = DEFAULT_VALUES_WRITER_FACTORY;
     private int columnIndexTruncateLength = DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH;
     private int pageRowCountLimit = DEFAULT_PAGE_ROW_COUNT_LIMIT;
+    private boolean pageWriteChecksumEnabled = DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED;
 
     private Builder() {
     }
@@ -236,6 +248,7 @@ public class ParquetProperties {
       this.valuesWriterFactory = toCopy.valuesWriterFactory;
       this.allocator = toCopy.allocator;
       this.pageRowCountLimit = toCopy.pageRowCountLimit;
+      this.pageWriteChecksumEnabled = toCopy.pageWriteChecksumEnabled;
     }
 
     /**
@@ -330,11 +343,17 @@ public class ParquetProperties {
       return this;
     }
 
+    public Builder withPageWriteChecksumEnabled(boolean val) {
+      this.pageWriteChecksumEnabled = val;
+      return this;
+    }
+
     public ParquetProperties build() {
       ParquetProperties properties =
         new ParquetProperties(writerVersion, pageSize, dictPageSize,
           enableDict, minRowCountForPageSizeCheck, maxRowCountForPageSizeCheck,
-          estimateNextSizeCheck, allocator, valuesWriterFactory, columnIndexTruncateLength, pageRowCountLimit);
+          estimateNextSizeCheck, allocator, valuesWriterFactory, columnIndexTruncateLength,
+          pageRowCountLimit, pageWriteChecksumEnabled);
       // we pass a constructed but uninitialized factory to ParquetProperties above as currently
       // creation of ValuesWriters is invoked from within ParquetProperties. In the future
       // we'd like to decouple that and won't need to pass an object to properties and then pass the

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/DataPageV1.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/DataPageV1.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -33,10 +33,6 @@ public class DataPageV1 extends DataPage {
   private final Encoding valuesEncoding;
   private final int indexRowCount;
 
-  // We need an additional flag, since we can not use a default value for the crc32
-  private final int crc32;
-  private final boolean isSetCrc32;
-
   /**
    * @param bytes the bytes for this page
    * @param valueCount count of values in this page
@@ -45,11 +41,8 @@ public class DataPageV1 extends DataPage {
    * @param rlEncoding the repetition level encoding for this page
    * @param dlEncoding the definition level encoding for this page
    * @param valuesEncoding the values encoding for this page
-   * @param crc32 the crc32 for this page
    */
-  private DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize,
-                    Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding,
-                    Encoding valuesEncoding, int crc32, boolean isSetCrc32) {
+  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding, Encoding valuesEncoding) {
     super(Math.toIntExact(bytes.size()), uncompressedSize, valueCount);
     this.bytes = bytes;
     this.statistics = statistics;
@@ -57,41 +50,6 @@ public class DataPageV1 extends DataPage {
     this.dlEncoding = dlEncoding;
     this.valuesEncoding = valuesEncoding;
     this.indexRowCount = -1;
-    this.crc32 = crc32;
-    this.isSetCrc32 = isSetCrc32;
-  }
-
-  /**
-   * @param bytes the bytes for this page
-   * @param valueCount count of values in this page
-   * @param uncompressedSize the uncompressed size of the page
-   * @param statistics of the page's values (max, min, num_null)
-   * @param rlEncoding the repetition level encoding for this page
-   * @param dlEncoding the definition level encoding for this page
-   * @param valuesEncoding the values encoding for this page
-   */
-  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize,
-                    Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding,
-                    Encoding valuesEncoding) {
-    this(bytes, valueCount, uncompressedSize, statistics, rlEncoding, dlEncoding, valuesEncoding,
-      0, false);
-  }
-
-  /**
-   * @param bytes the bytes for this page
-   * @param valueCount count of values in this page
-   * @param uncompressedSize the uncompressed size of the page
-   * @param statistics of the page's values (max, min, num_null)
-   * @param rlEncoding the repetition level encoding for this page
-   * @param dlEncoding the definition level encoding for this page
-   * @param valuesEncoding the values encoding for this page
-   * @param crc32 the crc32 for this page
-   */
-  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize,
-                    Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding,
-                    Encoding valuesEncoding, int crc32) {
-    this(bytes, valueCount, uncompressedSize, statistics, rlEncoding, dlEncoding, valuesEncoding,
-      crc32, true);
   }
 
   /**
@@ -104,11 +62,9 @@ public class DataPageV1 extends DataPage {
    * @param rlEncoding the repetition level encoding for this page
    * @param dlEncoding the definition level encoding for this page
    * @param valuesEncoding the values encoding for this page
-   * @param crc32 the crc32 for this page
    */
-  private DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, long firstRowIndex,
-                    int rowCount, Statistics<?> statistics, Encoding rlEncoding,
-                    Encoding dlEncoding, Encoding valuesEncoding, int crc32, boolean isSetCrc32) {
+  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, long firstRowIndex, int rowCount,
+                    Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding, Encoding valuesEncoding) {
     super(Math.toIntExact(bytes.size()), uncompressedSize, valueCount, firstRowIndex);
     this.bytes = bytes;
     this.statistics = statistics;
@@ -116,45 +72,6 @@ public class DataPageV1 extends DataPage {
     this.dlEncoding = dlEncoding;
     this.valuesEncoding = valuesEncoding;
     this.indexRowCount = rowCount;
-    this.crc32 = crc32;
-    this.isSetCrc32 = isSetCrc32;
-  }
-
-  /**
-   * @param bytes the bytes for this page
-   * @param valueCount count of values in this page
-   * @param uncompressedSize the uncompressed size of the page
-   * @param firstRowIndex the index of the first row in this page
-   * @param rowCount the number of rows in this page
-   * @param statistics of the page's values (max, min, num_null)
-   * @param rlEncoding the repetition level encoding for this page
-   * @param dlEncoding the definition level encoding for this page
-   * @param valuesEncoding the values encoding for this page
-   */
-  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, long firstRowIndex,
-                    int rowCount, Statistics<?> statistics, Encoding rlEncoding,
-                    Encoding dlEncoding, Encoding valuesEncoding) {
-    this(bytes, valueCount, uncompressedSize, firstRowIndex, rowCount, statistics, rlEncoding,
-      dlEncoding, valuesEncoding, 0, false);
-  }
-
-  /**
-   * @param bytes the bytes for this page
-   * @param valueCount count of values in this page
-   * @param uncompressedSize the uncompressed size of the page
-   * @param firstRowIndex the index of the first row in this page
-   * @param rowCount the number of rows in this page
-   * @param statistics of the page's values (max, min, num_null)
-   * @param rlEncoding the repetition level encoding for this page
-   * @param dlEncoding the definition level encoding for this page
-   * @param valuesEncoding the values encoding for this page
-   * @param crc32 the crc32 for this page
-   */
-  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, long firstRowIndex,
-                    int rowCount, Statistics<?> statistics, Encoding rlEncoding,
-                    Encoding dlEncoding, Encoding valuesEncoding, int crc32) {
-    this(bytes, valueCount, uncompressedSize, firstRowIndex, rowCount, statistics, rlEncoding,
-      dlEncoding, valuesEncoding, crc32, true);
   }
 
   /**
@@ -193,25 +110,9 @@ public class DataPageV1 extends DataPage {
     return valuesEncoding;
   }
 
-  /**
-   * @return the crc32 for this page
-   */
-  public int getCrc32() {
-    return crc32;
-  }
-
-  /**
-   * @return the boolean representing whether the crc32 field is actually set
-   */
-  public boolean isSetCrc32() {
-    return isSetCrc32;
-  }
-
   @Override
   public String toString() {
-    return "Page [bytes.size=" + bytes.size() + ", valueCount=" + getValueCount() +
-      ", uncompressedSize=" + getUncompressedSize() + (isSetCrc32() ? ", crc=" + getCrc32() : "" )
-      + "]";
+    return "Page [bytes.size=" + bytes.size() + ", valueCount=" + getValueCount() + ", uncompressedSize=" + getUncompressedSize() + "]";
   }
 
   @Override

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/DataPageV1.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/DataPageV1.java
@@ -33,6 +33,34 @@ public class DataPageV1 extends DataPage {
   private final Encoding valuesEncoding;
   private final int indexRowCount;
 
+  // We need an additional flag, since we can not use a default value for the crc32
+  private final int crc32;
+  private final boolean isSetCrc32;
+
+  /**
+   * @param bytes the bytes for this page
+   * @param valueCount count of values in this page
+   * @param uncompressedSize the uncompressed size of the page
+   * @param statistics of the page's values (max, min, num_null)
+   * @param rlEncoding the repetition level encoding for this page
+   * @param dlEncoding the definition level encoding for this page
+   * @param valuesEncoding the values encoding for this page
+   * @param crc32 the crc32 for this page
+   */
+  private DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize,
+                    Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding,
+                    Encoding valuesEncoding, int crc32, boolean isSetCrc32) {
+    super(Math.toIntExact(bytes.size()), uncompressedSize, valueCount);
+    this.bytes = bytes;
+    this.statistics = statistics;
+    this.rlEncoding = rlEncoding;
+    this.dlEncoding = dlEncoding;
+    this.valuesEncoding = valuesEncoding;
+    this.indexRowCount = -1;
+    this.crc32 = crc32;
+    this.isSetCrc32 = isSetCrc32;
+  }
+
   /**
    * @param bytes the bytes for this page
    * @param valueCount count of values in this page
@@ -42,14 +70,54 @@ public class DataPageV1 extends DataPage {
    * @param dlEncoding the definition level encoding for this page
    * @param valuesEncoding the values encoding for this page
    */
-  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding, Encoding valuesEncoding) {
-    super(Math.toIntExact(bytes.size()), uncompressedSize, valueCount);
+  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize,
+                    Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding,
+                    Encoding valuesEncoding) {
+    this(bytes, valueCount, uncompressedSize, statistics, rlEncoding, dlEncoding, valuesEncoding,
+      0, false);
+  }
+
+  /**
+   * @param bytes the bytes for this page
+   * @param valueCount count of values in this page
+   * @param uncompressedSize the uncompressed size of the page
+   * @param statistics of the page's values (max, min, num_null)
+   * @param rlEncoding the repetition level encoding for this page
+   * @param dlEncoding the definition level encoding for this page
+   * @param valuesEncoding the values encoding for this page
+   * @param crc32 the crc32 for this page
+   */
+  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize,
+                    Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding,
+                    Encoding valuesEncoding, int crc32) {
+    this(bytes, valueCount, uncompressedSize, statistics, rlEncoding, dlEncoding, valuesEncoding,
+      crc32, true);
+  }
+
+  /**
+   * @param bytes the bytes for this page
+   * @param valueCount count of values in this page
+   * @param uncompressedSize the uncompressed size of the page
+   * @param firstRowIndex the index of the first row in this page
+   * @param rowCount the number of rows in this page
+   * @param statistics of the page's values (max, min, num_null)
+   * @param rlEncoding the repetition level encoding for this page
+   * @param dlEncoding the definition level encoding for this page
+   * @param valuesEncoding the values encoding for this page
+   * @param crc32 the crc32 for this page
+   */
+  private DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, long firstRowIndex,
+                    int rowCount, Statistics<?> statistics, Encoding rlEncoding,
+                    Encoding dlEncoding, Encoding valuesEncoding, int crc32, boolean isSetCrc32) {
+    super(Math.toIntExact(bytes.size()), uncompressedSize, valueCount, firstRowIndex);
     this.bytes = bytes;
     this.statistics = statistics;
     this.rlEncoding = rlEncoding;
     this.dlEncoding = dlEncoding;
     this.valuesEncoding = valuesEncoding;
-    this.indexRowCount = -1;
+    this.indexRowCount = rowCount;
+    this.crc32 = crc32;
+    this.isSetCrc32 = isSetCrc32;
   }
 
   /**
@@ -63,15 +131,30 @@ public class DataPageV1 extends DataPage {
    * @param dlEncoding the definition level encoding for this page
    * @param valuesEncoding the values encoding for this page
    */
-  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, long firstRowIndex, int rowCount,
-      Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding, Encoding valuesEncoding) {
-    super(Math.toIntExact(bytes.size()), uncompressedSize, valueCount, firstRowIndex);
-    this.bytes = bytes;
-    this.statistics = statistics;
-    this.rlEncoding = rlEncoding;
-    this.dlEncoding = dlEncoding;
-    this.valuesEncoding = valuesEncoding;
-    this.indexRowCount = rowCount;
+  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, long firstRowIndex,
+                    int rowCount, Statistics<?> statistics, Encoding rlEncoding,
+                    Encoding dlEncoding, Encoding valuesEncoding) {
+    this(bytes, valueCount, uncompressedSize, firstRowIndex, rowCount, statistics, rlEncoding,
+      dlEncoding, valuesEncoding, 0, false);
+  }
+
+  /**
+   * @param bytes the bytes for this page
+   * @param valueCount count of values in this page
+   * @param uncompressedSize the uncompressed size of the page
+   * @param firstRowIndex the index of the first row in this page
+   * @param rowCount the number of rows in this page
+   * @param statistics of the page's values (max, min, num_null)
+   * @param rlEncoding the repetition level encoding for this page
+   * @param dlEncoding the definition level encoding for this page
+   * @param valuesEncoding the values encoding for this page
+   * @param crc32 the crc32 for this page
+   */
+  public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, long firstRowIndex,
+                    int rowCount, Statistics<?> statistics, Encoding rlEncoding,
+                    Encoding dlEncoding, Encoding valuesEncoding, int crc32) {
+    this(bytes, valueCount, uncompressedSize, firstRowIndex, rowCount, statistics, rlEncoding,
+      dlEncoding, valuesEncoding, crc32, true);
   }
 
   /**
@@ -110,9 +193,25 @@ public class DataPageV1 extends DataPage {
     return valuesEncoding;
   }
 
+  /**
+   * @return the crc32 for this page
+   */
+  public int getCrc32() {
+    return crc32;
+  }
+
+  /**
+   * @return the boolean representing whether the crc32 field is actually set
+   */
+  public boolean isSetCrc32() {
+    return isSetCrc32;
+  }
+
   @Override
   public String toString() {
-    return "Page [bytes.size=" + bytes.size() + ", valueCount=" + getValueCount() + ", uncompressedSize=" + getUncompressedSize() + "]";
+    return "Page [bytes.size=" + bytes.size() + ", valueCount=" + getValueCount() +
+      ", uncompressedSize=" + getUncompressedSize() + (isSetCrc32() ? ", crc=" + getCrc32() : "" )
+      + "]";
   }
 
   @Override

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/DataPageV1.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/DataPageV1.java
@@ -1,4 +1,4 @@
-/*
+/* 
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * 
  *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -64,7 +64,7 @@ public class DataPageV1 extends DataPage {
    * @param valuesEncoding the values encoding for this page
    */
   public DataPageV1(BytesInput bytes, int valueCount, int uncompressedSize, long firstRowIndex, int rowCount,
-                    Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding, Encoding valuesEncoding) {
+      Statistics<?> statistics, Encoding rlEncoding, Encoding dlEncoding, Encoding valuesEncoding) {
     super(Math.toIntExact(bytes.size()), uncompressedSize, valueCount, firstRowIndex);
     this.bytes = bytes;
     this.statistics = statistics;

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/Page.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/Page.java
@@ -45,8 +45,8 @@ abstract public class Page {
     return uncompressedSize;
   }
 
-  // Note: the following fields are only used for testing purposes and are NOT used in checksum
-  // verification. The crc value here is merely a copy of the actual crc field read in
+  // Note: the following field is only used for testing purposes and are NOT used in checksum
+  // verification. There crc value here will merely be a copy of the actual crc field read in
   // ParquetFileReader.Chunk.readAllPages()
   private OptionalInt crc = OptionalInt.empty();
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/Page.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/Page.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.column.page;
 
+import java.util.OptionalInt;
+
 /**
  * one page in a chunk
  */
@@ -46,22 +48,15 @@ abstract public class Page {
   // Note: the following fields are only used for testing purposes and are NOT used in checksum
   // verification. The crc value here is merely a copy of the actual crc field read in
   // ParquetFileReader.Chunk.readAllPages()
-  private int crc;
-  private boolean isSetCrc = false;
+  private OptionalInt crc = OptionalInt.empty();
 
   // Visible for testing
   public void setCrc(int crc) {
-    this.crc = crc;
-    this.isSetCrc = true;
+    this.crc = OptionalInt.of(crc);
   }
 
   // Visible for testing
-  public int getCrc() {
+  public OptionalInt getCrc() {
     return crc;
-  }
-
-  // Visible for testing
-  public boolean isSetCrc() {
-    return isSetCrc;
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/Page.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/Page.java
@@ -43,4 +43,25 @@ abstract public class Page {
     return uncompressedSize;
   }
 
+  // Note: the following fields are only used for testing purposes and are NOT used in checksum
+  // verification. The crc value here is merely a copy of the actual crc field read in
+  // ParquetFileReader.Chunk.readAllPages()
+  private int crc;
+  private boolean isSetCrc = false;
+
+  // Visible for testing
+  public void setCrc(int crc) {
+    this.crc = crc;
+    this.isSetCrc = true;
+  }
+
+  // Visible for testing
+  public int getCrc() {
+    return crc;
+  }
+
+  // Visible for testing
+  public boolean isSetCrc() {
+    return isSetCrc;
+  }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
@@ -28,7 +28,12 @@ import org.apache.parquet.hadoop.util.HadoopCodecs;
 
 import java.util.Map;
 
-import static org.apache.parquet.hadoop.ParquetInputFormat.*;
+import static org.apache.parquet.hadoop.ParquetInputFormat.COLUMN_INDEX_FILTERING_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.DICTIONARY_FILTERING_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
+import static org.apache.parquet.hadoop.ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.RECORD_FILTERING_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.STATS_FILTERING_ENABLED;
 import static org.apache.parquet.hadoop.UnmaterializableRecordCounter.BAD_RECORD_THRESHOLD_CONF_KEY;
 
 public class HadoopReadOptions extends ParquetReadOptions {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
@@ -21,6 +21,7 @@ package org.apache.parquet;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.bytes.ByteBufferAllocator;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.format.converter.ParquetMetadataConverter.MetadataFilter;
@@ -28,11 +29,7 @@ import org.apache.parquet.hadoop.util.HadoopCodecs;
 
 import java.util.Map;
 
-import static org.apache.parquet.hadoop.ParquetInputFormat.COLUMN_INDEX_FILTERING_ENABLED;
-import static org.apache.parquet.hadoop.ParquetInputFormat.DICTIONARY_FILTERING_ENABLED;
-import static org.apache.parquet.hadoop.ParquetInputFormat.RECORD_FILTERING_ENABLED;
-import static org.apache.parquet.hadoop.ParquetInputFormat.STATS_FILTERING_ENABLED;
-import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
+import static org.apache.parquet.hadoop.ParquetInputFormat.*;
 import static org.apache.parquet.hadoop.UnmaterializableRecordCounter.BAD_RECORD_THRESHOLD_CONF_KEY;
 
 public class HadoopReadOptions extends ParquetReadOptions {
@@ -45,6 +42,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
                             boolean useDictionaryFilter,
                             boolean useRecordFilter,
                             boolean useColumnIndexFilter,
+                            boolean usePageChecksumVerification,
                             FilterCompat.Filter recordFilter,
                             MetadataFilter metadataFilter,
                             CompressionCodecFactory codecFactory,
@@ -54,7 +52,8 @@ public class HadoopReadOptions extends ParquetReadOptions {
                             Configuration conf) {
     super(
         useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter, useColumnIndexFilter,
-        recordFilter, metadataFilter, codecFactory, allocator, maxAllocationSize, properties
+        usePageChecksumVerification, recordFilter, metadataFilter, codecFactory, allocator, maxAllocationSize,
+        properties
     );
     this.conf = conf;
   }
@@ -86,6 +85,8 @@ public class HadoopReadOptions extends ParquetReadOptions {
       useStatsFilter(conf.getBoolean(STATS_FILTERING_ENABLED, true));
       useRecordFilter(conf.getBoolean(RECORD_FILTERING_ENABLED, true));
       useColumnIndexFilter(conf.getBoolean(COLUMN_INDEX_FILTERING_ENABLED, true));
+      usePageChecksumVerification(conf.getBoolean(PAGE_VERIFY_CHECKSUM_ENABLED,
+        ParquetProperties.DEFAULT_PAGE_VERIFY_CHECKSUM_ENABLED));
       withCodecFactory(HadoopCodecs.newFactory(conf, 0));
       withRecordFilter(getFilter(conf));
       withMaxAllocationInBytes(conf.getInt(ALLOCATION_SIZE, 8388608));
@@ -98,9 +99,9 @@ public class HadoopReadOptions extends ParquetReadOptions {
     @Override
     public ParquetReadOptions build() {
       return new HadoopReadOptions(
-          useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter, useColumnIndexFilter,
-          recordFilter, metadataFilter, codecFactory, allocator, maxAllocationSize, properties,
-          conf);
+        useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter,
+        useColumnIndexFilter, usePageChecksumVerification, recordFilter, metadataFilter,
+        codecFactory, allocator, maxAllocationSize, properties, conf);
     }
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
@@ -21,7 +21,6 @@ package org.apache.parquet;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.bytes.ByteBufferAllocator;
-import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.format.converter.ParquetMetadataConverter.MetadataFilter;
@@ -86,7 +85,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
       useRecordFilter(conf.getBoolean(RECORD_FILTERING_ENABLED, true));
       useColumnIndexFilter(conf.getBoolean(COLUMN_INDEX_FILTERING_ENABLED, true));
       usePageChecksumVerification(conf.getBoolean(PAGE_VERIFY_CHECKSUM_ENABLED,
-        PAGE_VERIFY_CHECKSUM_ENABLED_DEFAULT));
+        usePageChecksumVerification));
       withCodecFactory(HadoopCodecs.newFactory(conf, 0));
       withRecordFilter(getFilter(conf));
       withMaxAllocationInBytes(conf.getInt(ALLOCATION_SIZE, 8388608));

--- a/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
@@ -86,7 +86,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
       useRecordFilter(conf.getBoolean(RECORD_FILTERING_ENABLED, true));
       useColumnIndexFilter(conf.getBoolean(COLUMN_INDEX_FILTERING_ENABLED, true));
       usePageChecksumVerification(conf.getBoolean(PAGE_VERIFY_CHECKSUM_ENABLED,
-        ParquetProperties.DEFAULT_PAGE_VERIFY_CHECKSUM_ENABLED));
+        PAGE_VERIFY_CHECKSUM_ENABLED_DEFAULT));
       withCodecFactory(HadoopCodecs.newFactory(conf, 0));
       withRecordFilter(getFilter(conf));
       withMaxAllocationInBytes(conf.getInt(ALLOCATION_SIZE, 8388608));

--- a/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
@@ -40,12 +40,14 @@ public class ParquetReadOptions {
   private static final boolean DICTIONARY_FILTERING_ENABLED_DEFAULT = true;
   private static final boolean COLUMN_INDEX_FILTERING_ENABLED_DEFAULT = true;
   private static final int ALLOCATION_SIZE_DEFAULT = 8388608; // 8MB
+  private static final boolean PAGE_VERIFY_CHECKSUM_ENABLED_DEFAULT = false;
 
   private final boolean useSignedStringMinMax;
   private final boolean useStatsFilter;
   private final boolean useDictionaryFilter;
   private final boolean useRecordFilter;
   private final boolean useColumnIndexFilter;
+  private final boolean usePageChecksumVerification;
   private final FilterCompat.Filter recordFilter;
   private final ParquetMetadataConverter.MetadataFilter metadataFilter;
   private final CompressionCodecFactory codecFactory;
@@ -58,6 +60,7 @@ public class ParquetReadOptions {
                      boolean useDictionaryFilter,
                      boolean useRecordFilter,
                      boolean useColumnIndexFilter,
+                     boolean usePageChecksumVerification,
                      FilterCompat.Filter recordFilter,
                      ParquetMetadataConverter.MetadataFilter metadataFilter,
                      CompressionCodecFactory codecFactory,
@@ -69,6 +72,7 @@ public class ParquetReadOptions {
     this.useDictionaryFilter = useDictionaryFilter;
     this.useRecordFilter = useRecordFilter;
     this.useColumnIndexFilter = useColumnIndexFilter;
+    this.usePageChecksumVerification = usePageChecksumVerification;
     this.recordFilter = recordFilter;
     this.metadataFilter = metadataFilter;
     this.codecFactory = codecFactory;
@@ -95,6 +99,10 @@ public class ParquetReadOptions {
 
   public boolean useColumnIndexFilter() {
     return useColumnIndexFilter;
+  }
+
+  public boolean usePageChecksumVerification() {
+    return usePageChecksumVerification;
   }
 
   public FilterCompat.Filter getRecordFilter() {
@@ -143,6 +151,7 @@ public class ParquetReadOptions {
     protected boolean useDictionaryFilter = DICTIONARY_FILTERING_ENABLED_DEFAULT;
     protected boolean useRecordFilter = RECORD_FILTERING_ENABLED_DEFAULT;
     protected boolean useColumnIndexFilter = COLUMN_INDEX_FILTERING_ENABLED_DEFAULT;
+    protected boolean usePageChecksumVerification = PAGE_VERIFY_CHECKSUM_ENABLED_DEFAULT;
     protected FilterCompat.Filter recordFilter = null;
     protected ParquetMetadataConverter.MetadataFilter metadataFilter = NO_FILTER;
     // the page size parameter isn't used when only using the codec factory to get decompressors
@@ -200,6 +209,16 @@ public class ParquetReadOptions {
       return useColumnIndexFilter(true);
     }
 
+
+    public Builder usePageChecksumVerification(boolean usePageChecksumVerification) {
+      this.usePageChecksumVerification = usePageChecksumVerification;
+      return this;
+    }
+
+    public Builder usePageChecksumVerification() {
+      return usePageChecksumVerification(true);
+    }
+
     public Builder withRecordFilter(FilterCompat.Filter rowGroupFilter) {
       this.recordFilter = rowGroupFilter;
       return this;
@@ -235,6 +254,11 @@ public class ParquetReadOptions {
       return this;
     }
 
+    public Builder withPageChecksumVerification(boolean val) {
+      this.usePageChecksumVerification = val;
+      return this;
+    }
+
     public Builder set(String key, String value) {
       properties.put(key, value);
       return this;
@@ -249,6 +273,7 @@ public class ParquetReadOptions {
       withMetadataFilter(options.metadataFilter);
       withCodecFactory(options.codecFactory);
       withAllocator(options.allocator);
+      withPageChecksumVerification(options.usePageChecksumVerification);
       for (Map.Entry<String, String> keyValue : options.properties.entrySet()) {
         set(keyValue.getKey(), keyValue.getValue());
       }
@@ -257,8 +282,9 @@ public class ParquetReadOptions {
 
     public ParquetReadOptions build() {
       return new ParquetReadOptions(
-          useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter, useColumnIndexFilter,
-          recordFilter, metadataFilter, codecFactory, allocator, maxAllocationSize, properties);
+        useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter,
+        useColumnIndexFilter, usePageChecksumVerification, recordFilter, metadataFilter,
+        codecFactory, allocator, maxAllocationSize, properties);
     }
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -1338,15 +1338,13 @@ public class ParquetMetadataConverter {
       org.apache.parquet.column.Encoding rlEncoding,
       org.apache.parquet.column.Encoding dlEncoding,
       org.apache.parquet.column.Encoding valuesEncoding,
-      int crc,
       OutputStream to) throws IOException {
     writePageHeader(newDataPageHeader(uncompressedSize,
                                       compressedSize,
                                       valueCount,
                                       rlEncoding,
                                       dlEncoding,
-                                      valuesEncoding,
-                                      crc), to);
+                                      valuesEncoding), to);
   }
 
   // Statistics are no longer saved in page headers

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -1338,13 +1338,15 @@ public class ParquetMetadataConverter {
       org.apache.parquet.column.Encoding rlEncoding,
       org.apache.parquet.column.Encoding dlEncoding,
       org.apache.parquet.column.Encoding valuesEncoding,
+      int crc32,
       OutputStream to) throws IOException {
     writePageHeader(newDataPageHeader(uncompressedSize,
                                       compressedSize,
                                       valueCount,
                                       rlEncoding,
                                       dlEncoding,
-                                      valuesEncoding), to);
+                                      valuesEncoding,
+                                      crc32), to);
   }
 
   // Statistics are no longer saved in page headers
@@ -1365,13 +1367,29 @@ public class ParquetMetadataConverter {
   }
 
   private PageHeader newDataPageHeader(
+    int uncompressedSize, int compressedSize,
+    int valueCount,
+    org.apache.parquet.column.Encoding rlEncoding,
+    org.apache.parquet.column.Encoding dlEncoding,
+    org.apache.parquet.column.Encoding valuesEncoding) {
+    PageHeader pageHeader = new PageHeader(PageType.DATA_PAGE, uncompressedSize, compressedSize);
+    pageHeader.setData_page_header(new DataPageHeader(
+      valueCount,
+      getEncoding(valuesEncoding),
+      getEncoding(dlEncoding),
+      getEncoding(rlEncoding)));
+    return pageHeader;
+  }
+
+  private PageHeader newDataPageHeader(
       int uncompressedSize, int compressedSize,
       int valueCount,
       org.apache.parquet.column.Encoding rlEncoding,
       org.apache.parquet.column.Encoding dlEncoding,
-      org.apache.parquet.column.Encoding valuesEncoding) {
+      org.apache.parquet.column.Encoding valuesEncoding,
+      int crc32) {
     PageHeader pageHeader = new PageHeader(PageType.DATA_PAGE, uncompressedSize, compressedSize);
-    // TODO: pageHeader.crc = ...;
+    pageHeader.setCrc(crc32);
     pageHeader.setData_page_header(new DataPageHeader(
         valueCount,
         getEncoding(valuesEncoding),
@@ -1398,19 +1416,37 @@ public class ParquetMetadataConverter {
   }
 
   public void writeDataPageV1Header(
+    int uncompressedSize,
+    int compressedSize,
+    int valueCount,
+    org.apache.parquet.column.Encoding rlEncoding,
+    org.apache.parquet.column.Encoding dlEncoding,
+    org.apache.parquet.column.Encoding valuesEncoding,
+    OutputStream to) throws IOException {
+    writePageHeader(newDataPageHeader(uncompressedSize,
+      compressedSize,
+      valueCount,
+      rlEncoding,
+      dlEncoding,
+      valuesEncoding), to);
+  }
+
+  public void writeDataPageV1Header(
       int uncompressedSize,
       int compressedSize,
       int valueCount,
       org.apache.parquet.column.Encoding rlEncoding,
       org.apache.parquet.column.Encoding dlEncoding,
       org.apache.parquet.column.Encoding valuesEncoding,
+      int crc32,
       OutputStream to) throws IOException {
     writePageHeader(newDataPageHeader(uncompressedSize,
                                       compressedSize,
                                       valueCount,
                                       rlEncoding,
                                       dlEncoding,
-                                      valuesEncoding), to);
+                                      valuesEncoding,
+                                      crc32), to);
   }
 
   public void writeDataPageV2Header(

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -1479,9 +1479,18 @@ public class ParquetMetadataConverter {
   }
 
   public void writeDictionaryPageHeader(
-      int uncompressedSize, int compressedSize, int valueCount,
-      org.apache.parquet.column.Encoding valuesEncoding, OutputStream to) throws IOException {
+    int uncompressedSize, int compressedSize, int valueCount,
+    org.apache.parquet.column.Encoding valuesEncoding, OutputStream to) throws IOException {
     PageHeader pageHeader = new PageHeader(PageType.DICTIONARY_PAGE, uncompressedSize, compressedSize);
+    pageHeader.setDictionary_page_header(new DictionaryPageHeader(valueCount, getEncoding(valuesEncoding)));
+    writePageHeader(pageHeader, to);
+  }
+
+  public void writeDictionaryPageHeader(
+      int uncompressedSize, int compressedSize, int valueCount,
+      org.apache.parquet.column.Encoding valuesEncoding, int crc32, OutputStream to) throws IOException {
+    PageHeader pageHeader = new PageHeader(PageType.DICTIONARY_PAGE, uncompressedSize, compressedSize);
+    pageHeader.setCrc(crc32);
     pageHeader.setDictionary_page_header(new DictionaryPageHeader(valueCount, getEncoding(valuesEncoding)));
     writePageHeader(pageHeader, to);
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -1338,7 +1338,7 @@ public class ParquetMetadataConverter {
       org.apache.parquet.column.Encoding rlEncoding,
       org.apache.parquet.column.Encoding dlEncoding,
       org.apache.parquet.column.Encoding valuesEncoding,
-      int crc32,
+      int crc,
       OutputStream to) throws IOException {
     writePageHeader(newDataPageHeader(uncompressedSize,
                                       compressedSize,
@@ -1346,7 +1346,7 @@ public class ParquetMetadataConverter {
                                       rlEncoding,
                                       dlEncoding,
                                       valuesEncoding,
-                                      crc32), to);
+                                      crc), to);
   }
 
   // Statistics are no longer saved in page headers
@@ -1387,9 +1387,9 @@ public class ParquetMetadataConverter {
       org.apache.parquet.column.Encoding rlEncoding,
       org.apache.parquet.column.Encoding dlEncoding,
       org.apache.parquet.column.Encoding valuesEncoding,
-      int crc32) {
+      int crc) {
     PageHeader pageHeader = new PageHeader(PageType.DATA_PAGE, uncompressedSize, compressedSize);
-    pageHeader.setCrc(crc32);
+    pageHeader.setCrc(crc);
     pageHeader.setData_page_header(new DataPageHeader(
         valueCount,
         getEncoding(valuesEncoding),
@@ -1438,7 +1438,7 @@ public class ParquetMetadataConverter {
       org.apache.parquet.column.Encoding rlEncoding,
       org.apache.parquet.column.Encoding dlEncoding,
       org.apache.parquet.column.Encoding valuesEncoding,
-      int crc32,
+      int crc,
       OutputStream to) throws IOException {
     writePageHeader(newDataPageHeader(uncompressedSize,
                                       compressedSize,
@@ -1446,7 +1446,7 @@ public class ParquetMetadataConverter {
                                       rlEncoding,
                                       dlEncoding,
                                       valuesEncoding,
-                                      crc32), to);
+                                      crc), to);
   }
 
   public void writeDataPageV2Header(
@@ -1488,9 +1488,9 @@ public class ParquetMetadataConverter {
 
   public void writeDictionaryPageHeader(
       int uncompressedSize, int compressedSize, int valueCount,
-      org.apache.parquet.column.Encoding valuesEncoding, int crc32, OutputStream to) throws IOException {
+      org.apache.parquet.column.Encoding valuesEncoding, int crc, OutputStream to) throws IOException {
     PageHeader pageHeader = new PageHeader(PageType.DICTIONARY_PAGE, uncompressedSize, compressedSize);
-    pageHeader.setCrc(crc32);
+    pageHeader.setCrc(crc);
     pageHeader.setDictionary_page_header(new DictionaryPageHeader(valueCount, getEncoding(valuesEncoding)));
     writePageHeader(pageHeader, to);
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
@@ -99,7 +99,7 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
         public DataPage visit(DataPageV1 dataPageV1) {
           try {
             BytesInput decompressed = decompressor.decompress(dataPageV1.getBytes(), dataPageV1.getUncompressedSize());
-            DataPageV1 decompressedPage;
+            final DataPageV1 decompressedPage;
             if (offsetIndex == null) {
               decompressedPage = new DataPageV1(
                   decompressed,

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
@@ -122,7 +122,9 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
                   dataPageV1.getDlEncoding(),
                   dataPageV1.getValueEncoding());
             }
-            if (dataPageV1.isSetCrc()) decompressedPage.setCrc(dataPageV1.getCrc());
+            if (dataPageV1.getCrc().isPresent()) {
+              decompressedPage.setCrc(dataPageV1.getCrc().getAsInt());
+            }
             return decompressedPage;
           } catch (IOException e) {
             throw new ParquetDecodingException("could not decompress page", e);
@@ -192,7 +194,9 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
           decompressor.decompress(compressedDictionaryPage.getBytes(), compressedDictionaryPage.getUncompressedSize()),
           compressedDictionaryPage.getDictionarySize(),
           compressedDictionaryPage.getEncoding());
-        if (compressedDictionaryPage.isSetCrc()) decompressedPage.setCrc(compressedDictionaryPage.getCrc());
+        if (compressedDictionaryPage.getCrc().isPresent()) {
+          decompressedPage.setCrc(compressedDictionaryPage.getCrc().getAsInt());
+        }
         return decompressedPage;
       } catch (IOException e) {
         throw new ParquetDecodingException("Could not decompress dictionary page", e);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
@@ -69,7 +69,7 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
     private int pageIndex = 0;
 
     ColumnChunkPageReader(BytesInputDecompressor decompressor, List<DataPage> compressedPages,
-                          DictionaryPage compressedDictionaryPage, OffsetIndex offsetIndex, long rowCount) {
+        DictionaryPage compressedDictionaryPage, OffsetIndex offsetIndex, long rowCount) {
       this.decompressor = decompressor;
       this.compressedPages = new LinkedList<DataPage>(compressedPages);
       this.compressedDictionaryPage = compressedDictionaryPage;
@@ -102,25 +102,25 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
             DataPageV1 decompressedPage;
             if (offsetIndex == null) {
               decompressedPage = new DataPageV1(
-                decompressed,
-                dataPageV1.getValueCount(),
-                dataPageV1.getUncompressedSize(),
-                dataPageV1.getStatistics(),
-                dataPageV1.getRlEncoding(),
-                dataPageV1.getDlEncoding(),
-                dataPageV1.getValueEncoding());
+                  decompressed,
+                  dataPageV1.getValueCount(),
+                  dataPageV1.getUncompressedSize(),
+                  dataPageV1.getStatistics(),
+                  dataPageV1.getRlEncoding(),
+                  dataPageV1.getDlEncoding(),
+                  dataPageV1.getValueEncoding());
             } else {
               long firstRowIndex = offsetIndex.getFirstRowIndex(currentPageIndex);
               decompressedPage = new DataPageV1(
-                decompressed,
-                dataPageV1.getValueCount(),
-                dataPageV1.getUncompressedSize(),
-                firstRowIndex,
-                Math.toIntExact(offsetIndex.getLastRowIndex(currentPageIndex, rowCount) - firstRowIndex + 1),
-                dataPageV1.getStatistics(),
-                dataPageV1.getRlEncoding(),
-                dataPageV1.getDlEncoding(),
-                dataPageV1.getValueEncoding());
+                  decompressed,
+                  dataPageV1.getValueCount(),
+                  dataPageV1.getUncompressedSize(),
+                  firstRowIndex,
+                  Math.toIntExact(offsetIndex.getLastRowIndex(currentPageIndex, rowCount) - firstRowIndex + 1),
+                  dataPageV1.getStatistics(),
+                  dataPageV1.getRlEncoding(),
+                  dataPageV1.getDlEncoding(),
+                  dataPageV1.getValueEncoding());
             }
             if (dataPageV1.isSetCrc()) decompressedPage.setCrc(dataPageV1.getCrc());
             return decompressedPage;
@@ -136,44 +136,44 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
               return dataPageV2;
             } else {
               return DataPageV2.uncompressed(
-                dataPageV2.getRowCount(),
-                dataPageV2.getNullCount(),
-                dataPageV2.getValueCount(),
-                offsetIndex.getFirstRowIndex(currentPageIndex),
-                dataPageV2.getRepetitionLevels(),
-                dataPageV2.getDefinitionLevels(),
-                dataPageV2.getDataEncoding(),
-                dataPageV2.getData(),
-                dataPageV2.getStatistics());
+                  dataPageV2.getRowCount(),
+                  dataPageV2.getNullCount(),
+                  dataPageV2.getValueCount(),
+                  offsetIndex.getFirstRowIndex(currentPageIndex),
+                  dataPageV2.getRepetitionLevels(),
+                  dataPageV2.getDefinitionLevels(),
+                  dataPageV2.getDataEncoding(),
+                  dataPageV2.getData(),
+                  dataPageV2.getStatistics());
             }
           }
           try {
             int uncompressedSize = Math.toIntExact(
-              dataPageV2.getUncompressedSize()
-                - dataPageV2.getDefinitionLevels().size()
-                - dataPageV2.getRepetitionLevels().size());
+                dataPageV2.getUncompressedSize()
+                    - dataPageV2.getDefinitionLevels().size()
+                    - dataPageV2.getRepetitionLevels().size());
             BytesInput decompressed = decompressor.decompress(dataPageV2.getData(), uncompressedSize);
             if (offsetIndex == null) {
               return DataPageV2.uncompressed(
-                dataPageV2.getRowCount(),
-                dataPageV2.getNullCount(),
-                dataPageV2.getValueCount(),
-                dataPageV2.getRepetitionLevels(),
-                dataPageV2.getDefinitionLevels(),
-                dataPageV2.getDataEncoding(),
-                decompressed,
-                dataPageV2.getStatistics());
+                  dataPageV2.getRowCount(),
+                  dataPageV2.getNullCount(),
+                  dataPageV2.getValueCount(),
+                  dataPageV2.getRepetitionLevels(),
+                  dataPageV2.getDefinitionLevels(),
+                  dataPageV2.getDataEncoding(),
+                  decompressed,
+                  dataPageV2.getStatistics());
             } else {
               return DataPageV2.uncompressed(
-                dataPageV2.getRowCount(),
-                dataPageV2.getNullCount(),
-                dataPageV2.getValueCount(),
-                offsetIndex.getFirstRowIndex(currentPageIndex),
-                dataPageV2.getRepetitionLevels(),
-                dataPageV2.getDefinitionLevels(),
-                dataPageV2.getDataEncoding(),
-                decompressed,
-                dataPageV2.getStatistics());
+                  dataPageV2.getRowCount(),
+                  dataPageV2.getNullCount(),
+                  dataPageV2.getValueCount(),
+                  offsetIndex.getFirstRowIndex(currentPageIndex),
+                  dataPageV2.getRepetitionLevels(),
+                  dataPageV2.getDefinitionLevels(),
+                  dataPageV2.getDataEncoding(),
+                  decompressed,
+                  dataPageV2.getStatistics());
             }
           } catch (IOException e) {
             throw new ParquetDecodingException("could not decompress page", e);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
@@ -102,7 +102,7 @@ class InternalParquetRecordWriter<T> {
 
   private void initStore() {
     pageStore = new ColumnChunkPageWriteStore(compressor, schema, props.getAllocator(),
-        props.getColumnIndexTruncateLength());
+        props.getColumnIndexTruncateLength(), props.getPageWriteChecksumEnabled());
     columnStore = props.newColumnWriteStore(schema, pageStore);
     MessageColumnIO columnIO = new ColumnIOFactory(validating).getColumnIO(schema);
     this.recordConsumer = columnIO.getRecordWriter(columnStore);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -62,7 +62,12 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
-import org.apache.parquet.column.page.*;
+import org.apache.parquet.column.page.DataPage;
+import org.apache.parquet.column.page.DataPageV1;
+import org.apache.parquet.column.page.DataPageV2;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.page.DictionaryPageReadStore;
+import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputDecompressor;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.compat.RowGroupFilter;
@@ -1191,7 +1196,7 @@ public class ParquetFileReader implements Closeable {
         PageHeader pageHeader = readPageHeader();
         int uncompressedPageSize = pageHeader.getUncompressed_page_size();
         int compressedPageSize = pageHeader.getCompressed_page_size();
-        BytesInput pageBytes;
+        final BytesInput pageBytes;
         switch (pageHeader.type) {
           case DICTIONARY_PAGE:
             // there is only one dictionary page per column chunk

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -1212,7 +1212,9 @@ public class ParquetFileReader implements Closeable {
                     converter.getEncoding(dicHeader.getEncoding())
                     );
             // Copy crc to new page, used for testing
-            if (pageHeader.isSetCrc()) dictionaryPage.setCrc(pageHeader.getCrc());
+            if (pageHeader.isSetCrc()) {
+              dictionaryPage.setCrc(pageHeader.getCrc());
+            }
             break;
           case DATA_PAGE:
             DataPageHeader dataHeaderV1 = pageHeader.getData_page_header();
@@ -1233,7 +1235,9 @@ public class ParquetFileReader implements Closeable {
               converter.getEncoding(dataHeaderV1.getDefinition_level_encoding()),
               converter.getEncoding(dataHeaderV1.getEncoding()));
             // Copy crc to new page, used for testing
-            if (pageHeader.isSetCrc()) dataPageV1.setCrc(pageHeader.getCrc());
+            if (pageHeader.isSetCrc()) {
+              dataPageV1.setCrc(pageHeader.getCrc());
+            }
             pagesInChunk.add(dataPageV1);
             valuesCountReadSoFar += dataHeaderV1.getNum_values();
             ++dataPageCountReadSoFar;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -204,9 +204,9 @@ public class ParquetFileWriter {
    */
   @Deprecated
   public ParquetFileWriter(Configuration configuration, MessageType schema,
-      Path file) throws IOException {
+                           Path file) throws IOException {
     this(HadoopOutputFile.fromPath(file, configuration),
-      schema, Mode.CREATE, DEFAULT_BLOCK_SIZE, MAX_PADDING_SIZE_DEFAULT);
+        schema, Mode.CREATE, DEFAULT_BLOCK_SIZE, MAX_PADDING_SIZE_DEFAULT);
   }
 
   /**
@@ -221,7 +221,7 @@ public class ParquetFileWriter {
   public ParquetFileWriter(Configuration configuration, MessageType schema,
                            Path file, Mode mode) throws IOException {
     this(HadoopOutputFile.fromPath(file, configuration),
-      schema, mode, DEFAULT_BLOCK_SIZE, MAX_PADDING_SIZE_DEFAULT);
+        schema, mode, DEFAULT_BLOCK_SIZE, MAX_PADDING_SIZE_DEFAULT);
   }
 
   /**
@@ -240,7 +240,7 @@ public class ParquetFileWriter {
                            int maxPaddingSize)
       throws IOException {
     this(HadoopOutputFile.fromPath(file, configuration),
-      schema, mode, rowGroupSize, maxPaddingSize);
+        schema, mode, rowGroupSize, maxPaddingSize);
   }
 
   /**
@@ -257,8 +257,8 @@ public class ParquetFileWriter {
                            long rowGroupSize, int maxPaddingSize)
       throws IOException {
     this(file, schema, mode, rowGroupSize, maxPaddingSize,
-      ParquetProperties.DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH,
-      ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED);
+        ParquetProperties.DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH,
+        ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED);
   }
   /**
    * @param file OutputFile to create or overwrite
@@ -444,12 +444,12 @@ public class ParquetFileWriter {
     LOG.debug("{}: write data page: {} values", beforeHeader, valueCount);
     int compressedPageSize = (int)bytes.size();
     metadataConverter.writeDataPageV1Header(
-      uncompressedPageSize, compressedPageSize,
-      valueCount,
-      rlEncoding,
-      dlEncoding,
-      valuesEncoding,
-      out);
+        uncompressedPageSize, compressedPageSize,
+        valueCount,
+        rlEncoding,
+        dlEncoding,
+        valuesEncoding,
+        out);
     long headerSize = out.getPos() - beforeHeader;
     this.uncompressedLength += uncompressedPageSize + headerSize;
     this.compressedLength += compressedPageSize + headerSize;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -332,9 +332,7 @@ public class ParquetFileWriter {
     this.encodingStatsBuilder = new EncodingStats.Builder();
     // no truncation is needed for testing
     this.columnIndexTruncateLength = Integer.MAX_VALUE;
-    this.pageWriteChecksumEnabled = configuration.getBoolean(
-      ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED,
-      ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED);
+    this.pageWriteChecksumEnabled = ParquetOutputFormat.getPageWriteChecksumEnabled(configuration);
     this.crc = pageWriteChecksumEnabled ? new CRC32() : null;
   }
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -135,6 +135,11 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
   public static final String COLUMN_INDEX_FILTERING_ENABLED = "parquet.filter.columnindex.enabled";
 
   /**
+   * key to configure whether page level checksum verification is enabled
+   */
+  public static final String PAGE_VERIFY_CHECKSUM_ENABLED = "parquet.page.verify-checksum.enabled";
+
+  /**
    * key to turn on or off task side metadata loading (default true)
    * if true then metadata is read on the task side and some tasks may finish immediately.
    * if false metadata is read on the client which is slower if there is a lot of metadata but tasks will only be spawn if there is work to do.

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -145,6 +145,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static final String ESTIMATE_PAGE_SIZE_CHECK = "parquet.page.size.check.estimate";
   public static final String COLUMN_INDEX_TRUNCATE_LENGTH = "parquet.columnindex.truncate.length";
   public static final String PAGE_ROW_COUNT_LIMIT = "parquet.page.row.count.limit";
+  public static final String PAGE_WRITE_CHECKSUM_ENABLED = "parquet.page.write-checksum.enabled";
 
   public static JobSummaryLevel getJobSummaryLevel(Configuration conf) {
     String level = conf.get(JOB_SUMMARY_LEVEL);
@@ -338,6 +339,18 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
     return conf.getInt(PAGE_ROW_COUNT_LIMIT, ParquetProperties.DEFAULT_PAGE_ROW_COUNT_LIMIT);
   }
 
+  public static void setPageWriteChecksumEnabled(JobContext jobContext, boolean val) {
+    setPageWriteChecksumEnabled(getConfiguration(jobContext), val);
+  }
+
+  public static void setPageWriteChecksumEnabled(Configuration conf, boolean val) {
+    conf.setBoolean(PAGE_WRITE_CHECKSUM_ENABLED, val);
+  }
+
+  public static boolean getPageWriteChecksumEnabled(Configuration conf) {
+    return conf.getBoolean(PAGE_WRITE_CHECKSUM_ENABLED, ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED);
+  }
+
   private WriteSupport<T> writeSupport;
   private ParquetOutputCommitter committer;
 
@@ -394,6 +407,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
         .withMaxRowCountForPageSizeCheck(getMaxRowCountForPageSizeCheck(conf))
         .withColumnIndexTruncateLength(getColumnIndexTruncateLength(conf))
         .withPageRowCountLimit(getPageRowCountLimit(conf))
+        .withPageWriteChecksumEnabled(getPageWriteChecksumEnabled(conf))
         .build();
 
     long blockSize = getLongBlockSize(conf);
@@ -413,11 +427,13 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
       LOG.info("Max row count for page size check is: {}", props.getMaxRowCountForPageSizeCheck());
       LOG.info("Truncate length for column indexes is: {}", props.getColumnIndexTruncateLength());
       LOG.info("Page row count limit to {}", props.getPageRowCountLimit());
+      LOG.info("Writing page checksums is: {}", props.getPageWriteChecksumEnabled() ? "on" : "off");
     }
 
     WriteContext init = writeSupport.init(conf);
     ParquetFileWriter w = new ParquetFileWriter(HadoopOutputFile.fromPath(file, conf),
-        init.getSchema(), Mode.CREATE, blockSize, maxPaddingSize, props.getColumnIndexTruncateLength());
+      init.getSchema(), Mode.CREATE, blockSize, maxPaddingSize, props.getColumnIndexTruncateLength(),
+      props.getPageWriteChecksumEnabled());
     w.start();
 
     float maxLoad = conf.getFloat(ParquetOutputFormat.MEMORY_POOL_RATIO,

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetReader.java
@@ -280,6 +280,16 @@ public class ParquetReader<T> implements Closeable {
       return this;
     }
 
+    public Builder<T> usePageChecksumVerification(boolean usePageChecksumVerification) {
+      optionsBuilder.usePageChecksumVerification(usePageChecksumVerification);
+      return this;
+    }
+
+    public Builder<T> usePageChecksumVerification() {
+      optionsBuilder.usePageChecksumVerification();
+      return this;
+    }
+
     public Builder<T> withFileRange(long start, long end) {
       optionsBuilder.withRange(start, end);
       return this;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -278,11 +278,8 @@ public class ParquetWriter<T> implements Closeable {
     MessageType schema = writeContext.getSchema();
 
     ParquetFileWriter fileWriter = new ParquetFileWriter(
-      file, schema, mode, rowGroupSize, maxPaddingSize, encodingProps.getColumnIndexTruncateLength(),
-      conf.getBoolean(
-        ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED,
-        ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED
-      ));
+      file, schema, mode, rowGroupSize, maxPaddingSize,
+      encodingProps.getColumnIndexTruncateLength(), encodingProps.getPageWriteChecksumEnabled());
     fileWriter.start();
 
     this.codecFactory = new CodecFactory(conf, encodingProps.getPageSizeThreshold());

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -278,7 +278,11 @@ public class ParquetWriter<T> implements Closeable {
     MessageType schema = writeContext.getSchema();
 
     ParquetFileWriter fileWriter = new ParquetFileWriter(
-        file, schema, mode, rowGroupSize, maxPaddingSize, encodingProps.getColumnIndexTruncateLength());
+      file, schema, mode, rowGroupSize, maxPaddingSize, encodingProps.getColumnIndexTruncateLength(),
+      conf.getBoolean(
+        ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED,
+        ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED
+      ));
     fileWriter.start();
 
     this.codecFactory = new CodecFactory(conf, encodingProps.getPageSizeThreshold());
@@ -512,6 +516,27 @@ public class ParquetWriter<T> implements Closeable {
      */
     public SELF withWriterVersion(WriterVersion version) {
       encodingPropsBuilder.withWriterVersion(version);
+      return self();
+    }
+
+    /**
+     * Enables writing page level checksums for the constructed writer.
+     *
+     * @return this builder for method chaining.
+     */
+    public SELF enablePageWriteChecksum() {
+      encodingPropsBuilder.withPageWriteChecksumEnabled(true);
+      return self();
+    }
+
+    /**
+     * Enables writing page level checksums for the constructed writer.
+     *
+     * @param enablePageWriteChecksum whether page checksums should be written out
+     * @return this builder for method chaining.
+     */
+    public SELF withPageWriteChecksumEnabled(boolean enablePageWriteChecksum) {
+      encodingPropsBuilder.withPageWriteChecksumEnabled(enablePageWriteChecksum);
       return self();
     }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.ParquetProperties;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -155,7 +156,9 @@ public class TestColumnChunkPageWriteStore {
     {
       OutputFileForTesting outputFile = new OutputFileForTesting(file, conf);
       ParquetFileWriter writer = new ParquetFileWriter(outputFile, schema, Mode.CREATE,
-          ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.MAX_PADDING_SIZE_DEFAULT);
+          ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.MAX_PADDING_SIZE_DEFAULT,
+          conf.getBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED,
+            ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED));
       writer.start();
       writer.startBlock(rowCount);
       pageOffset = outputFile.out().getPos();

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
@@ -156,9 +156,7 @@ public class TestColumnChunkPageWriteStore {
     {
       OutputFileForTesting outputFile = new OutputFileForTesting(file, conf);
       ParquetFileWriter writer = new ParquetFileWriter(outputFile, schema, Mode.CREATE,
-          ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.MAX_PADDING_SIZE_DEFAULT,
-          conf.getBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED,
-            ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED));
+          ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.MAX_PADDING_SIZE_DEFAULT);
       writer.start();
       writer.startBlock(rowCount);
       pageOffset = outputFile.out().getPos();

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDataPageV1Checksums.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDataPageV1Checksums.java
@@ -118,7 +118,7 @@ public class TestDataPageV1Checksums {
     writer.start();
     writer.startBlock(numRecordsLargeFile);
 
-    CodecFactory codecFactory = new CodecFactory(conf, 1024 * 1024);
+    CodecFactory codecFactory = new CodecFactory(conf, PAGE_SIZE);
     CodecFactory.BytesCompressor compressor = codecFactory.getCompressor(compression);
 
     ColumnChunkPageWriteStore writeStore = new ColumnChunkPageWriteStore(

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDataPageV1Checksums.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDataPageV1Checksums.java
@@ -517,18 +517,17 @@ public class TestDataPageV1Checksums {
    * check that the crc's are identical.
    */
   private void assertCrcSetAndCorrect(Page page, byte[] referenceBytes) {
-    assertTrue("Checksum was not set in page", page.isSetCrc());
-    int crcFromPage = page.getCrc();
+    assertTrue("Checksum was not set in page", page.getCrc().isPresent());
+    int crcFromPage = page.getCrc().getAsInt();
     crc.reset();
     crc.update(referenceBytes);
     assertEquals("Checksum found in page did not match calculated reference checksum",
       crc.getValue(), (long) crcFromPage & 0xffffffffL);
   }
 
-  /** Verify that the crc is not set and that is has the default value */
+  /** Verify that the crc is not set */
   private void assertCrcNotSet(Page page) {
-    assertFalse("Checksum was set in page", page.isSetCrc());
-    assertEquals("Checksum does not have default value", 0, page.getCrc());
+    assertFalse("Checksum was set in page", page.getCrc().isPresent());
   }
 
   /**

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDataPageV1Checksums.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDataPageV1Checksums.java
@@ -1,0 +1,511 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.hadoop;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+import java.util.zip.CRC32;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.column.page.*;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.GroupFactory;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.codec.SnappyCompressor;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.apache.parquet.hadoop.util.HadoopOutputFile;
+import org.apache.parquet.io.*;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.apache.parquet.schema.Types;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.junit.Assert.*;
+
+/**
+ * Tests that page level checksums are correctly written and that checksum verification works as
+ * expected
+ */
+public class TestDataPageV1Checksums {
+  @Rule
+  public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private static final Statistics<?> EMPTY_STATS_INT32 = Statistics.getBuilderForReading(
+    Types.required(INT32).named("a")).build();
+
+  private CRC32 crc = new CRC32();
+
+  // Sample data, two columns 'a' and 'b' (both int32),
+
+  private static final int PAGE_SIZE = 1024 * 1024; // 1MB
+
+  private static final MessageType schemaSimple = MessageTypeParser.parseMessageType(
+    "message m {" +
+    "  required int32 a;" +
+    "  required int32 b;" +
+    "}");
+  private static final ColumnDescriptor colADesc = schemaSimple.getColumns().get(0);
+  private static final ColumnDescriptor colBDesc = schemaSimple.getColumns().get(1);
+  private static final byte[] colAPage1Bytes = new byte[PAGE_SIZE];
+  private static final byte[] colAPage2Bytes = new byte[PAGE_SIZE];
+  private static final byte[] colBPage1Bytes = new byte[PAGE_SIZE];
+  private static final byte[] colBPage2Bytes = new byte[PAGE_SIZE];
+  private static final int numRecordsLargeFile = (2 * PAGE_SIZE) / Integer.BYTES;
+
+  /** Write out sample Parquet file using ColumnChunkPageWriteStore directly, return path to file */
+  private Path writeSimpleParquetFile(Configuration conf, CompressionCodecName compression)
+    throws IOException {
+    File file = tempFolder.newFile();
+    file.delete();
+    Path path = new Path(file.toURI());
+
+    for (int i = 0; i < PAGE_SIZE; i++) {
+      colAPage1Bytes[i] = (byte) i;
+      colAPage2Bytes[i] = (byte) -i;
+      colBPage1Bytes[i] = (byte) (i + 100);
+      colBPage2Bytes[i] = (byte) (i - 100);
+    }
+
+    ParquetFileWriter writer =  new ParquetFileWriter(conf, schemaSimple, path,
+      ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.MAX_PADDING_SIZE_DEFAULT);
+
+    writer.start();
+    writer.startBlock(numRecordsLargeFile);
+
+    CodecFactory codecFactory = new CodecFactory(conf, 1024 * 1024);
+    CodecFactory.BytesCompressor compressor = codecFactory.getCompressor(compression);
+
+    ColumnChunkPageWriteStore writeStore = new ColumnChunkPageWriteStore(
+      compressor, schemaSimple, new HeapByteBufferAllocator(),
+      Integer.MAX_VALUE, conf.getBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED,
+      ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED));
+
+    PageWriter pageWriter = writeStore.getPageWriter(colADesc);
+    pageWriter.writePage(BytesInput.from(colAPage1Bytes), numRecordsLargeFile / 2,
+      numRecordsLargeFile / 2, EMPTY_STATS_INT32, Encoding.RLE, Encoding.RLE, Encoding.PLAIN);
+    pageWriter.writePage(BytesInput.from(colAPage2Bytes), numRecordsLargeFile / 2,
+      numRecordsLargeFile / 2, EMPTY_STATS_INT32, Encoding.RLE, Encoding.RLE, Encoding.PLAIN);
+
+    pageWriter = writeStore.getPageWriter(colBDesc);
+    pageWriter.writePage(BytesInput.from(colBPage1Bytes), numRecordsLargeFile / 2,
+      numRecordsLargeFile / 2, EMPTY_STATS_INT32, Encoding.RLE, Encoding.RLE, Encoding.PLAIN);
+    pageWriter.writePage(BytesInput.from(colBPage2Bytes), numRecordsLargeFile / 2,
+      numRecordsLargeFile / 2, EMPTY_STATS_INT32, Encoding.RLE, Encoding.RLE, Encoding.PLAIN);
+
+    writeStore.flushToFileWriter(writer);
+
+    writer.endBlock();
+    writer.end(new HashMap<>());
+
+    codecFactory.release();
+
+    return path;
+  }
+
+  // Sample data, nested schema with nulls
+
+  private static final MessageType schemaNestedWithNulls = MessageTypeParser.parseMessageType(
+    "message m {" +
+      "  optional group c {" +
+      "    required int64 id;" +
+      "    required group d {" +
+      "      repeated int32 val;" +
+      "    }" +
+      "  }" +
+      "}");
+  private static final ColumnDescriptor colCIdDesc = schemaNestedWithNulls.getColumns().get(0);
+  private static final ColumnDescriptor colDValDesc = schemaNestedWithNulls.getColumns().get(1);
+
+  private static final double nullRatio = 0.3;
+  private static final int numRecordsNestedWithNullsFile = 1000;
+
+  private Path writeNestedWithNullsSampleParquetFile(Configuration conf,
+                                                     CompressionCodecName compression)
+    throws IOException {
+    File file = tempFolder.newFile();
+    file.delete();
+    Path path = new Path(file.toURI());
+
+    ParquetWriter<Group> writer = ExampleParquetWriter.builder(path)
+      .withConf(conf)
+      .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
+      .withCompressionCodec(compression)
+      .withType(schemaNestedWithNulls)
+      .withPageWriteChecksumEnabled(conf.getBoolean(ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED,
+        true))
+      .build();
+
+    GroupFactory groupFactory = new SimpleGroupFactory(schemaNestedWithNulls);
+    Random rand = new Random(42);
+
+    for (int i = 0; i < numRecordsNestedWithNullsFile; i++) {
+      Group group = groupFactory.newGroup();
+      if (rand.nextDouble() > nullRatio) {
+        // With equal probability, write out either 1 or 3 values in group e
+        if (rand.nextDouble() > 0.5) {
+          group.addGroup("c").append("id", (long) i).addGroup("d")
+            .append("val", rand.nextInt());
+        } else {
+          group.addGroup("c").append("id", (long) i).addGroup("d")
+            .append("val", rand.nextInt())
+            .append("val", rand.nextInt())
+            .append("val", rand.nextInt());
+        }
+      }
+      writer.write(group);
+    }
+    writer.close();
+
+    return path;
+  }
+
+  /**
+   * Enable writing out page level crc checksum, disable verification in read path but check that
+   * the crc checksums are correct. Tests whether we successfully write out correct crc checksums
+   * without potentially failing on the read path verification .
+   */
+  @Test
+  public void testWriteOnVerifyOff() throws IOException {
+    Configuration conf = new Configuration();
+    conf.setBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED, true);
+    conf.setBoolean(ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED, false);
+
+    Path path = writeSimpleParquetFile(conf, CompressionCodecName.UNCOMPRESSED);
+
+    try (ParquetFileReader reader = getParquetFileReader(path, conf,
+      Arrays.asList(colADesc, colBDesc))) {
+      PageReadStore pageReadStore = reader.readNextRowGroup();
+
+      DataPageV1 colAPage1 = readNextPage(colADesc, pageReadStore);
+      assertCrcSetAndCorrect(colAPage1, colAPage1Bytes);
+      assertCorrectContent(colAPage1, colAPage1Bytes);
+
+      DataPageV1 colAPage2 = readNextPage(colADesc, pageReadStore);
+      assertCrcSetAndCorrect(colAPage2, colAPage2Bytes);
+      assertCorrectContent(colAPage2, colAPage2Bytes);
+
+      DataPageV1 colBPage1 = readNextPage(colBDesc, pageReadStore);
+      assertCrcSetAndCorrect(colBPage1, colBPage1Bytes);
+      assertCorrectContent(colBPage1, colBPage1Bytes);
+
+      DataPageV1 colBPage2 = readNextPage(colBDesc, pageReadStore);
+      assertCrcSetAndCorrect(colBPage2, colBPage2Bytes);
+      assertCorrectContent(colBPage2, colBPage2Bytes);
+    }
+  }
+
+  /** Test that we do not write out checksums if the feature is turned off */
+  @Test
+  public void testWriteOffVerifyOff() throws IOException {
+    Configuration conf = new Configuration();
+    conf.setBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED, false);
+    conf.setBoolean(ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED, false);
+
+    Path path = writeSimpleParquetFile(conf, CompressionCodecName.UNCOMPRESSED);
+
+    try (ParquetFileReader reader = getParquetFileReader(path, conf,
+      Arrays.asList(colADesc, colBDesc))) {
+      PageReadStore pageReadStore = reader.readNextRowGroup();
+
+      assertCrcNotSet(readNextPage(colADesc, pageReadStore));
+      assertCrcNotSet(readNextPage(colADesc, pageReadStore));
+      assertCrcNotSet(readNextPage(colBDesc, pageReadStore));
+      assertCrcNotSet(readNextPage(colBDesc, pageReadStore));
+    }
+  }
+
+  /**
+   * Do not write out page level crc checksums, but enable verification on the read path. Tests
+   * that the read still succeeds and does not throw an exception.
+   */
+  @Test
+  public void testWriteOffVerifyOn() throws IOException {
+    Configuration conf = new Configuration();
+    conf.setBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED, false);
+    conf.setBoolean(ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED, true);
+
+    Path path = writeSimpleParquetFile(conf, CompressionCodecName.UNCOMPRESSED);
+
+    try (ParquetFileReader reader = getParquetFileReader(path, conf,
+      Arrays.asList(colADesc, colBDesc))) {
+      PageReadStore pageReadStore = reader.readNextRowGroup();
+
+      assertCorrectContent(readNextPage(colADesc, pageReadStore), colAPage1Bytes);
+      assertCorrectContent(readNextPage(colADesc, pageReadStore), colAPage2Bytes);
+      assertCorrectContent(readNextPage(colBDesc, pageReadStore), colBPage1Bytes);
+      assertCorrectContent(readNextPage(colBDesc, pageReadStore), colBPage2Bytes);
+    }
+  }
+
+  /**
+   * Write out checksums and verify them on the read path. Tests that crc is set and that we can
+   * read back what we wrote if checksums are enabled on both the write and read path.
+   */
+  @Test
+  public void testWriteOnVerifyOn() throws IOException {
+    Configuration conf = new Configuration();
+    conf.setBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED, true);
+    conf.setBoolean(ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED, true);
+
+    Path path = writeSimpleParquetFile(conf, CompressionCodecName.UNCOMPRESSED);
+
+    try (ParquetFileReader reader = getParquetFileReader(path, conf,
+      Arrays.asList(colADesc, colBDesc))) {
+      PageReadStore pageReadStore = reader.readNextRowGroup();
+
+      DataPageV1 colAPage1 = readNextPage(colADesc, pageReadStore);
+      assertCrcSetAndCorrect(colAPage1, colAPage1Bytes);
+      assertCorrectContent(colAPage1, colAPage1Bytes);
+
+      DataPageV1 colAPage2 = readNextPage(colADesc, pageReadStore);
+      assertCrcSetAndCorrect(colAPage2, colAPage2Bytes);
+      assertCorrectContent(colAPage2, colAPage2Bytes);
+
+      DataPageV1 colBPage1 = readNextPage(colBDesc, pageReadStore);
+      assertCrcSetAndCorrect(colBPage1, colBPage1Bytes);
+      assertCorrectContent(colBPage1, colBPage1Bytes);
+
+      DataPageV1 colBPage2 = readNextPage(colBDesc, pageReadStore);
+      assertCrcSetAndCorrect(colBPage2, colBPage2Bytes);
+      assertCorrectContent(colBPage2, colBPage2Bytes);
+    }
+  }
+
+  /**
+   * Test whether corruption in the page content is detected by checksum verification
+   */
+  @Test
+  public void testCorruptedPage() throws IOException {
+    Configuration conf = new Configuration();
+    conf.setBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED, true);
+
+    Path path = writeSimpleParquetFile(conf, CompressionCodecName.UNCOMPRESSED);
+
+    InputFile inputFile = HadoopInputFile.fromPath(path, conf);
+    SeekableInputStream inputStream = inputFile.newStream();
+    int fileLen = (int) inputFile.getLength();
+
+    byte[] fileBytes = new byte[fileLen];
+    inputStream.readFully(fileBytes);
+    inputStream.close();
+
+    // There are 4 pages in total (2 per column), we corrupt the first page of the first column and
+    // the second page of the second column. We do this by altering a byte roughly in the middle of
+    // each page to be corrupted
+    fileBytes[fileLen / 8]++;
+    fileBytes[fileLen / 8 + ((fileLen / 4) * 3)]++;
+
+    OutputFile outputFile = HadoopOutputFile.fromPath(path, conf);
+    PositionOutputStream outputStream = outputFile.createOrOverwrite(1024 * 1024);
+    outputStream.write(fileBytes);
+    outputStream.close();
+
+    // First we disable checksum verification, the corruption will go undetected as it is in the
+    // data section of the page
+    conf.setBoolean(ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED, false);
+    try (ParquetFileReader reader = getParquetFileReader(path, conf,
+      Arrays.asList(colADesc, colBDesc))) {
+      PageReadStore pageReadStore = reader.readNextRowGroup();
+
+      DataPageV1 colAPage1 = readNextPage(colADesc, pageReadStore);
+      assertFalse("Data in page was not corrupted",
+        Arrays.equals(colAPage1.getBytes().toByteArray(), colAPage1Bytes));
+      readNextPage(colADesc, pageReadStore);
+      readNextPage(colBDesc, pageReadStore);
+      DataPageV1 colBPage2 = readNextPage(colBDesc, pageReadStore);
+      assertFalse("Data in page was not corrupted",
+        Arrays.equals(colBPage2.getBytes().toByteArray(), colBPage2Bytes));
+    }
+
+    // Now we enable checksum verification, the corruption should be detected
+    conf.setBoolean(ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED, true);
+    try (ParquetFileReader reader =
+      getParquetFileReader(path, conf, Arrays.asList(colADesc, colBDesc))) {
+
+      PageReadStore pageReadStore = reader.readNextRowGroup();
+
+      assertVerificationFailed(colADesc, pageReadStore);
+      readNextPage(colADesc, pageReadStore);
+      readNextPage(colBDesc, pageReadStore);
+      assertVerificationFailed(colBDesc, pageReadStore);
+    }
+  }
+
+  /**
+   * Tests that the checksum is calculated using the compressed version of the data and that
+   * checksum verification succeeds
+   */
+  @Test
+  public void testCompression() throws IOException {
+    Configuration conf = new Configuration();
+    conf.setBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED, true);
+    conf.setBoolean(ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED, true);
+
+    Path path = writeSimpleParquetFile(conf, CompressionCodecName.SNAPPY);
+
+    try (ParquetFileReader reader = getParquetFileReader(path, conf,
+      Arrays.asList(colADesc, colBDesc))) {
+      PageReadStore pageReadStore = reader.readNextRowGroup();
+
+      DataPageV1 colAPage1 = readNextPage(colADesc, pageReadStore);
+      assertCrcSetAndCorrect(colAPage1, snappy(colAPage1Bytes));
+      assertCorrectContent(colAPage1, colAPage1Bytes);
+
+      DataPageV1 colAPage2 = readNextPage(colADesc, pageReadStore);
+      assertCrcSetAndCorrect(colAPage2, snappy(colAPage2Bytes));
+      assertCorrectContent(colAPage2, colAPage2Bytes);
+
+      DataPageV1 colBPage1 = readNextPage(colBDesc, pageReadStore);
+      assertCrcSetAndCorrect(colBPage1, snappy(colBPage1Bytes));
+      assertCorrectContent(colBPage1, colBPage1Bytes);
+
+      DataPageV1 colBPage2 = readNextPage(colBDesc, pageReadStore);
+      assertCrcSetAndCorrect(colBPage2, snappy(colBPage2Bytes));
+      assertCorrectContent(colBPage2, colBPage2Bytes);
+    }
+  }
+
+  /**
+   * Tests that we adhere to the checksum calculation specification, namely that the crc is
+   * calculated using the compressed concatenation of the repetition levels, definition levels and
+   * the actual data. This is done by generating sample data with a nested schema containing nulls
+   * (generating non trivial repetition and definition levels).
+   */
+  @Test
+  public void testNestedWithNulls() throws IOException {
+    Configuration conf = new Configuration();
+
+    // Write out sample file via the non-checksum code path, extract the raw bytes to calculate the
+    // reference crc with
+    conf.setBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED, false);
+    conf.setBoolean(ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED, false);
+    Path refPath = writeNestedWithNullsSampleParquetFile(conf, CompressionCodecName.SNAPPY);
+
+    try (ParquetFileReader refReader = getParquetFileReader(refPath, conf,
+      Arrays.asList(colCIdDesc, colDValDesc))) {
+      PageReadStore refPageReadStore = refReader.readNextRowGroup();
+      byte[] colCIdPageBytes = readNextPage(colCIdDesc, refPageReadStore).getBytes().toByteArray();
+      byte[] colDValPageBytes = readNextPage(colDValDesc, refPageReadStore).getBytes().toByteArray();
+
+      // Write out sample file with checksums
+      conf.setBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED, true);
+      conf.setBoolean(ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED, true);
+      Path path = writeNestedWithNullsSampleParquetFile(conf, CompressionCodecName.SNAPPY);
+
+      try (ParquetFileReader reader = getParquetFileReader(path, conf,
+        Arrays.asList(colCIdDesc, colDValDesc))) {
+        PageReadStore pageReadStore = reader.readNextRowGroup();
+
+        DataPageV1 colCIdPage = readNextPage(colCIdDesc, pageReadStore);
+        assertCrcSetAndCorrect(colCIdPage, snappy(colCIdPageBytes));
+        assertCorrectContent(colCIdPage, colCIdPageBytes);
+
+        DataPageV1 colDValPage = readNextPage(colDValDesc, pageReadStore);
+        assertCrcSetAndCorrect(colDValPage, snappy(colDValPageBytes));
+        assertCorrectContent(colDValPage, colDValPageBytes);
+      }
+    }
+  }
+
+  /** Compress using snappy */
+  private byte[] snappy(byte[] bytes) throws IOException {
+    SnappyCompressor compressor = new SnappyCompressor();
+    compressor.reset();
+    compressor.setInput(bytes, 0, bytes.length);
+    compressor.finish();
+    byte[] buffer = new byte[bytes.length * 2];
+    int compressedSize = compressor.compress(buffer, 0, buffer.length);
+    return Arrays.copyOfRange(buffer, 0, compressedSize);
+  }
+
+  /** Construct ParquetFileReader for input file and columns */
+  private ParquetFileReader getParquetFileReader(Path path, Configuration conf,
+                                                 List<ColumnDescriptor> columns)
+    throws IOException {
+    ParquetMetadata footer = ParquetFileReader.readFooter(conf, path);
+    return new ParquetFileReader(conf, footer.getFileMetaData(), path,
+      footer.getBlocks(), columns);
+  }
+
+  /** Read the next page for a column */
+  private DataPageV1 readNextPage(ColumnDescriptor colDesc, PageReadStore pageReadStore) {
+    return (DataPageV1) pageReadStore.getPageReader(colDesc).readPage();
+  }
+
+  /**
+   * Compare the extracted (decompressed) bytes to the reference bytes
+   */
+  private void assertCorrectContent(DataPageV1 page, byte[] referenceBytes) throws IOException {
+    assertArrayEquals("Read page content was different from expected page content", referenceBytes,
+      page.getBytes().toByteArray());
+  }
+
+  /**
+   * Verify that the crc is set in a page, calculate the reference crc using the reference bytes and
+   * check that the crc's are identical.
+   */
+  private void assertCrcSetAndCorrect(DataPageV1 page, byte[] referenceBytes) {
+    assertTrue("Checksum was not set in page", page.isSetCrc32());
+    int crcFromPage = page.getCrc32();
+    crc.reset();
+    crc.update(referenceBytes);
+    assertEquals("Checksum found in page did not match calculated reference checksum",
+      (int) crc.getValue(), crcFromPage);
+  }
+
+  /** Verify that the crc is not set and that is has the default value */
+  private void assertCrcNotSet(DataPageV1 page) {
+    assertFalse("Checksum was set in page", page.isSetCrc32());
+    assertEquals("Checksum does not have default value", 0, page.getCrc32());
+  }
+
+  /**
+   * Read the next page for a column, fail if this did not throw an checksum verification exception,
+   * if the read succeeds (no exception was thrown ), verify that the checksum was not set.
+   */
+  private void assertVerificationFailed(ColumnDescriptor columnDesc, PageReadStore pageReadStore) {
+    try {
+      DataPage page = pageReadStore.getPageReader(columnDesc).readPage();
+      fail("Expected checksum verification exception to be thrown");
+    } catch (Exception e) {
+      assertTrue("Thrown exception is of incorrect type", e instanceof ParquetDecodingException);
+      assertTrue("Did not catch checksum verification ParquetDecodingException",
+        e.getMessage().contains("could not verify page integrity, CRC checksum verification " +
+          "failed"));
+    }
+  }
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -225,6 +225,8 @@ public class TestParquetFileWriter {
 
     Path path = new Path(testFile.toURI());
     Configuration conf = new Configuration();
+    // Disable writing out checksums as hardcoded byte offsets in assertions below expect it
+    conf.setBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED, false);
 
     // uses the test constructor
     ParquetFileWriter w = new ParquetFileWriter(conf, SCHEMA, path, 120, 60);
@@ -330,6 +332,8 @@ public class TestParquetFileWriter {
 
     Path path = new Path(testFile.toURI());
     Configuration conf = new Configuration();
+    // Disable writing out checksums as hardcoded byte offsets in assertions below expect it
+    conf.setBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED, false);
 
     // uses the test constructor
     ParquetFileWriter w = new ParquetFileWriter(conf, SCHEMA, path, 100, 50);

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/DumpCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/DumpCommand.java
@@ -274,7 +274,7 @@ public class DumpCommand extends ArgsOnlyCommand {
                 } else {
                   out.format(" ST:[none]");
                 }
-                out.format(" CRC:%s", pageV1.isSetCrc32() ? pageV1.getCrc32() : "-");
+                out.format(" CRC:%s", pageV1.isSetCrc() ? pageV1.getCrc() : "-");
                 return null;
               }
 

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/DumpCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/DumpCommand.java
@@ -274,6 +274,7 @@ public class DumpCommand extends ArgsOnlyCommand {
                 } else {
                   out.format(" ST:[none]");
                 }
+                out.format(" CRC:%s", pageV1.isSetCrc32() ? pageV1.getCrc32() : "-");
                 return null;
               }
 


### PR DESCRIPTION
This PR implements page-level CRC checksums for DataPageV1. It is the implementation follow up to the clarification of the checksums in `parquet-format` ([Jira](https://jira.apache.org/jira/browse/PARQUET-1539), [PR](https://github.com/apache/parquet-format/pull/126)). Key points:
- Checksums are calculated using the CRC32 implementation in `java.util.zip`
- Checksums are implemented for `DataPageV1` and `DictionaryPage`
- Writing out checksums is **enabled** by default (impact is minimal, see Benchmark results below)
- Checksum verification on the read path is **disabled** by default (benchmarks indicate minimal impact, but requires more thorough benchmarking)
- Backwards compatibility with Parquet files that do not have the CRC field set, even if checksum verification is turned on

### Jira
- [x] My PR addresses the following [Parquet Jira](https://jira.apache.org/jira/browse/PARQUET-1580) issue:
  - https://jira.apache.org/jira/browse/PARQUET-1580

### Tests
This PR adds the following tests in a new test suite `TestDataPageV1Checksums`:
- Test writing out checksums without verification on read, verify calculated checksums are correct
- Test not writing out checksums without verification on read, tests feature can be turned off entirely
- Test not writing out checksums with verification on read, tests backward compatibility of read path with files without checksums
- Test writing out checksums with verification on read, tests that the checksum is correctly set and that we can read what we wrote
- Test corruption detection by corrupting bytes in data section of pages, tests that these corruptions go undetected with the feature disabled and are detected with the feature enabled
- Test checksums with compression enabled, tests that the checksum is calculated on the compressed version of the data (as per the specification)
- Test checksums with compression and nested schema, tests that the checksum is calculated on the compressed concatenation of the repetition levels, definition levels and the actual data (as per the specification)
- Test checksums with dictionary encoded data, tests that the dictionary page is also checksummed

### Documentation
The feature is feature flagged and is disabled by default. Both writing out checksums and verifying them on the read path can be turned on individually, via the following two new config flags:
* `parquet.page.write-checksum.enabled` (default: `true`)
* `parquet.page.verify-checksum.enabled` (default: `false`)

### Benchmark results
This PR adds 2 new benchmark suites, benchmarking the penalty of both writing out checksums and verifying them. I've run the suites on the following setup:
- AWS m4.4xlarge instance
- Single shot mode
- 3 warmup iterations
- 5 measured iterations (3 forked JVMs)

**PageChecksumWriteBenchmarks**

```
Benchmark                                  Mode  Cnt   Score   Error  Units
write100KRowsGzipWithChecksums               ss   15   0.500 ? 0.012   s/op
write100KRowsGzipWithoutChecksums            ss   15   0.497 ? 0.013   s/op
write100KRowsSnappyWithChecksums             ss   15   0.235 ? 0.015   s/op
write100KRowsSnappyWithoutChecksums          ss   15   0.239 ? 0.018   s/op
write100KRowsUncompressedWithChecksums       ss   15   0.213 ? 0.012   s/op
write100KRowsUncompressedWithoutChecksums    ss   15   0.210 ? 0.013   s/op
write1MRowsGzipWithChecksums                 ss   15   4.720 ? 0.018   s/op
write1MRowsGzipWithoutChecksums              ss   15   4.718 ? 0.013   s/op
write1MRowsSnappyWithChecksums               ss   15   2.288 ? 0.182   s/op
write1MRowsSnappyWithoutChecksums            ss   15   2.122 ? 0.122   s/op
write1MRowsUncompressedWithChecksums         ss   15   1.945 ? 0.137   s/op
write1MRowsUncompressedWithoutChecksums      ss   15   1.913 ? 0.124   s/op
write10MRowsGzipWithChecksums                ss   15  47.226 ? 0.127   s/op
write10MRowsGzipWithoutChecksums             ss   15  47.430 ? 0.306   s/op
write10MRowsSnappyWithChecksums              ss   15  21.164 ? 0.628   s/op
write10MRowsSnappyWithoutChecksums           ss   15  20.905 ? 0.332   s/op
write10MRowsUncompressedWithChecksums        ss   15  18.806 ? 0.390   s/op
write10MRowsUncompressedWithoutChecksums     ss   15  18.637 ? 0.201   s/op
```

**PageChecksumReadBenchmarks**

```
Benchmark                                    Mode  Cnt  Score   Error  Units
read100KRowsGzipWithVerification               ss   15  0.105 ? 0.005   s/op
read100KRowsGzipWithoutVerification            ss   15  0.104 ? 0.004   s/op
read100KRowsSnappyWithVerification             ss   15  0.080 ? 0.003   s/op
read100KRowsSnappyWithoutVerification          ss   15  0.081 ? 0.006   s/op
read100KRowsUncompressedWithVerification       ss   15  0.074 ? 0.002   s/op
read100KRowsUncompressedWithoutVerification    ss   15  0.071 ? 0.005   s/op
read1MRowsGzipWithVerification                 ss   15  0.956 ? 0.012   s/op
read1MRowsGzipWithoutVerification              ss   15  0.952 ? 0.025   s/op
read1MRowsSnappyWithVerification               ss   15  0.707 ? 0.025   s/op
read1MRowsSnappyWithoutVerification            ss   15  0.699 ? 0.013   s/op
read1MRowsUncompressedWithVerification         ss   15  0.676 ? 0.013   s/op
read1MRowsUncompressedWithoutVerification      ss   15  0.651 ? 0.025   s/o
read10MRowsGzipWithVerification                ss   15  9.717 ? 0.588   s/op
read10MRowsGzipWithoutVerification             ss   15  9.593 ? 0.310   s/op
read10MRowsSnappyWithVerification              ss   15  7.038 ? 0.113   s/op
read10MRowsSnappyWithoutVerification           ss   15  6.854 ? 0.078   s/op
read10MRowsUncompressedWithVerification        ss   15  6.544 ? 0.071   s/op
read10MRowsUncompressedWithoutVerification     ss   15  6.463 ? 0.121   s/op
```
