### PR TITLE
PARQUET-1598: Make convert-csv work with the input filename which starts with a period or an numeric

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ConvertCSVCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ConvertCSVCommand.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.apache.avro.generic.GenericData.Record;
 import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
@@ -155,6 +156,12 @@ public class ConvertCSVCommand extends BaseCommand {
         recordName = filename.substring(0, filename.indexOf("."));
       } else {
         recordName = filename;
+      }
+
+      if (recordName.isEmpty()) {
+        recordName = "_";
+      } else if (Pattern.matches("^[^A-Za-z_].*", recordName)) {
+        recordName = "_" + recordName.substring(1);
       }
 
       csvSchema = AvroCSV.inferNullableSchema(

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVFileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVFileTest.java
@@ -27,18 +27,18 @@ import java.io.IOException;
 
 public abstract class CSVFileTest extends FileTest {
 
-  @Before
-  public void setUp() throws IOException {
-    createTestCSVFile();
+  protected File csvFile() throws IOException {
+    return csvFile(getClass().getSimpleName());
   }
 
-  protected File csvFile() {
+  protected File csvFile(String basename) throws IOException {
     File tmpDir = getTempFolder();
-    return new File(tmpDir, getClass().getSimpleName() + ".csv");
+    File file = new File(tmpDir, basename + ".csv");
+    createTestCSVFile(file);
+    return file;
   }
 
-  private void createTestCSVFile() throws IOException {
-    File file = csvFile();
+  private void createTestCSVFile(File file) throws IOException {
     try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
       writer.write(String.format("%s,%s,%s\n",
         INT32_FIELD, INT64_FIELD, BINARY_FIELD));

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCSVCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCSVCommandTest.java
@@ -27,9 +27,8 @@ import java.io.IOException;
 import java.util.Arrays;
 
 public class ConvertCSVCommandTest extends CSVFileTest {
-  @Test
-  public void testConvertCSVCommand() throws IOException {
-    File file = csvFile();
+
+  private void testConvertCSVCommandWithInputFile(File file) throws IOException {
     ConvertCSVCommand command = new ConvertCSVCommand(createLogger());
     command.targets = Arrays.asList(file.getAbsolutePath());
     File output = new File(getTempFolder(), getClass().getSimpleName() + ".parquet");
@@ -37,5 +36,23 @@ public class ConvertCSVCommandTest extends CSVFileTest {
     command.setConf(new Configuration());
     Assert.assertEquals(0, command.run());
     Assert.assertTrue(output.exists());
+  }
+
+  @Test
+  public void testConvertCSVCommand() throws IOException {
+    File file = csvFile();
+    testConvertCSVCommandWithInputFile(file);
+  }
+
+  @Test
+  public void testConvertCSVCommandWithInputFileNameBeginningWithPeriod() throws IOException {
+    File file = csvFile("." + getClass().getSimpleName());
+    testConvertCSVCommandWithInputFile(file);
+  }
+
+  @Test
+  public void testConvertCSVCommandWithInputFileNameBeginningWithNumeric() throws IOException {
+    File file = csvFile("0" + getClass().getSimpleName());
+    testConvertCSVCommandWithInputFile(file);
   }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1598
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

  - testConvertCSVCommandWithInputFileNameBeginningWithPeriod
  - testConvertCSVCommandWithInputFileNameBeginningWithNumeric

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
