### PR TITLE
PARQUET-1744: Some filters throws ArrayIndexOutOfBoundsException

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/BoundaryOrder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/BoundaryOrder.java
@@ -84,6 +84,10 @@ public enum BoundaryOrder {
     @Override
     OfInt gt(ColumnIndexBase<?>.ValueComparator comparator) {
       int length = comparator.arrayLength();
+      if (length == 0) {
+        // No matching rows if the column index contains null pages only
+        return IndexIterator.EMPTY;
+      }
       int left = 0;
       int right = length;
       do {
@@ -100,6 +104,10 @@ public enum BoundaryOrder {
     @Override
     OfInt gtEq(ColumnIndexBase<?>.ValueComparator comparator) {
       int length = comparator.arrayLength();
+      if (length == 0) {
+        // No matching rows if the column index contains null pages only
+        return IndexIterator.EMPTY;
+      }
       int left = 0;
       int right = length;
       do {
@@ -116,6 +124,10 @@ public enum BoundaryOrder {
     @Override
     OfInt lt(ColumnIndexBase<?>.ValueComparator comparator) {
       int length = comparator.arrayLength();
+      if (length == 0) {
+        // No matching rows if the column index contains null pages only
+        return IndexIterator.EMPTY;
+      }
       int left = -1;
       int right = length - 1;
       do {
@@ -132,6 +144,10 @@ public enum BoundaryOrder {
     @Override
     OfInt ltEq(ColumnIndexBase<?>.ValueComparator comparator) {
       int length = comparator.arrayLength();
+      if (length == 0) {
+        // No matching rows if the column index contains null pages only
+        return IndexIterator.EMPTY;
+      }
       int left = -1;
       int right = length - 1;
       do {
@@ -207,6 +223,10 @@ public enum BoundaryOrder {
     @Override
     OfInt gt(ColumnIndexBase<?>.ValueComparator comparator) {
       int length = comparator.arrayLength();
+      if (length == 0) {
+        // No matching rows if the column index contains null pages only
+        return IndexIterator.EMPTY;
+      }
       int left = -1;
       int right = length - 1;
       do {
@@ -223,6 +243,10 @@ public enum BoundaryOrder {
     @Override
     OfInt gtEq(ColumnIndexBase<?>.ValueComparator comparator) {
       int length = comparator.arrayLength();
+      if (length == 0) {
+        // No matching rows if the column index contains null pages only
+        return IndexIterator.EMPTY;
+      }
       int left = -1;
       int right = length - 1;
       do {
@@ -239,6 +263,10 @@ public enum BoundaryOrder {
     @Override
     OfInt lt(ColumnIndexBase<?>.ValueComparator comparator) {
       int length = comparator.arrayLength();
+      if (length == 0) {
+        // No matching rows if the column index contains null pages only
+        return IndexIterator.EMPTY;
+      }
       int left = 0;
       int right = length;
       do {
@@ -255,6 +283,10 @@ public enum BoundaryOrder {
     @Override
     OfInt ltEq(ColumnIndexBase<?>.ValueComparator comparator) {
       int length = comparator.arrayLength();
+      if (length == 0) {
+        // No matching rows if the column index contains null pages only
+        return IndexIterator.EMPTY;
+      }
       int left = 0;
       int right = length;
       do {

--- a/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestBoundaryOrder.java
+++ b/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestBoundaryOrder.java
@@ -183,6 +183,7 @@ public class TestBoundaryOrder {
   private static final int RAND_COUNT = 2000;
   private static final ColumnIndexBase<?> RAND_ASCENDING;
   private static final ColumnIndexBase<?> RAND_DESCENDING;
+  private static final ColumnIndexBase<?> ALL_NULL_PAGES;
   private static final SpyValueComparatorBuilder SPY_COMPARATOR_BUILDER = new SpyValueComparatorBuilder();
   static {
     ColumnIndexBuilder builder = ColumnIndexBuilder.getBuilder(TYPE, Integer.MAX_VALUE);
@@ -233,6 +234,13 @@ public class TestBoundaryOrder {
       builder.add(stats(it.next(), it.next()));
     }
     RAND_DESCENDING = (ColumnIndexBase<?>) builder.build();
+
+    builder = ColumnIndexBuilder.getBuilder(TYPE, Integer.MAX_VALUE);
+    // Add a couple of empty stats so column index will contain null pages only
+    for (int i = 0; i < 10; ++i) {
+      builder.add(Statistics.createStats(TYPE));
+    }
+    ALL_NULL_PAGES = (ColumnIndexBase<?>) builder.build();
   }
 
   private static Statistics<?> stats(int min, int max) {
@@ -267,6 +275,14 @@ public class TestBoundaryOrder {
           BoundaryOrder.UNORDERED::eq,
           BoundaryOrder.DESCENDING::eq,
           DESCENDING.createValueComparator(i));
+      validateOperator("Mismatching page indexes for all null pages and value " + i + " with ASCENDING order in ",
+          BoundaryOrder.UNORDERED::eq,
+          BoundaryOrder.ASCENDING::eq,
+          ALL_NULL_PAGES.createValueComparator(i));
+      validateOperator("Mismatching page indexes for all null pages and value " + i + " with DESCENDING order in ",
+          BoundaryOrder.UNORDERED::eq,
+          BoundaryOrder.DESCENDING::eq,
+          ALL_NULL_PAGES.createValueComparator(i));
     }
     for (int i = SINGLE_FROM - 1; i <= SINGLE_TO + 1; ++i) {
       ColumnIndexBase<?>.ValueComparator singleComparator = SINGLE.createValueComparator(i);
@@ -305,6 +321,14 @@ public class TestBoundaryOrder {
           BoundaryOrder.UNORDERED::gt,
           BoundaryOrder.DESCENDING::gt,
           DESCENDING.createValueComparator(i));
+      validateOperator("Mismatching page indexes for all null pages and value " + i + " with ASCENDING order in ",
+          BoundaryOrder.UNORDERED::gt,
+          BoundaryOrder.ASCENDING::gt,
+          ALL_NULL_PAGES.createValueComparator(i));
+      validateOperator("Mismatching page indexes for all null pages and value " + i + " with DESCENDING order in ",
+          BoundaryOrder.UNORDERED::gt,
+          BoundaryOrder.DESCENDING::gt,
+          ALL_NULL_PAGES.createValueComparator(i));
     }
     for (int i = SINGLE_FROM - 1; i <= SINGLE_TO + 1; ++i) {
       ColumnIndexBase<?>.ValueComparator singleComparator = SINGLE.createValueComparator(i);
@@ -343,6 +367,14 @@ public class TestBoundaryOrder {
           BoundaryOrder.UNORDERED::gtEq,
           BoundaryOrder.DESCENDING::gtEq,
           DESCENDING.createValueComparator(i));
+      validateOperator("Mismatching page indexes for all null pages and value " + i + " with ASCENDING order in ",
+          BoundaryOrder.UNORDERED::gtEq,
+          BoundaryOrder.ASCENDING::gtEq,
+          ALL_NULL_PAGES.createValueComparator(i));
+      validateOperator("Mismatching page indexes for all null pages and value " + i + " with DESCENDING order in ",
+          BoundaryOrder.UNORDERED::gtEq,
+          BoundaryOrder.DESCENDING::gtEq,
+          ALL_NULL_PAGES.createValueComparator(i));
     }
     for (int i = SINGLE_FROM - 1; i <= SINGLE_TO + 1; ++i) {
       ColumnIndexBase<?>.ValueComparator singleComparator = SINGLE.createValueComparator(i);
@@ -381,6 +413,14 @@ public class TestBoundaryOrder {
           BoundaryOrder.UNORDERED::lt,
           BoundaryOrder.DESCENDING::lt,
           DESCENDING.createValueComparator(i));
+      validateOperator("Mismatching page indexes for all null pages and value " + i + " with ASCENDING order in ",
+          BoundaryOrder.UNORDERED::lt,
+          BoundaryOrder.ASCENDING::lt,
+          ALL_NULL_PAGES.createValueComparator(i));
+      validateOperator("Mismatching page indexes for all null pages and value " + i + " with DESCENDING order in ",
+          BoundaryOrder.UNORDERED::lt,
+          BoundaryOrder.DESCENDING::lt,
+          ALL_NULL_PAGES.createValueComparator(i));
     }
     for (int i = SINGLE_FROM - 1; i <= SINGLE_TO + 1; ++i) {
       ColumnIndexBase<?>.ValueComparator singleComparator = SINGLE.createValueComparator(i);
@@ -419,6 +459,14 @@ public class TestBoundaryOrder {
           BoundaryOrder.UNORDERED::ltEq,
           BoundaryOrder.DESCENDING::ltEq,
           DESCENDING.createValueComparator(i));
+      validateOperator("Mismatching page indexes for all null pages and value " + i + " with ASCENDING order in ",
+          BoundaryOrder.UNORDERED::ltEq,
+          BoundaryOrder.ASCENDING::ltEq,
+          ALL_NULL_PAGES.createValueComparator(i));
+      validateOperator("Mismatching page indexes for all null pages and value " + i + " with DESCENDING order in ",
+          BoundaryOrder.UNORDERED::ltEq,
+          BoundaryOrder.DESCENDING::ltEq,
+          ALL_NULL_PAGES.createValueComparator(i));
     }
     for (int i = SINGLE_FROM - 1; i <= SINGLE_TO + 1; ++i) {
       ColumnIndexBase<?>.ValueComparator singleComparator = SINGLE.createValueComparator(i);
@@ -457,6 +505,14 @@ public class TestBoundaryOrder {
           BoundaryOrder.UNORDERED::notEq,
           BoundaryOrder.DESCENDING::notEq,
           DESCENDING.createValueComparator(i));
+      validateOperator("Mismatching page indexes for all null pages and value " + i + " with ASCENDING order in ",
+          BoundaryOrder.UNORDERED::notEq,
+          BoundaryOrder.ASCENDING::notEq,
+          ALL_NULL_PAGES.createValueComparator(i));
+      validateOperator("Mismatching page indexes for all null pages and value " + i + " with DESCENDING order in ",
+          BoundaryOrder.UNORDERED::notEq,
+          BoundaryOrder.DESCENDING::notEq,
+          ALL_NULL_PAGES.createValueComparator(i));
     }
     for (int i = FROM - 1; i <= TO + 1; ++i) {
       ColumnIndexBase<?>.ValueComparator singleComparator = SINGLE.createValueComparator(i);


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
