### PR TITLE
PARQUET-1552: upgrade protoc-jar-maven-plugin to 3.8.0 to fix proxy issue

### DIFF
--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -159,7 +159,7 @@
       <plugin>
         <groupId>com.github.os72</groupId>
         <artifactId>protoc-jar-maven-plugin</artifactId>
-        <version>3.6.0.1</version>
+        <version>3.8.0</version>
         <executions>
           <execution>
             <id>generate-sources</id>


### PR DESCRIPTION
### Jira

- [ ]The PR addresses the [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET-1552) issue, here is the related issue: https://github.com/os72/protoc-jar-maven-plugin/issues/68

### Tests

The build on proxy works.
