### PR TITLE
PARQUET-1601: Add zstd support to parquet-cli to-avro

### DIFF
--- a/parquet-cli/pom.xml
+++ b/parquet-cli/pom.xml
@@ -44,6 +44,11 @@
       <version>${avro.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+      <version>${zstd-jni.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/util/Codecs.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/util/Codecs.java
@@ -42,6 +42,8 @@ public class Codecs {
         return CodecFactory.snappyCodec();
       case GZIP:
         return CodecFactory.deflateCodec(9);
+      case ZSTD:
+        return CodecFactory.zstandardCodec(CodecFactory.DEFAULT_ZSTANDARD_LEVEL);
       default:
         throw new IllegalArgumentException(
             "Codec incompatible with Avro: " + codec);

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/AvroFileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/AvroFileTest.java
@@ -27,10 +27,15 @@ import java.util.Arrays;
 public class AvroFileTest extends ParquetFileTest {
 
   protected File toAvro(File parquetFile) throws IOException {
+    return toAvro(parquetFile, "GZIP");
+  }
+
+  protected File toAvro(File parquetFile, String compressionCodecName) throws IOException {
     ToAvroCommand command = new ToAvroCommand(createLogger());
     command.targets = Arrays.asList(parquetFile.getAbsolutePath());
     File output = new File(getTempFolder(), getClass().getSimpleName() + ".avro");
     command.outputPath = output.getAbsolutePath();
+    command.compressionCodecName = compressionCodecName;
     command.setConf(new Configuration());
     int exitCode = command.run();
     assert(exitCode == 0);

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
@@ -30,4 +30,27 @@ public class ToAvroCommandTest extends AvroFileTest {
     File avroFile = toAvro(parquetFile());
     Assert.assertTrue(avroFile.exists());
   }
+
+  @Test
+  public void testToAvroCommandWithGzipCompression() throws IOException {
+    File avroFile = toAvro(parquetFile(), "GZIP");
+    Assert.assertTrue(avroFile.exists());
+  }
+
+  @Test
+  public void testToAvroCommandWithSnappyCompression() throws IOException {
+    File avroFile = toAvro(parquetFile(), "SNAPPY");
+    Assert.assertTrue(avroFile.exists());
+  }
+
+  @Test
+  public void testToAvroCommandWithZstdCompression() throws IOException {
+    File avroFile = toAvro(parquetFile(), "ZSTD");
+    Assert.assertTrue(avroFile.exists());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testToAvroCommandWithInvalidCompression() throws IOException {
+    toAvro(parquetFile(), "FOO");
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
     <opencsv.version>2.3</opencsv.version>
     <jcommander.version>1.35</jcommander.version>
     <commons-codec.version>1.10</commons-codec.version>
+    <zstd-jni.version>1.3.8-6</zstd-jni.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1601
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

  - testToAvroCommandWithGzipCompression
  - testToAvroCommandWithSnappyCompression
  - testToAvroCommandWithZstdCompression
  - testToAvroCommandWithInvalidCompression

In addition, I confirmed an output file generated by to-avro was properly compressed by zstd as follows:

```
$ java -cp 'target/dependency/*:target/*' org.apache.parquet.cli.Main to-avro sample.parquet -o sample.avro --compression-codec zstd
$ java -jar ~/avro-tools-1.9.0.jar getmeta sample.avro 

(snip)

avro.codec	zstandard
```

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
