### PR TITLE
PARQUET-1624: Use Hadoop options for HadoopInputFiles.

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -590,7 +590,13 @@ public class ParquetFileReader implements Closeable {
    * @throws IOException if there is an error while opening the file
    */
   public static ParquetFileReader open(InputFile file) throws IOException {
-    return new ParquetFileReader(file, ParquetReadOptions.builder().build());
+    ParquetReadOptions options;
+    if (file instanceof HadoopInputFile) {
+      options = HadoopReadOptions.builder(((HadoopInputFile) file).getConfiguration()).build();
+    } else {
+      options = ParquetReadOptions.builder().build();
+    }
+    return new ParquetFileReader(file, options);
   }
 
   /**


### PR DESCRIPTION
This is a minor fix. When opening a HadoopInputFile, use its configuration for read options.