### PR TITLE
[PARQUET-1719] Make ParquetReader(List<InputFile>, ParquetReadOptions, ReadSupport<T>) constructor public

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetReader.java
@@ -104,7 +104,7 @@ public class ParquetReader<T> implements Closeable {
     this(conf, file, readSupport, FilterCompat.get(unboundRecordFilter));
   }
 
-  private ParquetReader(Configuration conf,
+  public ParquetReader(Configuration conf,
                         Path file,
                         ReadSupport<T> readSupport,
                         FilterCompat.Filter filter) throws IOException {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [PARQUET-1719](https://issues.apache.org/jira/browse/PARQUET-1719) issues "PARQUET-1719: Make ParquetReader(List<InputFile>, ParquetReadOptions, ReadSupport<T>) constructor public"

### Tests

- [ ] My PR does not need testing for this extremely good reason: No new functions were added

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
