### PR TITLE
PARQUET-1661: Upgrade to Avro 1.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <fastutil.version>8.2.3</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>
     <slf4j.version>1.7.22</slf4j.version>
-    <avro.version>1.9.0</avro.version>
+    <avro.version>1.9.1</avro.version>
     <guava.version>27.0.1-jre</guava.version>
     <brotli-codec.version>0.1.1</brotli-codec.version>
     <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
Avro 1.9.1 fixes some [regression issues](https://github.com/apache/avro/releases/tag/release-1.9.1) from 1.9.0

PTAL @gszadovszky