### PR TITLE
PARQUET-1662 Upgrade Jackson to version 2.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
     <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
     <jackson.groupId>com.fasterxml.jackson.core</jackson.groupId>
     <jackson.package>com.fasterxml.jackson</jackson.package>
-    <jackson.version>2.9.9</jackson.version>
-    <jackson-databind.version>2.9.9.3</jackson-databind.version>
+    <jackson.version>2.9.10</jackson.version>
+    <jackson-databind.version>2.9.10</jackson-databind.version>
     <shade.prefix>shaded.parquet</shade.prefix>
     <hadoop.version>2.7.3</hadoop.version>
     <hadoop1.version>1.2.1</hadoop1.version>


### PR DESCRIPTION
Jackson 2.9.10 addresses multiple CVE issues from previous Jackson versions, so we need to upgrade it.