### PR TITLE
PARQUET-1729: Avoid AutoBoxing in EncodingStats

### DIFF
--- a/parquet-column/src/test/java/org/apache/parquet/column/TestEncodingStats.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/TestEncodingStats.java
@@ -39,12 +39,6 @@ public class TestEncodingStats {
     builder.addDataEncoding(Encoding.DELTA_BYTE_ARRAY);
     EncodingStats stats1 = builder.build();
 
-    Map<Encoding, Integer> expectedDictStats1 = new HashMap<Encoding, Integer>();
-    expectedDictStats1.put(Encoding.PLAIN, 1);
-    Map<Encoding, Integer> expectedDataStats1 = new HashMap<Encoding, Integer>();
-    expectedDataStats1.put(Encoding.RLE_DICTIONARY, 3);
-    expectedDataStats1.put(Encoding.DELTA_BYTE_ARRAY, 2);
-
     builder.clear();
     builder.addDataEncoding(Encoding.PLAIN);
     builder.addDataEncoding(Encoding.PLAIN);
@@ -52,15 +46,24 @@ public class TestEncodingStats {
     builder.addDataEncoding(Encoding.PLAIN);
     EncodingStats stats2 = builder.build();
 
-    Map<Encoding, Integer> expectedDictStats2 = new HashMap<Encoding, Integer>();
-    Map<Encoding, Integer> expectedDataStats2 = new HashMap<Encoding, Integer>();
-    expectedDataStats2.put(Encoding.PLAIN, 4);
+    assertEquals("Dictionary stats should be correct", 0,
+        stats2.dictStats.size());
+    assertEquals("Data stats size should be correct", 1,
+        stats2.dataStats.size());
+    assertEquals("Data stats content should be correct", 4,
+        stats2.dataStats.get(Encoding.PLAIN).intValue());
 
-    assertEquals("Dictionary stats should be correct", expectedDictStats2, stats2.dictStats);
-    assertEquals("Data stats should be correct", expectedDataStats2, stats2.dataStats);
+    assertEquals("Dictionary stats size should be correct after reuse",
+        1, stats1.dictStats.size());
+    assertEquals("Dictionary stats content should be correct", 1,
+        stats1.dictStats.get(Encoding.PLAIN).intValue());
 
-    assertEquals("Dictionary stats should be correct after reuse", expectedDictStats1, stats1.dictStats);
-    assertEquals("Data stats should be correct after reuse", expectedDataStats1, stats1.dataStats);
+    assertEquals("Data stats size should be correct after reuse", 2,
+        stats1.dataStats.size());
+    assertEquals("Data stats content should be correct", 3,
+        stats1.dataStats.get(Encoding.RLE_DICTIONARY).intValue());
+    assertEquals("Data stats content should be correct", 2,
+        stats1.dataStats.get(Encoding.DELTA_BYTE_ARRAY).intValue());
   }
 
   @Test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [PARQUET-1729](https://issues.apache.org/jira/browse/PARQUET/PARQUET-1729) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1729
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
