### PR TITLE
PARQUET-1743: Add equals API to BloomFilter interface

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
@@ -337,7 +337,7 @@ public class BlockSplitBloomFilter implements BloomFilter {
     if (object instanceof BlockSplitBloomFilter) {
       BlockSplitBloomFilter that = (BlockSplitBloomFilter) object;
       return Arrays.equals(this.bitset, that.bitset)
-        && this.maximumBytes == that.maximumBytes
+        && this.getAlgorithm() == that.getAlgorithm()
         && this.hashStrategy == that.hashStrategy;
     }
     return false;

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
+import java.util.Arrays;
 
 /*
  * This Bloom filter is implemented using block-based Bloom filter algorithm from Putze et al.'s
@@ -326,6 +327,20 @@ public class BlockSplitBloomFilter implements BloomFilter {
     }
 
     return doHash();
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (object == this) {
+      return true;
+    }
+    if (object instanceof BlockSplitBloomFilter) {
+      BlockSplitBloomFilter that = (BlockSplitBloomFilter) object;
+      return Arrays.equals(this.bitset, that.bitset)
+        && this.maximumBytes == that.maximumBytes
+        && this.hashStrategy == that.hashStrategy;
+    }
+    return false;
   }
 
   @Override

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
@@ -97,6 +97,14 @@ public interface BloomFilter {
   int getBitsetSize();
 
   /**
+   * Compare this Bloom filter to the specified object.
+   *
+   * @param object
+   * @return true if the given object represents a Bloom filter equivalent to this Bloom filter, false otherwise.
+   */
+  boolean equals(Object object);
+
+  /**
    * Compute hash for int value by using its plain encoding result.
    *
    * @param value the value to hash

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bloomfilter/TestBlockSplitBloomFilter.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bloomfilter/TestBlockSplitBloomFilter.java
@@ -31,6 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class TestBlockSplitBloomFilter {
@@ -141,6 +142,25 @@ public class TestBlockSplitBloomFilter {
 
     // The exist should be probably less than 1000 according FPP 0.01. Add 20% here for error space.
     assertTrue(exist < totalCount * (FPP * 1.2));
+  }
+
+  @Test
+  public void testEquals() {
+    final String[] words = {"hello", "parquet", "bloom", "filter"};
+    BloomFilter bloomFilterOne = new BlockSplitBloomFilter(1024);
+    BloomFilter bloomFilterTwo = new BlockSplitBloomFilter(1024);
+
+    for (String word : words) {
+      bloomFilterOne.insertHash(bloomFilterOne.hash(Binary.fromString(word)));
+      bloomFilterTwo.insertHash(bloomFilterTwo.hash(Binary.fromString(word)));
+    }
+
+    assertEquals(bloomFilterOne, bloomFilterTwo);
+
+    BloomFilter bloomFilterThree = new BlockSplitBloomFilter(1024);
+    bloomFilterThree.insertHash(bloomFilterThree.hash(Binary.fromString("parquet")));
+
+    assertNotEquals(bloomFilterTwo, bloomFilterThree);
   }
 
   @Test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
