### PR TITLE
PARQUET-1668: Show string min/max in parquet-cli/tools meta command

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ParquetMetadataCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ParquetMetadataCommand.java
@@ -25,6 +25,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.cli.BaseCommand;
 import org.apache.commons.lang.StringUtils;
 import org.apache.parquet.column.ColumnDescriptor;
@@ -72,8 +73,10 @@ public class ParquetMetadataCommand extends BaseCommand {
         "Cannot process multiple Parquet files.");
 
     String source = targets.get(0);
+    Configuration conf = getConf();
+    conf.setBoolean("parquet.strings.signed-min-max.enabled", true);
     ParquetMetadata footer = ParquetFileReader.readFooter(
-        getConf(), qualifiedPath(source), ParquetMetadataConverter.NO_FILTER);
+        conf, qualifiedPath(source), ParquetMetadataConverter.NO_FILTER);
 
     console.info("\nFile path:  {}", source);
     console.info("Created by: {}", footer.getFileMetaData().getCreatedBy());

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/ShowMetaCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/ShowMetaCommand.java
@@ -76,6 +76,7 @@ public class ShowMetaCommand extends ArgsOnlyCommand {
     boolean showOriginalTypes = options.hasOption('o');
 
     Configuration conf = new Configuration();
+    conf.setBoolean("parquet.strings.signed-min-max.enabled", true);
     Path inputPath = new Path(input);
     FileStatus inputFileStatus = inputPath.getFileSystem(conf).getFileStatus(inputPath);
     List<Footer> footers = ParquetFileReader.readFooters(conf, inputFileStatus, false);


### PR DESCRIPTION
It's better to show min/max of string type by default when using parquet-cli/parquet-tools meta command, by setting `parquet.strings.signed-min-max.enabled` to `true`