### PR TITLE
PARQUET-1622: Add implementation for BYTE_STREAM_SPLIT

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java
@@ -31,6 +31,8 @@ import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.bitpacking.ByteBitPackingValuesReader;
+import org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesReaderForDouble;
+import org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesReaderForFloat;
 import org.apache.parquet.column.values.rle.ZeroIntegerValuesReader;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
 import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesReader;
@@ -117,6 +119,20 @@ public enum Encoding {
         return new ZeroIntegerValuesReader();
       }
       return new RunLengthBitPackingHybridValuesReader(bitWidth);
+    }
+  },
+
+  BYTE_STREAM_SPLIT {
+    @Override
+    public ValuesReader getValuesReader(ColumnDescriptor descriptor, ValuesType valuesType) {
+      switch (descriptor.getType()) {
+      case FLOAT:
+        return new ByteStreamSplitValuesReaderForFloat();
+      case DOUBLE:
+        return new ByteStreamSplitValuesReaderForDouble();
+      default:
+        throw new ParquetDecodingException("no byte stream split reader for type " + descriptor.getType());
+      }
     }
   },
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReader.java
@@ -1,0 +1,99 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.bytestreamsplit;
+
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.ValuesReader;
+import org.apache.parquet.io.ParquetDecodingException;
+
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class ByteStreamSplitValuesReader extends ValuesReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ByteStreamSplitValuesReader.class);
+  private final int numStreams;
+  private final int elementSizeInBytes;
+  private byte[] byteStreamData;
+  private int indexInStream;
+  private int numberOfValues;
+
+  protected ByteStreamSplitValuesReader(int elementSizeInBytes) {
+    this.numStreams = elementSizeInBytes;
+    this.elementSizeInBytes = elementSizeInBytes;
+    this.indexInStream = 0;
+    this.numberOfValues = 0;
+  }
+
+  protected void gatherElementDataFromStreams(byte[] gatheredData)
+          throws IOException, ArrayIndexOutOfBoundsException {
+    if (gatheredData.length != numStreams) {
+      throw new IOException("gatherData buffer is not of the expected size.");
+    }
+    if (indexInStream >= numberOfValues) {
+      throw new ArrayIndexOutOfBoundsException("Byte-stream data was already exhausted.");
+    }
+    for (int i = 0; i < numStreams; ++i) {
+      gatheredData[i] = byteStreamData[i * numberOfValues + indexInStream];
+    }
+    ++indexInStream;
+  }
+
+  @Override
+  public void initFromPage(int valueCount, ByteBufferInputStream stream) throws IOException {
+    LOG.debug("init from page at offset {} for length {}", stream.position(), stream.available());
+
+    if (valueCount * elementSizeInBytes > stream.available()) {
+      throw new IOException("Stream does not contain enough data for the given number of values.");
+    }
+
+    /* Allocate buffer for all of the byte stream data */
+    final int totalSizeInBytes = valueCount * numStreams;
+    byteStreamData = new byte[totalSizeInBytes];
+
+    /* Eagerly read the data for each stream */
+    final int numRead = stream.read(byteStreamData, 0, totalSizeInBytes);
+    if (numRead != totalSizeInBytes) {
+      String errorMessage = String.format("Failed to read requested number of bytes. Expected: %d. Read %d.",
+              totalSizeInBytes, numRead);
+      throw new IOException(errorMessage);
+    }
+
+    indexInStream = 0;
+    numberOfValues = valueCount;
+  }
+
+  @Override
+  public void skip() {
+    skip(1);
+  }
+
+  @Override
+  public void skip(int n) {
+    if (indexInStream + n > numberOfValues || n < 0) {
+      String errorMessage = String.format(
+              "Cannot skip this many elements. Current index: %d. Skip %d. Total number of elements: %d",
+              indexInStream, n, numberOfValues);
+      throw new ParquetDecodingException(errorMessage);
+    }
+    indexInStream += n;
+  }
+
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForDouble.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForDouble.java
@@ -1,0 +1,51 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.bytestreamsplit;
+
+import org.apache.parquet.io.ParquetDecodingException;
+
+import java.io.IOException;
+
+public class ByteStreamSplitValuesReaderForDouble extends ByteStreamSplitValuesReader {
+
+  private byte[] valueByteBuffer;
+
+  public ByteStreamSplitValuesReaderForDouble() {
+    super(Double.BYTES);
+    valueByteBuffer = new byte[Double.BYTES];
+  }
+
+  @Override
+  public double readDouble() {
+    try {
+      gatherElementDataFromStreams(valueByteBuffer);
+      long value = (long)(valueByteBuffer[0] & 0xFF) |
+                   ((long)(valueByteBuffer[1] & 0xFF) << 8) |
+                   ((long)(valueByteBuffer[2] & 0xFF) << 16) |
+                   ((long)(valueByteBuffer[3] & 0xFF) << 24) |
+                   ((long)(valueByteBuffer[4] & 0xFF) << 32) |
+                   ((long)(valueByteBuffer[5] & 0xFF) << 40) |
+                   ((long)(valueByteBuffer[6] & 0xFF) << 48) |
+                   ((long)(valueByteBuffer[7] & 0xFF) << 56);
+      return Double.longBitsToDouble(value);
+    } catch (IOException | ArrayIndexOutOfBoundsException ex) {
+      throw new ParquetDecodingException("Could not read double.", ex);
+    }
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForDouble.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForDouble.java
@@ -18,13 +18,12 @@
  */
 package org.apache.parquet.column.values.bytestreamsplit;
 
-import org.apache.parquet.io.ParquetDecodingException;
-
-import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 public class ByteStreamSplitValuesReaderForDouble extends ByteStreamSplitValuesReader {
 
-  private byte[] valueByteBuffer;
+  private final byte[] valueByteBuffer;
 
   public ByteStreamSplitValuesReaderForDouble() {
     super(Double.BYTES);
@@ -33,19 +32,7 @@ public class ByteStreamSplitValuesReaderForDouble extends ByteStreamSplitValuesR
 
   @Override
   public double readDouble() {
-    try {
-      gatherElementDataFromStreams(valueByteBuffer);
-      long value = (long)(valueByteBuffer[0] & 0xFF) |
-                   ((long)(valueByteBuffer[1] & 0xFF) << 8) |
-                   ((long)(valueByteBuffer[2] & 0xFF) << 16) |
-                   ((long)(valueByteBuffer[3] & 0xFF) << 24) |
-                   ((long)(valueByteBuffer[4] & 0xFF) << 32) |
-                   ((long)(valueByteBuffer[5] & 0xFF) << 40) |
-                   ((long)(valueByteBuffer[6] & 0xFF) << 48) |
-                   ((long)(valueByteBuffer[7] & 0xFF) << 56);
-      return Double.longBitsToDouble(value);
-    } catch (IOException | ArrayIndexOutOfBoundsException ex) {
-      throw new ParquetDecodingException("Could not read double.", ex);
-    }
+    gatherElementDataFromStreams(valueByteBuffer);
+    return ByteBuffer.wrap(valueByteBuffer).order(ByteOrder.LITTLE_ENDIAN).getDouble();
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForDouble.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForDouble.java
@@ -18,8 +18,7 @@
  */
 package org.apache.parquet.column.values.bytestreamsplit;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+import org.apache.parquet.bytes.BytesUtils;
 
 public class ByteStreamSplitValuesReaderForDouble extends ByteStreamSplitValuesReader {
 
@@ -33,6 +32,6 @@ public class ByteStreamSplitValuesReaderForDouble extends ByteStreamSplitValuesR
   @Override
   public double readDouble() {
     gatherElementDataFromStreams(valueByteBuffer);
-    return ByteBuffer.wrap(valueByteBuffer).order(ByteOrder.LITTLE_ENDIAN).getDouble();
+    return Double.longBitsToDouble(BytesUtils.bytesToLong(valueByteBuffer));
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForFloat.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForFloat.java
@@ -18,13 +18,12 @@
  */
 package org.apache.parquet.column.values.bytestreamsplit;
 
-import org.apache.parquet.io.ParquetDecodingException;
-
-import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 public class ByteStreamSplitValuesReaderForFloat extends ByteStreamSplitValuesReader {
 
-  private byte[] valueByteBuffer;
+  private final byte[] valueByteBuffer;
 
   public ByteStreamSplitValuesReaderForFloat() {
     super(Float.BYTES);
@@ -33,15 +32,7 @@ public class ByteStreamSplitValuesReaderForFloat extends ByteStreamSplitValuesRe
 
   @Override
   public float readFloat() {
-    try {
       gatherElementDataFromStreams(valueByteBuffer);
-      int value = (int)(valueByteBuffer[0] & 0xFF) |
-                  ((int)(valueByteBuffer[1] & 0xFF) << 8) |
-                  ((int)(valueByteBuffer[2] & 0xFF) << 16) |
-                  ((int)(valueByteBuffer[3] & 0xFF) << 24);
-      return Float.intBitsToFloat(value);
-    } catch (IOException | ArrayIndexOutOfBoundsException ex) {
-      throw new ParquetDecodingException("Could not read float.", ex);
-    }
+      return ByteBuffer.wrap(valueByteBuffer).order(ByteOrder.LITTLE_ENDIAN).getFloat();
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForFloat.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForFloat.java
@@ -18,8 +18,7 @@
  */
 package org.apache.parquet.column.values.bytestreamsplit;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
+import org.apache.parquet.bytes.BytesUtils;
 
 public class ByteStreamSplitValuesReaderForFloat extends ByteStreamSplitValuesReader {
 
@@ -33,6 +32,6 @@ public class ByteStreamSplitValuesReaderForFloat extends ByteStreamSplitValuesRe
   @Override
   public float readFloat() {
       gatherElementDataFromStreams(valueByteBuffer);
-      return ByteBuffer.wrap(valueByteBuffer).order(ByteOrder.LITTLE_ENDIAN).getFloat();
+      return Float.intBitsToFloat(BytesUtils.bytesToInt(valueByteBuffer));
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForFloat.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForFloat.java
@@ -1,0 +1,47 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.bytestreamsplit;
+
+import org.apache.parquet.io.ParquetDecodingException;
+
+import java.io.IOException;
+
+public class ByteStreamSplitValuesReaderForFloat extends ByteStreamSplitValuesReader {
+
+  private byte[] valueByteBuffer;
+
+  public ByteStreamSplitValuesReaderForFloat() {
+    super(Float.BYTES);
+    valueByteBuffer = new byte[Float.BYTES];
+  }
+
+  @Override
+  public float readFloat() {
+    try {
+      gatherElementDataFromStreams(valueByteBuffer);
+      int value = (int)(valueByteBuffer[0] & 0xFF) |
+                  ((int)(valueByteBuffer[1] & 0xFF) << 8) |
+                  ((int)(valueByteBuffer[2] & 0xFF) << 16) |
+                  ((int)(valueByteBuffer[3] & 0xFF) << 24);
+      return Float.intBitsToFloat(value);
+    } catch (IOException | ArrayIndexOutOfBoundsException ex) {
+      throw new ParquetDecodingException("Could not read float.", ex);
+    }
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesWriter.java
@@ -1,0 +1,150 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.bytestreamsplit;
+
+import org.apache.parquet.bytes.ByteBufferAllocator;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.CapacityByteArrayOutputStream;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.io.ParquetEncodingException;
+
+public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
+
+  protected final int numStreams;
+  protected final int elementSizeInBytes;
+  private CapacityByteArrayOutputStream[] byteStreams;
+
+  public ByteStreamSplitValuesWriter(int elementSizeInBytes, int initialCapacity, int pageSize, ByteBufferAllocator allocator) {
+    this.numStreams = elementSizeInBytes;
+    this.elementSizeInBytes = elementSizeInBytes;
+    this.byteStreams = new CapacityByteArrayOutputStream[elementSizeInBytes];
+
+    // Round-up the capacity hint.
+    final int capacityPerStream = (pageSize + this.numStreams - 1) / this.numStreams;
+    final int initialCapacityPerStream = (initialCapacity + this.numStreams - 1) / this.numStreams;
+    for (int i = 0; i < this.numStreams; ++i) {
+      this.byteStreams[i] = new CapacityByteArrayOutputStream(
+              initialCapacityPerStream, capacityPerStream, allocator);
+    }
+  }
+
+  @Override
+  public long getBufferedSize() {
+    long totalSize = 0;
+    for (CapacityByteArrayOutputStream stream : this.byteStreams) {
+      totalSize += stream.size();
+    }
+    return totalSize;
+  }
+
+  @Override
+  public BytesInput getBytes() {
+    BytesInput[] allInputs = new BytesInput[this.numStreams];
+    for (int i = 0; i < this.numStreams; ++i) {
+      allInputs[i] = BytesInput.from(this.byteStreams[i]);
+    }
+    return BytesInput.concat(allInputs);
+  }
+
+  @Override
+  public Encoding getEncoding() {
+    return Encoding.BYTE_STREAM_SPLIT;
+  }
+
+  @Override
+  public void reset() {
+    for (CapacityByteArrayOutputStream stream : this.byteStreams) {
+      stream.reset();
+    }
+  }
+
+  @Override
+  public void close() {
+    for (CapacityByteArrayOutputStream stream : byteStreams) {
+      stream.close();
+    }
+  }
+
+  protected void scatterBytes(byte[] bytes) {
+    if (bytes.length != this.numStreams) {
+      throw new ParquetEncodingException("Number of bytes doesn't match the number of streams.");
+    }
+    for (int i = 0; i < bytes.length; ++i) {
+      this.byteStreams[i].write(bytes[i]);
+    }
+  }
+
+  @Override
+  public long getAllocatedSize() {
+    long totalCapacity = 0;
+    for (CapacityByteArrayOutputStream stream : byteStreams) {
+      totalCapacity += stream.getCapacity();
+    }
+    return totalCapacity;
+  }
+
+  public static class FloatByteStreamSplitValuesWriter extends ByteStreamSplitValuesWriter {
+
+    private static final int FLOAT_SIZE_IN_BYTES = 4;
+
+    public FloatByteStreamSplitValuesWriter(int initialCapacity, int pageSize, ByteBufferAllocator allocator) {
+      super(FLOAT_SIZE_IN_BYTES, initialCapacity, pageSize, allocator);
+    }
+
+    @Override
+    public void writeFloat(float v) {
+      int vAsInt = Float.floatToIntBits(v);
+      byte[] bytes = new byte[FLOAT_SIZE_IN_BYTES];
+      for (int i = 0; i < FLOAT_SIZE_IN_BYTES; ++i) {
+        byte b = (byte) ((vAsInt >> (i * 8)) & 0xFF);
+        bytes[i] = b;
+      }
+      super.scatterBytes(bytes);
+    }
+
+    public String memUsageString(String prefix) {
+      return String.format("%s FloatByteStreamSplitWriter %d bytes", prefix, getAllocatedSize());
+    }
+  }
+
+  public static class DoubleByteStreamSplitValuesWriter extends ByteStreamSplitValuesWriter {
+
+    private static final int DOUBLE_SIZE_IN_BYTES = 8;
+
+    public DoubleByteStreamSplitValuesWriter(int initialCapacity, int pageSize, ByteBufferAllocator allocator) {
+      super(DOUBLE_SIZE_IN_BYTES, initialCapacity, pageSize, allocator);
+    }
+
+    @Override
+    public void writeDouble(double v) {
+      long vAsLong = Double.doubleToLongBits(v);
+      byte[] bytes = new byte[DOUBLE_SIZE_IN_BYTES];
+      for (int i = 0; i < DOUBLE_SIZE_IN_BYTES; ++i) {
+        byte b = (byte) ((vAsLong >> (i * 8)) & 0xFF);
+        bytes[i] = b;
+      }
+      super.scatterBytes(bytes);
+    }
+
+    public String memUsageString(String prefix) {
+      return String.format("%s DoubleByteStreamSplitWriter %d bytes", prefix, getAllocatedSize());
+    }
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesWriter.java
@@ -18,10 +18,9 @@
  */
 package org.apache.parquet.column.values.bytestreamsplit;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.bytes.CapacityByteArrayOutputStream;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
@@ -115,7 +114,7 @@ public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
 
     @Override
     public void writeFloat(float v) {
-      super.scatterBytes(ByteBuffer.allocate(Float.BYTES).order(ByteOrder.LITTLE_ENDIAN).putFloat(v).array());
+      super.scatterBytes(BytesUtils.intToBytes(Float.floatToIntBits(v)));
     }
 
     @Override
@@ -132,7 +131,7 @@ public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
 
     @Override
     public void writeDouble(double v) {
-      super.scatterBytes(ByteBuffer.allocate(Double.BYTES).order(ByteOrder.LITTLE_ENDIAN).putDouble(v).array());
+      super.scatterBytes(BytesUtils.longToBytes(Double.doubleToLongBits(v)));
     }
 
     @Override

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/factory/DefaultV1ValuesWriterFactory.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/factory/DefaultV1ValuesWriterFactory.java
@@ -27,6 +27,7 @@ import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
 
 import static org.apache.parquet.column.Encoding.PLAIN_DICTIONARY;
+import org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesWriter;
 
 public class DefaultV1ValuesWriterFactory implements ValuesWriterFactory {
 
@@ -100,12 +101,22 @@ public class DefaultV1ValuesWriterFactory implements ValuesWriterFactory {
   }
 
   private ValuesWriter getDoubleValuesWriter(ColumnDescriptor path) {
-    ValuesWriter fallbackWriter = new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator());
+    ValuesWriter fallbackWriter = null;
+    if (this.parquetProperties.isByteStreamSplitEnabled()) {
+      fallbackWriter = new ByteStreamSplitValuesWriter.DoubleByteStreamSplitValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator());
+    } else {
+      fallbackWriter = new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator());
+    }
     return DefaultValuesWriterFactory.dictWriterWithFallBack(path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
   }
 
   private ValuesWriter getFloatValuesWriter(ColumnDescriptor path) {
-    ValuesWriter fallbackWriter = new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator());
+    ValuesWriter fallbackWriter = null;
+    if (this.parquetProperties.isByteStreamSplitEnabled()) {
+      fallbackWriter = new ByteStreamSplitValuesWriter.FloatByteStreamSplitValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator());
+    } else {
+      fallbackWriter = new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator());
+    }
     return DefaultValuesWriterFactory.dictWriterWithFallBack(path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/factory/DefaultV2ValuesWriterFactory.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/factory/DefaultV2ValuesWriterFactory.java
@@ -22,6 +22,7 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
 import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter;
@@ -104,12 +105,22 @@ public class DefaultV2ValuesWriterFactory implements ValuesWriterFactory {
   }
 
   private ValuesWriter getDoubleValuesWriter(ColumnDescriptor path) {
-    ValuesWriter fallbackWriter = new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator());
+    ValuesWriter fallbackWriter = null;
+    if (this.parquetProperties.isByteStreamSplitEnabled()) {
+      fallbackWriter = new ByteStreamSplitValuesWriter.DoubleByteStreamSplitValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator());
+    } else {
+      fallbackWriter = new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator());
+    }
     return DefaultValuesWriterFactory.dictWriterWithFallBack(path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
   }
 
   private ValuesWriter getFloatValuesWriter(ColumnDescriptor path) {
-    ValuesWriter fallbackWriter = new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator());
+    ValuesWriter fallbackWriter = null;
+    if (this.parquetProperties.isByteStreamSplitEnabled()) {
+      fallbackWriter = new ByteStreamSplitValuesWriter.FloatByteStreamSplitValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator());
+    } else {
+      fallbackWriter = new PlainValuesWriter(parquetProperties.getInitialSlabSize(), parquetProperties.getPageSizeThreshold(), parquetProperties.getAllocator());
+    }
     return DefaultValuesWriterFactory.dictWriterWithFallBack(path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
   }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesEndToEndTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesEndToEndTest.java
@@ -1,0 +1,111 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.bytestreamsplit;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Random;
+
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.DirectByteBufferAllocator;
+import org.junit.Test;
+
+public class ByteStreamSplitValuesEndToEndTest {
+
+  @Test
+  public void testFloatPipeline() throws Exception {
+    // Generate random data.
+    Random rand = new Random(1337);
+    final int numElements = 1024;
+    float[] values = new float[numElements];
+    for (int i = 0; i < numElements; ++i) {
+      float f = rand.nextFloat() * 4096.0f;
+      values[i] = f;
+    }
+
+    ByteStreamSplitValuesWriter.FloatByteStreamSplitValuesWriter writer = null;
+    try {
+      // Encode data.
+      writer
+            = new ByteStreamSplitValuesWriter.FloatByteStreamSplitValuesWriter(
+                    numElements * 4, numElements * 4, new DirectByteBufferAllocator());
+      for (float v : values) {
+        writer.writeFloat(v);
+      }
+
+      assertEquals(numElements * 4, writer.getBufferedSize());
+      BytesInput input = writer.getBytes();
+      assertEquals(numElements * 4, input.size());
+
+      ByteStreamSplitValuesReaderForFloat reader
+              = new ByteStreamSplitValuesReaderForFloat();
+
+      reader.initFromPage(numElements, ByteBufferInputStream.wrap(input.toByteBuffer()));
+
+      for (float expectedValue : values) {
+        float newValue = reader.readFloat();
+        assertEquals(expectedValue, newValue, 0.0f);
+      }
+    } finally {
+      if (writer != null) {
+        writer.reset();
+        writer.close();
+      }
+    }
+  }
+
+  @Test
+  public void testDoublePipeline() throws Exception {
+    // Generate random data.
+    Random rand = new Random(18990);
+    final int numElements = 1024;
+    double[] values = new double[numElements];
+    for (int i = 0; i < numElements; ++i) {
+      double f = rand.nextDouble() * 16384.0;
+      values[i] = f;
+    }
+
+    // Encode data.
+    ByteStreamSplitValuesWriter.DoubleByteStreamSplitValuesWriter writer
+            = new ByteStreamSplitValuesWriter.DoubleByteStreamSplitValuesWriter(
+                    numElements * 8, numElements * 8, new DirectByteBufferAllocator());
+    for (double v : values) {
+      writer.writeDouble(v);
+    }
+
+    assertEquals(numElements * 8, writer.getBufferedSize());
+    BytesInput input = writer.getBytes();
+    assertEquals(numElements * 8, input.size());
+
+    ByteStreamSplitValuesReaderForDouble reader
+            = new ByteStreamSplitValuesReaderForDouble();
+
+    reader.initFromPage(numElements, ByteBufferInputStream.wrap(input.toByteBuffer()));
+
+    for (double expectedValue : values) {
+      double newValue = reader.readDouble();
+      assertEquals(expectedValue, newValue, 0.0);
+    }
+
+    writer.reset();
+    writer.close();
+  }
+
+}

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderTest.java
@@ -1,0 +1,193 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.bytestreamsplit;
+
+import java.io.IOException;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.io.ParquetDecodingException;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+import org.junit.Assert;
+
+public class ByteStreamSplitValuesReaderTest {
+
+  public static class FloatTest {
+
+    private void testReader(byte[] input, float[] values) throws IOException {
+      ByteBuffer buffer = ByteBuffer.wrap(input);
+      ByteBufferInputStream stream = ByteBufferInputStream.wrap(buffer);
+      ByteStreamSplitValuesReaderForFloat reader = new ByteStreamSplitValuesReaderForFloat();
+      reader.initFromPage(values.length, stream);
+      for (float expectedValue : values) {
+        float f = reader.readFloat();
+        assertEquals(expectedValue, f, 0.0f);
+      }
+    }
+
+    @Test
+    public void testSingleElement() throws Exception {
+      byte[] byteData = {(byte) 0x00, (byte) 0x00, (byte) 0x10, (byte) 0x40};
+      testReader(byteData, new float[]{2.25f});
+    }
+
+    @Test
+    public void testSmallBuffer() throws Exception {
+      byte[] byteData = {(byte) 0x40, (byte) 0x00, (byte) 0x80, (byte) 0x40, (byte) 0x05, (byte) 0x84,
+        (byte) 0xc5, (byte) 0xbd, (byte) 0x32, (byte) 0xc2, (byte) 0x41, (byte) 0x42};
+      float expectedValues[] = {-98.62548828125f, 23.62744140625f, 44.62939453125f};
+      testReader(byteData, expectedValues);
+    }
+
+    @Test
+    public void testRandomInput() throws Exception {
+      Random rand = new Random(1337);
+      final int numElements = 256;
+      byte[] byteData = new byte[numElements * 4];
+      float[] values = new float[numElements];
+      for (int i = 0; i < numElements; ++i) {
+        float f = rand.nextFloat() * 1024.0f;
+        values[i] = f;
+        int fAsInt = Float.floatToIntBits(f);
+        byteData[i] = (byte) (fAsInt & 0xFF);
+        byteData[numElements + i] = (byte) ((fAsInt >> 8) & 0xFF);
+        byteData[numElements * 2 + i] = (byte) ((fAsInt >> 16) & 0xFF);
+        byteData[numElements * 3 + i] = (byte) ((fAsInt >> 24) & 0xFF);
+      }
+      testReader(byteData, values);
+    }
+
+    @Test
+    public void testExtraReads() throws Exception {
+      byte[] byteData = {(byte) 0x00, (byte) 0x00, (byte) 0x10, (byte) 0x40};
+      ByteBuffer buffer = ByteBuffer.wrap(byteData);
+      ByteBufferInputStream stream = ByteBufferInputStream.wrap(buffer);
+
+      ByteStreamSplitValuesReaderForFloat reader = new ByteStreamSplitValuesReaderForFloat();
+      reader.initFromPage(1, stream);
+      float f = reader.readFloat();
+      assertEquals(2.25f, f, 0.0f);
+      try {
+        reader.readFloat();
+        Assert.fail("Expected an exception.");
+      } catch (ParquetDecodingException ex) {}
+    }
+
+    @Test
+    public void testSkip() throws Exception {
+      byte[] byteData = new byte[16];
+      for (int i = 0; i < 16; ++i) {
+        byteData[i] = (byte) 0xFF;
+      }
+      byteData[3] = (byte) 0x00;
+      byteData[7] = (byte) 0x00;
+      byteData[11] = (byte) 0x10;
+      byteData[15] = (byte) 0x40;
+      ByteBuffer buffer = ByteBuffer.wrap(byteData);
+      ByteBufferInputStream stream = ByteBufferInputStream.wrap(buffer);
+
+      ByteStreamSplitValuesReaderForFloat reader = new ByteStreamSplitValuesReaderForFloat();
+      reader.initFromPage(4, stream);
+      reader.skip(3);
+      float f = reader.readFloat();
+      assertEquals(2.25f, f, 0.0f);
+    }
+
+    @Test
+    public void testSkipOverflow() throws Exception {
+      byte[] byteData = new byte[128];
+      ByteBuffer buffer = ByteBuffer.wrap(byteData);
+      ByteBufferInputStream stream = ByteBufferInputStream.wrap(buffer);
+
+      ByteStreamSplitValuesReaderForFloat reader = new ByteStreamSplitValuesReaderForFloat();
+      reader.initFromPage(32, stream);
+
+      try {
+        reader.skip(33);
+        Assert.fail("Expected an exception.");
+      } catch (ParquetDecodingException ex) {}
+    }
+
+    @Test
+    public void testSkipUnderflow() throws Exception {
+      byte[] byteData = new byte[128];
+      ByteBuffer buffer = ByteBuffer.wrap(byteData);
+      ByteBufferInputStream stream = ByteBufferInputStream.wrap(buffer);
+
+      ByteStreamSplitValuesReaderForFloat reader = new ByteStreamSplitValuesReaderForFloat();
+      reader.initFromPage(32, stream);
+
+      try {
+        reader.skip(-1);
+        Assert.fail("Expected an exception.");
+      } catch (ParquetDecodingException ex) {}
+    }
+  }
+
+  public static class DoubleTest {
+
+    private void testReader(byte[] input, double[] values) throws IOException {
+      ByteBuffer buffer = ByteBuffer.wrap(input);
+      ByteBufferInputStream stream = ByteBufferInputStream.wrap(buffer);
+      ByteStreamSplitValuesReaderForDouble reader = new ByteStreamSplitValuesReaderForDouble();
+      reader.initFromPage(values.length, stream);
+      for (double expectedValue : values) {
+        double d = reader.readDouble();
+        assertEquals(expectedValue, d, 0.0);
+      }
+    }
+
+    @Test
+    public void testSingleElement() throws Exception {
+      byte[] byteData = {(byte) 0xFE, (byte) 0xFF, (byte) 0xFF, (byte) 0x0D, (byte) 0xA8, (byte) 0x77,
+        (byte) 0xD2, (byte) 0x40};
+      testReader(byteData, new double[]{18910.62585449218});
+    }
+
+    @Test
+    public void testSmallBuffer() throws Exception {
+      byte[] byteData = {(byte) 0xE7, (byte) 0x72, (byte) 0xBE, (byte) 0x09, (byte) 0xA1, (byte) 0xC1,
+        (byte) 0x0A, (byte) 0x0A, (byte) 0x17, (byte) 0xD7, (byte) 0x21, (byte) 0x26, (byte) 0x01,
+        (byte) 0xC7, (byte) 0x53, (byte) 0x0A, (byte) 0x46, (byte) 0x05, (byte) 0x70, (byte) 0xF3,
+        (byte) 0xE4, (byte) 0x40, (byte) 0xC0, (byte) 0x3F};
+      double expectedValues[] = {256.625449218, -78956.4455667788, 0.62565};
+      testReader(byteData, expectedValues);
+    }
+
+    @Test
+    public void testRandomInput() throws Exception {
+      Random rand = new Random(6557);
+      final int numElements = 256;
+      byte[] byteData = new byte[numElements * 8];
+      double[] values = new double[numElements];
+      for (int i = 0; i < numElements; ++i) {
+        double f = rand.nextDouble() * 8192.0;
+        values[i] = f;
+        long fAsLong = Double.doubleToLongBits(f);
+        for (int j = 0; j < 8; ++j) {
+          byteData[numElements * j + i] = (byte) ((fAsLong >> (8 * j)) & 0xFF);
+        }
+      }
+      testReader(byteData, values);
+    }
+  }
+}

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesWriterTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesWriterTest.java
@@ -1,0 +1,189 @@
+/* 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.values.bytestreamsplit;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.DirectByteBufferAllocator;
+
+public class ByteStreamSplitValuesWriterTest {
+
+  public static class FloatTest {
+
+    static float convertType(byte[] bytes) {
+      int v = 0;
+      for (int i = 0; i < bytes.length; ++i) {
+        v |= (((int) (bytes[i] & 0xFF)) << (i * 8));
+      }
+      return Float.intBitsToFloat(v);
+    }
+
+    private ByteStreamSplitValuesWriter.FloatByteStreamSplitValuesWriter getWriter(int capacity) {
+      return new ByteStreamSplitValuesWriter.FloatByteStreamSplitValuesWriter(
+              capacity, capacity, new DirectByteBufferAllocator());
+    }
+
+    @Test
+    public void testSingleElement() throws Exception {
+      final float value = 0.56274414062f;
+      ByteStreamSplitValuesWriter.FloatByteStreamSplitValuesWriter writer = null;
+      try {
+        writer = getWriter(1);
+        writer.writeFloat(value);
+
+        // Check that the buffer size is exactly the size of one float in bytes.
+        assertEquals(4, writer.getBufferedSize());
+
+        // Get bytes and check that this doesn't modify the internal state.
+        BytesInput bytesInput = writer.getBytes();
+        assertEquals(4, writer.getBufferedSize());
+        assertEquals(4, bytesInput.size());
+
+        // Check that the bytes are as expected.
+        final float newValue = convertType(bytesInput.toByteArray());
+        assertEquals(value, newValue, 0.0f);
+
+        // Check that reseting the writer clears the buffered data.
+        writer.reset();
+        assertEquals(0, writer.getBufferedSize());
+        assertEquals(0, writer.getBytes().size());
+      } finally {
+        if (writer != null) {
+          writer.reset();
+          writer.close();
+        }
+      }
+    }
+
+    @Test
+    public void testSmallBuffer() throws Exception {
+      ByteStreamSplitValuesWriter.FloatByteStreamSplitValuesWriter writer = null;
+      try {
+        writer = getWriter(3);
+        writer.writeFloat(202.625f);
+        writer.writeFloat(1024.921875f);
+        writer.writeFloat(2024.5f);
+
+        assertEquals(12, writer.getBufferedSize());
+        byte[] rawBytes = writer.getBytes().toByteArray();
+        assertEquals(12, rawBytes.length);
+
+        final byte[] expectedBytes = {
+          (byte) 0x00, (byte) 0x80, (byte) 0x00,
+          (byte) 0xa0, (byte) 0x1d, (byte) 0x10,
+          (byte) 0x4a, (byte) 0x80, (byte) 0xfd,
+          (byte) 0x43, (byte) 0x44, (byte) 0x44
+        };
+        for (int i = 0; i < 12; ++i) {
+          assertEquals(expectedBytes[i], rawBytes[i]);
+        }
+      } finally {
+        if (writer != null) {
+          writer.reset();
+          writer.close();
+        }
+      }
+    }
+  }
+
+  public static class DoubleTest {
+
+    static double convertType(byte[] bytes) {
+      long v = 0;
+      for (int i = 0; i < bytes.length; ++i) {
+        v |= (((long) (bytes[i] & 0xFF)) << (i * 8));
+      }
+      return Double.longBitsToDouble(v);
+    }
+
+    private ByteStreamSplitValuesWriter.DoubleByteStreamSplitValuesWriter getWriter(int capacity) {
+      return new ByteStreamSplitValuesWriter.DoubleByteStreamSplitValuesWriter(
+              capacity, capacity, new DirectByteBufferAllocator());
+    }
+
+    @Test
+    public void testSingleElement() throws Exception {
+      final double value = 23.6718811111112;
+      ByteStreamSplitValuesWriter.DoubleByteStreamSplitValuesWriter writer = null;
+      try {
+        writer = getWriter(1);
+        writer.writeDouble(value);
+
+        // Check that the buffer size is exactly the size of one double in bytes.
+        assertEquals(8, writer.getBufferedSize());
+
+        // Get bytes and check that this doesn't modify the internal state.
+        BytesInput bytesInput = writer.getBytes();
+        assertEquals(8, writer.getBufferedSize());
+        assertEquals(8, bytesInput.size());
+
+        // Check that the bytes are as expected.
+        final double newValue = convertType(bytesInput.toByteArray());
+        assertEquals(value, newValue, 0.0);
+
+        // Check that reseting the writer clears the buffered data.
+        writer.reset();
+        assertEquals(0, writer.getBufferedSize());
+        assertEquals(0, writer.getBytes().size());
+      } finally {
+        if (writer != null) {
+          writer.reset();
+          writer.close();
+        }
+      }
+    }
+
+    @Test
+    public void testSmallBuffer() throws Exception {
+      ByteStreamSplitValuesWriter.DoubleByteStreamSplitValuesWriter writer = null;
+      try {
+        writer = getWriter(3);
+        writer.writeDouble(13.6288992);
+        writer.writeDouble(671.99901111);
+        writer.writeDouble(3500199909.3019013);
+
+        assertEquals(24, writer.getBufferedSize());
+        byte[] rawBytes = writer.getBytes().toByteArray();
+        assertEquals(24, rawBytes.length);
+
+        final byte[] expectedBytes = {
+          (byte) 0x0c, (byte) 0x53, (byte) 0x2D,
+          (byte) 0xF6, (byte) 0x6E, (byte) 0xA9,
+          (byte) 0x70, (byte) 0x89, (byte) 0xA9,
+          (byte) 0x13, (byte) 0xF9, (byte) 0xFC,
+          (byte) 0xFF, (byte) 0xFD, (byte) 0x19,
+          (byte) 0x41, (byte) 0xFF, (byte) 0x14,
+          (byte) 0x2b, (byte) 0x84, (byte) 0xEA,
+          (byte) 0x40, (byte) 0x40, (byte) 0x41
+        };
+
+        for (int i = 0; i < 24; ++i) {
+          assertEquals(expectedBytes[i], rawBytes[i]);
+        }
+      } finally {
+        if (writer != null) {
+          writer.reset();
+          writer.close();
+        }
+      }
+    }
+  }
+}

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactoryTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactoryTest.java
@@ -31,6 +31,7 @@ import org.apache.parquet.column.values.fallback.FallbackValuesWriter;
 import org.apache.parquet.column.values.plain.BooleanPlainValuesWriter;
 import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
+import org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesWriter;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 
@@ -48,6 +49,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.BOOLEAN,
       WriterVersion.PARQUET_1_0,
       true,
+      false,
       BooleanPlainValuesWriter.class);
   }
 
@@ -57,6 +59,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.BOOLEAN,
       WriterVersion.PARQUET_2_0,
       true,
+      false,
       RunLengthBitPackingHybridValuesWriter.class);
   }
 
@@ -66,6 +69,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
       WriterVersion.PARQUET_1_0,
       true,
+      false,
       FixedLenByteArrayPlainValuesWriter.class);
   }
 
@@ -75,6 +79,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
       WriterVersion.PARQUET_2_0,
       true,
+      false,
       DictionaryValuesWriter.class, DeltaByteArrayWriter.class);
   }
 
@@ -83,6 +88,7 @@ public class DefaultValuesWriterFactoryTest {
     doTestValueWriter(
       PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
       WriterVersion.PARQUET_2_0,
+      false,
       false,
       DeltaByteArrayWriter.class);
   }
@@ -93,6 +99,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.BINARY,
       WriterVersion.PARQUET_1_0,
       true,
+      false,
       PlainBinaryDictionaryValuesWriter.class, PlainValuesWriter.class);
   }
 
@@ -101,6 +108,7 @@ public class DefaultValuesWriterFactoryTest {
     doTestValueWriter(
       PrimitiveTypeName.BINARY,
       WriterVersion.PARQUET_1_0,
+      false,
       false,
       PlainValuesWriter.class);
   }
@@ -111,6 +119,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.BINARY,
       WriterVersion.PARQUET_2_0,
       true,
+      false,
       PlainBinaryDictionaryValuesWriter.class, DeltaByteArrayWriter.class);
   }
 
@@ -119,6 +128,7 @@ public class DefaultValuesWriterFactoryTest {
     doTestValueWriter(
       PrimitiveTypeName.BINARY,
       WriterVersion.PARQUET_2_0,
+      false,
       false,
       DeltaByteArrayWriter.class);
   }
@@ -129,6 +139,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.INT32,
       WriterVersion.PARQUET_1_0,
       true,
+      false,
       PlainIntegerDictionaryValuesWriter.class, PlainValuesWriter.class);
   }
 
@@ -137,6 +148,7 @@ public class DefaultValuesWriterFactoryTest {
     doTestValueWriter(
       PrimitiveTypeName.INT32,
       WriterVersion.PARQUET_1_0,
+      false,
       false,
       PlainValuesWriter.class);
   }
@@ -147,6 +159,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.INT32,
       WriterVersion.PARQUET_2_0,
       true,
+      false,
       PlainIntegerDictionaryValuesWriter.class, DeltaBinaryPackingValuesWriter.class);
   }
 
@@ -155,6 +168,7 @@ public class DefaultValuesWriterFactoryTest {
     doTestValueWriter(
       PrimitiveTypeName.INT32,
       WriterVersion.PARQUET_2_0,
+      false,
       false,
       DeltaBinaryPackingValuesWriter.class);
   }
@@ -165,6 +179,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.INT64,
       WriterVersion.PARQUET_1_0,
       true,
+      false,
       PlainLongDictionaryValuesWriter.class, PlainValuesWriter.class);
   }
 
@@ -173,6 +188,7 @@ public class DefaultValuesWriterFactoryTest {
     doTestValueWriter(
       PrimitiveTypeName.INT64,
       WriterVersion.PARQUET_1_0,
+      false,
       false,
       PlainValuesWriter.class);
   }
@@ -183,6 +199,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.INT64,
       WriterVersion.PARQUET_2_0,
       true,
+      false,
       PlainLongDictionaryValuesWriter.class, DeltaBinaryPackingValuesWriterForLong.class);
   }
 
@@ -191,6 +208,7 @@ public class DefaultValuesWriterFactoryTest {
     doTestValueWriter(
       PrimitiveTypeName.INT64,
       WriterVersion.PARQUET_2_0,
+      false,
       false,
       DeltaBinaryPackingValuesWriterForLong.class);
   }
@@ -201,6 +219,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.INT96,
       WriterVersion.PARQUET_1_0,
       true,
+      false,
       PlainFixedLenArrayDictionaryValuesWriter.class, FixedLenByteArrayPlainValuesWriter.class);
   }
 
@@ -209,6 +228,7 @@ public class DefaultValuesWriterFactoryTest {
     doTestValueWriter(
       PrimitiveTypeName.INT96,
       WriterVersion.PARQUET_1_0,
+      false,
       false,
       FixedLenByteArrayPlainValuesWriter.class);
   }
@@ -219,6 +239,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.INT96,
       WriterVersion.PARQUET_2_0,
       true,
+      false,
       PlainFixedLenArrayDictionaryValuesWriter.class, FixedLenByteArrayPlainValuesWriter.class);
   }
 
@@ -227,6 +248,7 @@ public class DefaultValuesWriterFactoryTest {
     doTestValueWriter(
       PrimitiveTypeName.INT96,
       WriterVersion.PARQUET_2_0,
+      false,
       false,
       FixedLenByteArrayPlainValuesWriter.class);
   }
@@ -237,6 +259,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.DOUBLE,
       WriterVersion.PARQUET_1_0,
       true,
+      false,
       PlainDoubleDictionaryValuesWriter.class, PlainValuesWriter.class);
   }
 
@@ -245,6 +268,7 @@ public class DefaultValuesWriterFactoryTest {
     doTestValueWriter(
       PrimitiveTypeName.DOUBLE,
       WriterVersion.PARQUET_1_0,
+      false,
       false,
       PlainValuesWriter.class);
   }
@@ -255,6 +279,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.DOUBLE,
       WriterVersion.PARQUET_2_0,
       true,
+      false,
       PlainDoubleDictionaryValuesWriter.class, PlainValuesWriter.class);
   }
 
@@ -263,6 +288,7 @@ public class DefaultValuesWriterFactoryTest {
     doTestValueWriter(
       PrimitiveTypeName.DOUBLE,
       WriterVersion.PARQUET_2_0,
+      false,
       false,
       PlainValuesWriter.class);
   }
@@ -273,6 +299,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.FLOAT,
       WriterVersion.PARQUET_1_0,
       true,
+      false,
       PlainFloatDictionaryValuesWriter.class, PlainValuesWriter.class);
   }
 
@@ -281,6 +308,7 @@ public class DefaultValuesWriterFactoryTest {
     doTestValueWriter(
       PrimitiveTypeName.FLOAT,
       WriterVersion.PARQUET_1_0,
+      false,
       false,
       PlainValuesWriter.class);
   }
@@ -291,6 +319,7 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.FLOAT,
       WriterVersion.PARQUET_2_0,
       true,
+      false,
       PlainFloatDictionaryValuesWriter.class, PlainValuesWriter.class);
   }
 
@@ -300,20 +329,100 @@ public class DefaultValuesWriterFactoryTest {
       PrimitiveTypeName.FLOAT,
       WriterVersion.PARQUET_2_0,
       false,
+      false,
       PlainValuesWriter.class);
   }
 
-  private void doTestValueWriter(PrimitiveTypeName typeName, WriterVersion version, boolean enableDictionary, Class<? extends ValuesWriter> expectedValueWriterClass) {
+  @Test
+  public void testFloat_V1_WithByteStreamSplit() {
+   doTestValueWriter(
+     PrimitiveTypeName.FLOAT,
+     WriterVersion.PARQUET_1_0,
+     false,
+     true,
+     ByteStreamSplitValuesWriter.class);
+  }
+
+  @Test
+  public void testDouble_V1_WithByteStreamSplit() {
+    doTestValueWriter(
+      PrimitiveTypeName.DOUBLE,
+      WriterVersion.PARQUET_1_0,
+      false,
+      true,
+      ByteStreamSplitValuesWriter.class);
+  }
+
+  @Test
+  public void testFloat_V2_WithByteStreamSplit() {
+    doTestValueWriter(
+      PrimitiveTypeName.FLOAT,
+      WriterVersion.PARQUET_2_0,
+      false,
+      true,
+      ByteStreamSplitValuesWriter.class);
+  }
+
+  @Test
+  public void testDouble_V2_WithByteStreamSplit() {
+    doTestValueWriter(
+      PrimitiveTypeName.DOUBLE,
+      WriterVersion.PARQUET_2_0,
+      false,
+      true,
+      ByteStreamSplitValuesWriter.class);
+  }
+
+  public void testFloat_V1_WithByteStreamSplitAndDictionary() {
+    doTestValueWriter(
+      PrimitiveTypeName.FLOAT,
+      WriterVersion.PARQUET_1_0,
+      true,
+      true,
+      PlainFloatDictionaryValuesWriter.class, ByteStreamSplitValuesWriter.class);
+  }
+
+  @Test
+  public void testDouble_V1_WithByteStreamSplitAndDictionary() {
+    doTestValueWriter(
+      PrimitiveTypeName.DOUBLE,
+      WriterVersion.PARQUET_1_0,
+      true,
+      true,
+      PlainDoubleDictionaryValuesWriter.class, ByteStreamSplitValuesWriter.class);
+  }
+
+  @Test
+  public void testFloat_V2_WithByteStreamSplitAndDictionary() {
+    doTestValueWriter(
+      PrimitiveTypeName.FLOAT,
+      WriterVersion.PARQUET_2_0,
+      true,
+      true,
+      PlainFloatDictionaryValuesWriter.class, ByteStreamSplitValuesWriter.class);
+  }
+
+  @Test
+  public void testDouble_V2_WithByteStreamSplitAndDictionary() {
+    doTestValueWriter(
+      PrimitiveTypeName.DOUBLE,
+      WriterVersion.PARQUET_2_0,
+      true,
+      true,
+      PlainDoubleDictionaryValuesWriter.class, ByteStreamSplitValuesWriter.class);
+  }
+
+  private void doTestValueWriter(PrimitiveTypeName typeName, WriterVersion version, boolean enableDictionary, boolean enableByteStreamSplit, Class<? extends ValuesWriter> expectedValueWriterClass) {
     ColumnDescriptor mockPath = getMockColumn(typeName);
-    ValuesWriterFactory factory = getDefaultFactory(version, enableDictionary);
+    ValuesWriterFactory factory = getDefaultFactory(version, enableDictionary, enableByteStreamSplit);
     ValuesWriter writer = factory.newValuesWriter(mockPath);
 
     validateWriterType(writer, expectedValueWriterClass);
   }
 
-  private void doTestValueWriter(PrimitiveTypeName typeName, WriterVersion version, boolean enableDictionary, Class<? extends ValuesWriter> initialValueWriterClass, Class<? extends ValuesWriter> fallbackValueWriterClass) {
+  private void doTestValueWriter(PrimitiveTypeName typeName, WriterVersion version, boolean enableDictionary, boolean enableByteStreamSplit, Class<? extends ValuesWriter> initialValueWriterClass, Class<? extends ValuesWriter> fallbackValueWriterClass) {
     ColumnDescriptor mockPath = getMockColumn(typeName);
-    ValuesWriterFactory factory = getDefaultFactory(version, enableDictionary);
+    ValuesWriterFactory factory = getDefaultFactory(version, enableDictionary, enableByteStreamSplit);
     ValuesWriter writer = factory.newValuesWriter(mockPath);
 
     validateFallbackWriter(writer, initialValueWriterClass, fallbackValueWriterClass);
@@ -325,10 +434,11 @@ public class DefaultValuesWriterFactoryTest {
     return mockPath;
   }
 
-  private ValuesWriterFactory getDefaultFactory(WriterVersion writerVersion, boolean enableDictionary) {
+  private ValuesWriterFactory getDefaultFactory(WriterVersion writerVersion, boolean enableDictionary, boolean enableByteStreamSplit) {
     ValuesWriterFactory factory = new DefaultValuesWriterFactory();
     ParquetProperties.builder()
       .withDictionaryEncoding(enableDictionary)
+      .withByteStreamSplitEncoding(enableByteStreamSplit)
       .withWriterVersion(writerVersion)
       .withValuesWriterFactory(factory)
       .build();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -484,6 +484,11 @@ public class ParquetWriter<T> implements Closeable {
       return self();
     }
 
+    public SELF withByteStreamSplitEncoding(boolean enableByteStreamSplit) {
+      encodingPropsBuilder.withByteStreamSplitEncoding(enableByteStreamSplit);
+      return self();
+    }
+
     /**
      * Enables validation for the constructed writer.
      *

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <hadoop.version>2.7.3</hadoop.version>
     <cascading.version>2.7.1</cascading.version>
     <cascading3.version>3.1.2</cascading3.version>
-    <parquet.format.version>2.7.0</parquet.format.version>
+    <parquet.format.version>2.8.0</parquet.format.version>
     <previous.version>1.11.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <format.thrift.executable>thrift</format.thrift.executable>


### PR DESCRIPTION
The patch adds an implementation and tests for the
BYTE_STREAM_SPLIT encoding.
