### PR TITLE
PARQUET-1607: Remove duplicate maven-enforcer-plugin

### DIFF
--- a/parquet-cascading3/pom.xml
+++ b/parquet-cascading3/pom.xml
@@ -65,6 +65,12 @@
       <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.thrift</groupId>

--- a/parquet-cascading3/pom.xml
+++ b/parquet-cascading3/pom.xml
@@ -101,24 +101,6 @@
 
   <build>
     <plugins>
-        <!-- TEMPORARY UNTIL AFTER previous.version &gt;= 1.8.2
-
-        (enforcer checks against the API in 1.7.0, this module did not exist back then, therefore it can't succeed)
-        -->
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>none</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-        <!-- /TEMPORARY -->
-
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>


### PR DESCRIPTION
```
[WARNING] Some problems were encountered while building the effective model for org.apache.parquet:parquet-cascading3:jar:1.12.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-enforcer-plugin @ org.apache.parquet:parquet-cascading3:[unknown-version], /home/travis/build/Fokko/parquet-mr/parquet-cascading3/pom.xml, line 167, column 15
[WARNING]
```

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1607: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1607
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
