### PR TITLE
[PARQUET-1717] Convert i16 thrift to INT16 logical type instead

### DIFF
--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
@@ -314,7 +314,7 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
 
   @Override
   public ConvertedField visit(I16Type i16Type, State state) {
-    return visitPrimitiveType(INT32, state);
+    return visitPrimitiveType(INT32, LogicalTypeAnnotation.intType(16, true),state);
   }
 
   @Override

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConverter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConverter.java
@@ -28,6 +28,7 @@ import org.apache.parquet.thrift.struct.ThriftType;
 import org.apache.parquet.thrift.struct.ThriftType.StructType;
 import org.apache.parquet.thrift.test.compat.MapStructV2;
 import org.apache.parquet.thrift.test.compat.SetStructV2;
+import org.apache.parquet.thrift.test.TestLogicalType;
 import org.apache.thrift.TBase;
 import org.junit.Test;
 
@@ -337,4 +338,16 @@ public class TestThriftSchemaConverter {
     final ThriftType fromJSON = StructType.fromJSON(json);
     assertEquals(json, fromJSON.toJSON());
   }
+
+  @Test
+  public void testLogicalTypeConvertion() throws Exception {
+    String expected =
+      "message ParquetSchema {\n" +
+        "  required int32 test_i16 (INTEGER(16,true)) = 1;" +
+        "}";
+    ThriftSchemaConverter schemaConverter = new ThriftSchemaConverter();
+    final MessageType converted = schemaConverter.convert(TestLogicalType.class);
+    assertEquals(MessageTypeParser.parseMessageType(expected), converted);
+  }
+
 }

--- a/parquet-thrift/src/test/thrift/test.thrift
+++ b/parquet-thrift/src/test/thrift/test.thrift
@@ -95,3 +95,7 @@ struct StructWithExtraField {
   3: required Phone extraPhone,
   6: required Phone phone
 }
+
+struct TestLogicalType {
+  1: required i16 test_i16
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [PARQUET-1717](https://issues.apache.org/jira/browse/PARQUET/PARQUET-1717)

### Tests

- [X] My PR does not need testing for this extremely good reason: No new functions were added

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
