### PR TITLE
PARQUET-1790: Add Api for writing DataPageV2 to ParquetFileWriter class

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -952,10 +952,8 @@ public class ParquetFileWriter {
   }
 
   private int toIntWithCheck(long size) {
-    if (size > Integer.MAX_VALUE) {
-      throw new ParquetEncodingException(
-        "Cannot write page larger than " + Integer.MAX_VALUE + " bytes: " +
-          size);
+    if ((int)size != size) {
+      throw new ParquetEncodingException("Cannot write page larger than " + Integer.MAX_VALUE + " bytes: " + size);
     }
     return (int)size;
   }


### PR DESCRIPTION
This PR addresses [PARQUET-1790](https://issues.apache.org/jira/projects/PARQUET/issues/PARQUET-1790).

The ParquetFileWriter class currently does not  have an API for writing a DataPageV2 page. 
A similar API is already defined in ColumnChunkPageWriteStore and inspiration can/should be derived from there in implementing this.