### PR TITLE
PARQUET-1728: Simplify NullPointerException Handling in AvroWriteSupport

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
@@ -551,15 +551,16 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
           }
         } catch (NullPointerException e) {
           // find the null element and throw a better error message
-          final int idx = Arrays.asList(array).indexOf(null);
+          final int idx =
+              Arrays.asList(array.toArray(new Object[0])).indexOf(null);
           if (idx < 0) {
             // no element was null, throw the original exception
             throw e;
           }
-            throw new NullPointerException(
-                "Array contains a null element at " + idx + ". " +
-                "Set parquet.avro.write-old-list-structure=false to turn " +
-                "on support for arrays with null elements.");
+          throw new NullPointerException(
+              "Array contains a null element at " + idx + ". "
+                  + "Set parquet.avro.write-old-list-structure=false to turn "
+                  + "on support for arrays with null elements.");
         }
         recordConsumer.endField(OLD_LIST_REPEATED_NAME, 0);
       }

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
@@ -19,6 +19,7 @@
 package org.apache.parquet.avro;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -542,7 +543,7 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
     @Override
     public void writeCollection(GroupType schema, Schema avroSchema,
                                 Collection<?> array) {
-      if (array.size() > 0) {
+      if (!array.isEmpty()) {
         recordConsumer.startField(OLD_LIST_REPEATED_NAME, 0);
         try {
           for (Object elt : array) {
@@ -550,18 +551,15 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
           }
         } catch (NullPointerException e) {
           // find the null element and throw a better error message
-          int i = 0;
-          for (Object elt : array) {
-            if (elt == null) {
-              throw new NullPointerException(
-                  "Array contains a null element at " + i + "\n" +
-                  "Set parquet.avro.write-old-list-structure=false to turn " +
-                  "on support for arrays with null elements.");
-            }
-            i += 1;
+          final int idx = Arrays.asList(array).indexOf(null);
+          if (idx < 0) {
+            // no element was null, throw the original exception
+            throw e;
           }
-          // no element was null, throw the original exception
-          throw e;
+            throw new NullPointerException(
+                "Array contains a null element at " + idx + ". " +
+                "Set parquet.avro.write-old-list-structure=false to turn " +
+                "on support for arrays with null elements.");
         }
         recordConsumer.endField(OLD_LIST_REPEATED_NAME, 0);
       }
@@ -578,16 +576,15 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
           }
         } catch (NullPointerException e) {
           // find the null element and throw a better error message
-          for (int i = 0; i < array.length; i += 1) {
-            if (array[i] == null) {
-              throw new NullPointerException(
-                  "Array contains a null element at " + i + "\n" +
-                  "Set parquet.avro.write-old-list-structure=false to turn " +
-                  "on support for arrays with null elements.");
-            }
+          final int idx = Arrays.asList(array).indexOf(null);
+          if (idx < 0) {
+            // no element was null, throw the original exception
+            throw e;
           }
-          // no element was null, throw the original exception
-          throw e;
+          throw new NullPointerException(
+              "Array contains a null element at " + idx + ". " +
+              "Set parquet.avro.write-old-list-structure=false to turn " +
+              "on support for arrays with null elements.");
         }
         recordConsumer.endField(OLD_LIST_REPEATED_NAME, 0);
       }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [PARQUET-1728](https://issues.apache.org/jira/browse/PARQUET/PARQUET-1728) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1728
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
