### PR TITLE
PARQUET-1669: Disable compiling all libraries when building thrift

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ wget -nv http://archive.apache.org/dist/thrift/0.12.0/thrift-0.12.0.tar.gz
 tar xzf thrift-0.12.0.tar.gz
 cd thrift-0.12.0
 chmod +x ./configure
-./configure --disable-gen-erl --disable-gen-hs --without-c-glib --without-erlang --without-go --without-haskell --without-java --without-nodejs --without-php --without-python --without-ruby
+./configure --disable-libs
 sudo make install
 ```
 

--- a/dev/travis-before_install.sh
+++ b/dev/travis-before_install.sh
@@ -33,7 +33,7 @@ wget -nv https://archive.apache.org/dist/thrift/${THIFT_VERSION}/thrift-${THIFT_
 tar zxf thrift-${THIFT_VERSION}.tar.gz
 cd thrift-${THIFT_VERSION}
 chmod +x ./configure
-./configure --disable-gen-erl --disable-gen-hs --without-c-glib --without-erlang --without-go --without-haskell --without-java --without-nodejs --without-php --without-python --without-ruby
+./configure --disable-libs
 sudo make install
 cd ..
 branch_specific_script="dev/travis-before_install-${TRAVIS_BRANCH}.sh"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1669
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's a fix for the CI script. I confirmed that all CI jobs succeeded and each job saved about 3 minutes using my Travis account.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
