### PR TITLE
PARQUET-1775: Deprecate AvroParquetWriter Builder Hadoop Path

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
@@ -35,6 +35,14 @@ import org.apache.parquet.io.OutputFile;
  */
 public class AvroParquetWriter<T> extends ParquetWriter<T> {
 
+
+  /**
+   * @param file a file path
+   * @param <T> the Java type of records to read from the file
+   * @return an Avro reader builder
+   * @deprecated will be removed in 2.0.0; use {@link #builder(OutputFile)} instead.
+   */
+  @Deprecated
   public static <T> Builder<T> builder(Path file) {
     return new Builder<T>(file);
   }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [PARQUET-1775](https://issues.apache.org/jira/browse/PARQUET/PARQUET-1775) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1775
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
