### PR TITLE
PARQUET-1687: Update release process

### DIFF
--- a/dev/finalize-release
+++ b/dev/finalize-release
@@ -20,20 +20,22 @@
 
 set -e
 
-if [ -z "$2" ]; then
+if [ -z "$3" ]; then
     cat <<EOF
-Usage: $0 <release-version> <rc-num>
-Example: $0 1.11.0 7
+Usage: $0 <release-version> <rc-num> <new-development-version-without-SNAPSHOT-suffix>
+Example: $0 1.11.0 7 1.12.0
 EOF
   exit 1
 fi
 
-release_version="$1"
-new_development_version="$release_version-SNAPSHOT"
+release_version=$1
+release_tag="apache-parquet-$release_version"
+rc_tag="$release_tag-rc$2"
+new_development_version="$3-SNAPSHOT"
 
-tag="apache-parquet-$release_version-rc$2"
+git tag -am 'Release Apache Parquet $release_version' $release_tag $rc_tag
+mvn --batch-mode release:update-versions -DdevelopmentVersion=$new_development_version
+git commit -am 'Prepare for next development iteration'
 
-mvn release:clean
-mvn release:prepare -Dtag="$tag" "-DreleaseVersion=$release_version" -DdevelopmentVersion="$new_development_version"
-
-echo "Finish staging binary artifacts by running: mvn release:perform"
+echo
+echo "Verify the release tag and the current development version then push the changes by running: git push --follow-tags"

--- a/dev/finalize-release
+++ b/dev/finalize-release
@@ -28,13 +28,13 @@ EOF
   exit 1
 fi
 
-release_version=$1
+release_version="$1"
 release_tag="apache-parquet-$release_version"
 rc_tag="$release_tag-rc$2"
 new_development_version="$3-SNAPSHOT"
 
-git tag -am 'Release Apache Parquet $release_version' $release_tag $rc_tag
-mvn --batch-mode release:update-versions -DdevelopmentVersion=$new_development_version
+git tag -am "Release Apache Parquet $release_version" "$release_tag" "$rc_tag"
+mvn --batch-mode release:update-versions -DdevelopmentVersion="$new_development_version"
 git commit -am 'Prepare for next development iteration'
 
 echo

--- a/dev/prepare-release.sh
+++ b/dev/prepare-release.sh
@@ -20,8 +20,13 @@
 
 set -e
 
-if [ -z "$2" ]; then
+[[ $# != 2 ]] && err="Incorrect number of arguments: $#"
+[[ -z $err ]] && ! [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && err="Invalid release version: \"$1\""
+[[ -z $err ]] && ! [[ $2 =~ ^[0-9]+$ ]] && err="Invalid rc number: \"$2\""
+
+if [[ -n $err ]]; then
     cat <<EOF
+$err
 Usage: $0 <release-version> <rc-num>
 Example: $0 1.11.0 7
 EOF

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -41,7 +41,7 @@ tagrc=${tag}-rc${rc}
 
 echo "Preparing source for $tagrc"
 
-release_hash=`git rev-list $tagrc 2> /dev/null | head -n 1 `
+release_hash=`git rev-list "$tagrc" 2> /dev/null | head -n 1 `
 
 if [ -z "$release_hash" ]; then
   echo "Cannot continue: unknown git tag: $tagrc"

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -41,10 +41,10 @@ tagrc=${tag}-rc${rc}
 
 echo "Preparing source for $tagrc"
 
-release_hash=`git rev-list $tag 2> /dev/null | head -n 1 `
+release_hash=`git rev-list $tagrc 2> /dev/null | head -n 1 `
 
 if [ -z "$release_hash" ]; then
-  echo "Cannot continue: unknown git tag: $tag"
+  echo "Cannot continue: unknown git tag: $tagrc"
   exit
 fi
 


### PR DESCRIPTION
Update prepare-release.sh to create RC tags and keep using the current
RC version with SNAPSHOT for development.
Update source-release.sh to retrieve the hash of the RC tag.
Create the new script finalize-release to create the final release tag
and update the development version.
