### PR TITLE
PARQUET-1750: Reduce Memory Usage of RowRanges Class

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/internal/filter2/columnindex/RowRanges.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/filter2/columnindex/RowRanges.java
@@ -91,20 +91,20 @@ public class RowRanges {
     }
   }
 
-  static final RowRanges EMPTY = new RowRanges(0);
+  static final RowRanges EMPTY = new RowRanges(Collections.emptyList());
 
   private final List<Range> ranges;
 
   private RowRanges() {
-    this.ranges = new ArrayList<>();
+    this(new ArrayList<>());
   }
 
-  private RowRanges(int initialCapacity) {
-    this.ranges = new ArrayList<>(initialCapacity);
+  private RowRanges(Range range) {
+    this(Collections.singletonList(range));
   }
 
-  private RowRanges(final Range range) {
-    this.ranges = Collections.singletonList(range);
+  private RowRanges(List<Range> ranges) {
+    this.ranges = ranges;
   }
 
   /**

--- a/parquet-column/src/main/java/org/apache/parquet/internal/filter2/columnindex/RowRanges.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/filter2/columnindex/RowRanges.java
@@ -91,27 +91,50 @@ public class RowRanges {
     }
   }
 
-  static final RowRanges EMPTY = new RowRanges();
+  static final RowRanges EMPTY = new RowRanges(0);
 
-  /*
-   * Creates a new RowRanges object with the single range [0, rowCount - 1].
-   */
-  static RowRanges createSingle(long rowCount) {
-    RowRanges ranges = new RowRanges();
-    ranges.add(new Range(0, rowCount - 1));
-    return ranges;
+  private final List<Range> ranges;
+
+  private RowRanges() {
+    this.ranges = new ArrayList<>();
   }
 
-  /*
-   * Creates a new RowRanges object with the following ranges.
+  private RowRanges(int initialCapacity) {
+    this.ranges = new ArrayList<>(initialCapacity);
+  }
+
+  private RowRanges(final Range range) {
+    this.ranges = Collections.singletonList(range);
+  }
+
+  /**
+   * Creates an immutable RowRanges object with the single range [0, rowCount -
+   * 1].
+   *
+   * @param rowCount a single row count
+   * @return an immutable RowRanges
+   */
+  static RowRanges createSingle(long rowCount) {
+    return new RowRanges(new Range(0L, rowCount - 1L));
+  }
+
+  /**
+   * Creates a mutable RowRanges object with the following ranges:
+   * <pre>
    * [firstRowIndex[0], lastRowIndex[0]],
    * [firstRowIndex[1], lastRowIndex[1]],
    * ...,
    * [firstRowIndex[n], lastRowIndex[n]]
+   * </pre>
    * (See OffsetIndex.getFirstRowIndex and OffsetIndex.getLastRowIndex for details.)
    *
    * The union of the ranges are calculated so the result ranges always contain the disjunct ranges. See union for
    * details.
+   *
+   * @param rowCount row count
+   * @param pageIndexes pageIndexes
+   * @param offsetIndex offsetIndex
+   * @return a mutable RowRanges
    */
   static RowRanges create(long rowCount, PrimitiveIterator.OfInt pageIndexes, OffsetIndex offsetIndex) {
     RowRanges ranges = new RowRanges();
@@ -190,11 +213,6 @@ public class RowRanges {
     }
 
     return result;
-  }
-
-  private final List<Range> ranges = new ArrayList<>();
-
-  private RowRanges() {
   }
 
   /*


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [PARQUET-1750](https://issues.apache.org/jira/browse/PARQUET/PARQUET-1750) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1750
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
