### PR TITLE
PARQUET-1724: Use ConcurrentHashMap for Cache in DictionaryPageReader

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DictionaryPageReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DictionaryPageReader.java
@@ -18,7 +18,6 @@
  */
 package org.apache.parquet.hadoop;
 
-import org.apache.parquet.Strings;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
@@ -31,7 +30,10 @@ import org.apache.parquet.io.ParquetDecodingException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.parquet.column.Encoding.PLAIN_DICTIONARY;
 import static org.apache.parquet.column.Encoding.RLE_DICTIONARY;
@@ -48,12 +50,23 @@ class DictionaryPageReader implements DictionaryPageReadStore {
 
   private final ParquetFileReader reader;
   private final Map<String, ColumnChunkMetaData> columns;
-  private final Map<String, DictionaryPage> cache = new HashMap<String, DictionaryPage>();
+  private final Map<String, Optional<DictionaryPage>> cache;
   private ColumnChunkPageReadStore rowGroup = null;
 
+  /**
+   * Instantiate a new DictionaryPageReader.
+   *
+   * @param reader The target ParquetFileReader
+   * @param block The target BlockMetaData
+   *
+   * @throws NullPointerException if {@code reader} or {@code block} is
+   *           {@code null}
+   */
   DictionaryPageReader(ParquetFileReader reader, BlockMetaData block) {
-    this.reader = reader;
-    this.columns = new HashMap<String, ColumnChunkMetaData>();
+    this.reader = Objects.requireNonNull(reader);
+    this.columns = new HashMap<>();
+    this.cache = new ConcurrentHashMap<>();
+
     for (ColumnChunkMetaData column : block.getColumns()) {
       columns.put(column.getPath().toDotString(), column);
     }
@@ -78,47 +91,32 @@ class DictionaryPageReader implements DictionaryPageReadStore {
       return rowGroup.readDictionaryPage(descriptor);
     }
 
-    String dotPath = Strings.join(descriptor.getPath(), ".");
+    String dotPath = String.join(".", descriptor.getPath());
     ColumnChunkMetaData column = columns.get(dotPath);
     if (column == null) {
       throw new ParquetDecodingException(
-          "Cannot load dictionary, unknown column: " + dotPath);
+          "Failed to load dictionary, unknown column: " + dotPath);
     }
 
-    if (cache.containsKey(dotPath)) {
-      return cache.get(dotPath);
-    }
+    return cache.computeIfAbsent(dotPath, key -> {
+      try {
+        final DictionaryPage dict =
+            hasDictionaryPage(column) ? reader.readDictionary(column) : null;
 
-    try {
-      synchronized (cache) {
-        // check the cache again in case this thread waited on another reading the same page
-        if (!cache.containsKey(dotPath)) {
-          DictionaryPage dict = hasDictionaryPage(column) ? reader.readDictionary(column) : null;
-          // copy the dictionary to ensure it can be reused if it is returned
-          // more than once. this can happen when a DictionaryFilter has two or
-          // more predicates for the same column.
-          cache.put(dotPath, reusableCopy(dict));
-        }
+        // Copy the dictionary to ensure it can be reused if it is returned
+        // more than once. This can happen when a DictionaryFilter has two or
+        // more predicates for the same column. Cache misses as well.
+        return (dict != null) ? Optional.of(reusableCopy(dict)) : Optional.empty();
+      } catch (IOException e) {
+        throw new ParquetDecodingException("Failed to read dictionary", e);
       }
-
-      return cache.get(dotPath);
-    } catch (IOException e) {
-      throw new ParquetDecodingException(
-          "Failed to read dictionary", e);
-    }
+    }).orElse(null);
   }
 
-  private static DictionaryPage reusableCopy(DictionaryPage dict) {
-    if (dict == null) {
-      return null;
-    }
-    try {
-      return new DictionaryPage(
-          BytesInput.from(dict.getBytes().toByteArray()),
-          dict.getDictionarySize(), dict.getEncoding());
-    } catch (IOException e) {
-      throw new ParquetDecodingException("Cannot read dictionary", e);
-    }
+  private static DictionaryPage reusableCopy(DictionaryPage dict)
+      throws IOException {
+    return new DictionaryPage(BytesInput.from(dict.getBytes().toByteArray()),
+        dict.getDictionarySize(), dict.getEncoding());
   }
 
   private boolean hasDictionaryPage(ColumnChunkMetaData column) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [PARQUET-1724](https://issues.apache.org/jira/browse/PARQUET/PARQUET-1724) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
