### PR TITLE
PARQUET-1771: Support configurable for DirectByteBufferAllocator from Hadoop Configuration

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
@@ -28,6 +28,7 @@ import org.apache.parquet.hadoop.util.HadoopCodecs;
 
 import java.util.Map;
 
+import static org.apache.parquet.hadoop.ParquetInputFormat.ALLOCATOR_DIRECT_BYTEBUFFER_ENABLED;
 import static org.apache.parquet.hadoop.ParquetInputFormat.COLUMN_INDEX_FILTERING_ENABLED;
 import static org.apache.parquet.hadoop.ParquetInputFormat.DICTIONARY_FILTERING_ENABLED;
 import static org.apache.parquet.hadoop.ParquetInputFormat.BLOOM_FILTERING_ENABLED;
@@ -91,6 +92,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
       useStatsFilter(conf.getBoolean(STATS_FILTERING_ENABLED, true));
       useRecordFilter(conf.getBoolean(RECORD_FILTERING_ENABLED, true));
       useColumnIndexFilter(conf.getBoolean(COLUMN_INDEX_FILTERING_ENABLED, true));
+      useDirectByteBufferAllocator(conf.getBoolean(ALLOCATOR_DIRECT_BYTEBUFFER_ENABLED, false));
       usePageChecksumVerification(conf.getBoolean(PAGE_VERIFY_CHECKSUM_ENABLED,
         usePageChecksumVerification));
       useBloomFilter(conf.getBoolean(BLOOM_FILTERING_ENABLED, true));

--- a/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
@@ -243,8 +243,8 @@ public class ParquetReadOptions {
       return this;
     }
 
-    public Builder useDirectByteBufferAllocator(boolean val) {
-      if (val) {
+    public Builder useDirectByteBufferAllocator(boolean useDirectByteBuffer) {
+      if (useDirectByteBuffer) {
         this.allocator = new DirectByteBufferAllocator();
       }
       return this;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
@@ -20,6 +20,7 @@
 package org.apache.parquet;
 
 import org.apache.parquet.bytes.ByteBufferAllocator;
+import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.filter2.compat.FilterCompat;
@@ -239,6 +240,13 @@ public class ParquetReadOptions {
 
     public Builder withRecordFilter(FilterCompat.Filter rowGroupFilter) {
       this.recordFilter = rowGroupFilter;
+      return this;
+    }
+
+    public Builder useDirectByteBufferAllocator(boolean val) {
+      if (val) {
+        this.allocator = new DirectByteBufferAllocator();
+      }
       return this;
     }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -145,6 +145,11 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
   public static final String BLOOM_FILTERING_ENABLED = "parquet.filter.bloom.enabled";
 
   /**
+   * key to configure whether direct bytebuffer allocator is enabled
+   */
+  public static final String ALLOCATOR_DIRECT_BYTEBUFFER_ENABLED = "parquet.allocator.direct.enabled";
+
+  /**
    * key to turn on or off task side metadata loading (default true)
    * if true then metadata is read on the task side and some tasks may finish immediately.
    * if false metadata is read on the client which is slower if there is a lot of metadata but tasks will only be spawn if there is work to do.


### PR DESCRIPTION

### Jira

- "Support configurable for DirectByteBufferAllocator from Hadoop Configuration": https://jira.apache.org/jira/browse/PARQUET-1771#

### Tests

- Old unit tests.

### Commits

- PARQUET-1771: Support configurable for DirectByteBufferAllocator from Hadoop Configuration

