### PR TITLE
PARQUET-1606: Fix invalid tests scope

### DIFF
--- a/parquet-arrow/pom.xml
+++ b/parquet-arrow/pom.xml
@@ -72,7 +72,7 @@
       <artifactId>parquet-column</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
-      <scope>tests</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.parquet:parquet-arrow:jar:1.12.0-SNAPSHOT
[WARNING] 'dependencies.dependency.scope' for org.apache.parquet:parquet-column:test-jar must be one of [provided, compile, runtime, test, system] but is 'tests'. @ org.apache.parquet:parquet-arrow:[unknown-version], /home/travis/build/Fokko/parquet-mr/parquet-arrow/pom.xml, line 75, column 14
[WARNING] 
```

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1606: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1606
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
