### PR TITLE
PARQUET-1821: Add 'column-size' command to parquet-cli and parquet-tools

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/Main.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/Main.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.parquet.cli.commands.CSVSchemaCommand;
 import org.apache.parquet.cli.commands.CatCommand;
 import org.apache.parquet.cli.commands.CheckParquet251Command;
+import org.apache.parquet.cli.commands.ColumnSizeCommand;
 import org.apache.parquet.cli.commands.ConvertCSVCommand;
 import org.apache.parquet.cli.commands.ConvertCommand;
 import org.apache.parquet.cli.commands.ParquetMetadataCommand;
@@ -89,6 +90,7 @@ public class Main extends Configured implements Tool {
     jc.addCommand("cat", new CatCommand(console, 0));
     jc.addCommand("head", new CatCommand(console, 10));
     jc.addCommand("column-index", new ShowColumnIndexCommand(console));
+    jc.addCommand("column-size", new ColumnSizeCommand(console));
   }
 
   @Override

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnSizeCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnSizeCommand.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.cli.commands;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.avro.file.SeekableInput;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.cli.BaseCommand;
+import org.apache.parquet.cli.util.Formats;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Parameters(commandDescription="Print the column sizes of a parquet file")
+public class ColumnSizeCommand extends BaseCommand {
+
+  public ColumnSizeCommand(Logger console) {
+    super(console);
+  }
+
+  @Parameter(description = "<parquet path>")
+  String target;
+
+  @Parameter(
+    names = {"-c", "--column", "--columns"},
+    description = "List of columns",
+    required = false)
+  List<String> columns;
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public int run() throws IOException {
+    Preconditions.checkArgument(target != null,
+      "A Parquet file is required.");
+
+    Path inputFile = new Path(target);
+    Map<String, Long> columnSizes = getColumnSizeInBytes(inputFile);
+    Map<String, Float> columnPercentage = getColumnPercentage(columnSizes);
+
+    // If user inputted columns, only print out size for those columns
+    if (columns != null && columns.size() > 0) {
+      for (String inputColumn : columns) {
+        long size = 0;
+        float percentage = 0;
+        for (String column : columnSizes.keySet()) {
+          if (column.startsWith(inputColumn)) {
+            size += columnSizes.get(column);
+            percentage += columnPercentage.get(column);
+          }
+        }
+        console.info(inputColumn + "->" + " Size In Bytes: " + size + " Size In Percentage: " + percentage);
+      }
+    } else {
+      for (String column : columnSizes.keySet()) {
+        console.info(column + "->" + " Size In Bytes: " + columnSizes.get(column)
+          + " Size In Percentage: " + columnPercentage.get(column));
+      }
+    }
+
+    return 0;
+  }
+
+  @Override
+  public List<String> getExamples() {
+    return Lists.newArrayList(
+        "# Print every column size in byte and percentage for a Parquet file",
+        "sample.parquet",
+        "sample.parquet col_1 col_2",
+        "sample.parquet col_1 col_2.sub_col_a"
+    );
+  }
+
+  // Make it public to allow some automation tools to call it
+  public Map<String, Long> getColumnSizeInBytes(Path inputFile) throws IOException {
+    Map<String, Long> colSizes = new HashMap<>();
+    ParquetMetadata pmd = ParquetFileReader.readFooter(new Configuration(), inputFile, ParquetMetadataConverter.NO_FILTER);
+
+    for (BlockMetaData block : pmd.getBlocks()) {
+      for (ColumnChunkMetaData column : block.getColumns()) {
+        String colName = column.getPath().toDotString();
+        colSizes.put(colName, column.getTotalSize() + colSizes.getOrDefault(colName, 0L));
+      }
+    }
+
+    return colSizes;
+  }
+
+  // Make it public to allow some automation tools to call it
+  public Map<String, Float> getColumnPercentage(Map<String, Long> colSizes) {
+    long totalSize = colSizes.values().stream().reduce(0L, Long::sum);
+    Map<String, Float> colPercentage = new HashMap<>();
+
+    for (Map.Entry<String, Long> entry : colSizes.entrySet()) {
+      colPercentage.put(entry.getKey(), ((float) entry.getValue()) / ((float) totalSize));
+    }
+
+    return colPercentage;
+  }
+}

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnSizeCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnSizeCommand.java
@@ -68,25 +68,25 @@ public class ColumnSizeCommand extends BaseCommand {
 
     Path inputFile = new Path(target);
     Map<String, Long> columnSizes = getColumnSizeInBytes(inputFile);
-    Map<String, Float> columnPercentage = getColumnPercentage(columnSizes);
+    Map<String, Float> columnRatio = getColumnRatio(columnSizes);
 
     // If user defined columns, only print out size for those columns
     if (columns != null && columns.size() > 0) {
       for (String inputColumn : columns) {
         long size = 0;
-        float percentage = 0;
+        float ratio = 0;
         for (String column : columnSizes.keySet()) {
-          if (column.startsWith(inputColumn)) {
+          if (column.equals(inputColumn) || column.startsWith(inputColumn + ".")) {
             size += columnSizes.get(column);
-            percentage += columnPercentage.get(column);
+            ratio += columnRatio.get(column);
           }
         }
-        console.info(inputColumn + "->" + " Size In Bytes: " + size + " Size In Percentage: " + percentage);
+        console.info(inputColumn + "->" + " Size In Bytes: " + size + " Size In Ratio: " + ratio);
       }
     } else {
       for (String column : columnSizes.keySet()) {
         console.info(column + "->" + " Size In Bytes: " + columnSizes.get(column)
-          + " Size In Percentage: " + columnPercentage.get(column));
+          + " Size In Ratio: " + columnRatio.get(column));
       }
     }
 
@@ -96,10 +96,12 @@ public class ColumnSizeCommand extends BaseCommand {
   @Override
   public List<String> getExamples() {
     return Lists.newArrayList(
-        "# Print every column size in byte and percentage for a Parquet file",
+        "# Print every column size in byte and ratio for a Parquet file",
         "sample.parquet",
-        "sample.parquet col_1 col_2",
-        "sample.parquet col_1 col_2.sub_col_a"
+        "sample.parquet -c col_1",
+        "sample.parquet -column col_2",
+        "sample.parquet -columns col_1 col_2",
+        "sample.parquet -columns col_1 col_2.sub_col_a"
     );
   }
 
@@ -119,14 +121,14 @@ public class ColumnSizeCommand extends BaseCommand {
   }
 
   // Make it public to allow some automation tools to call it
-  public Map<String, Float> getColumnPercentage(Map<String, Long> colSizes) {
+  public Map<String, Float> getColumnRatio(Map<String, Long> colSizes) {
     long totalSize = colSizes.values().stream().reduce(0L, Long::sum);
-    Map<String, Float> colPercentage = new HashMap<>();
+    Map<String, Float> colRatio = new HashMap<>();
 
     for (Map.Entry<String, Long> entry : colSizes.entrySet()) {
-      colPercentage.put(entry.getKey(), ((float) entry.getValue()) / ((float) totalSize));
+      colRatio.put(entry.getKey(), ((float) entry.getValue()) / ((float) totalSize));
     }
 
-    return colPercentage;
+    return colRatio;
   }
 }

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnSizeCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnSizeCommand.java
@@ -99,9 +99,9 @@ public class ColumnSizeCommand extends BaseCommand {
         "# Print every column size in byte and ratio for a Parquet file",
         "sample.parquet",
         "sample.parquet -c col_1",
-        "sample.parquet -column col_2",
-        "sample.parquet -columns col_1 col_2",
-        "sample.parquet -columns col_1 col_2.sub_col_a"
+        "sample.parquet --column col_2",
+        "sample.parquet --columns col_1 col_2",
+        "sample.parquet --columns col_1 col_2.sub_col_a"
     );
   }
 

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnSizeCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnSizeCommand.java
@@ -56,7 +56,10 @@ public class ColumnSizeCommand extends BaseCommand {
 
   @Parameter(
     names = {"-c", "--column", "--columns"},
-    description = "List of columns",
+    description = "List of columns in the case sensitive dot format to be calculated, " +
+                  "for example a.b.c. If an input column is intermediate column, all " +
+                  "the child columns will be printed out. If no columns are set, all " +
+                  "the columns will be printed out.",
     required = false)
   List<String> columns;
 

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnSizeCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnSizeCommand.java
@@ -70,7 +70,7 @@ public class ColumnSizeCommand extends BaseCommand {
     Map<String, Long> columnSizes = getColumnSizeInBytes(inputFile);
     Map<String, Float> columnPercentage = getColumnPercentage(columnSizes);
 
-    // If user inputted columns, only print out size for those columns
+    // If user defined columns, only print out size for those columns
     if (columns != null && columns.size() > 0) {
       for (String inputColumn : columns) {
         long size = 0;

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ColumnSizeCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ColumnSizeCommandTest.java
@@ -59,7 +59,7 @@ public class ColumnSizeCommandTest extends ParquetFileTest {
 
   @Test
   public void testColumnSize() throws Exception {
-    String inputFile = createParquetFile("input");
+    String inputFile = createParquetFile();
     Map<String, Long> columnSizeInBytes = command.getColumnSizeInBytes(new Path(inputFile));
     assertEquals(columnSizeInBytes.size(), 2);
     assertTrue(columnSizeInBytes.get("DocId") > columnSizeInBytes.get("Num"));
@@ -67,14 +67,14 @@ public class ColumnSizeCommandTest extends ParquetFileTest {
     assertTrue(columnRatio.get("DocId") > columnRatio.get("Num"));
   }
 
-  private String createParquetFile(String prefix) throws IOException {
+  private String createParquetFile() throws IOException {
     MessageType schema = new MessageType("schema",
       new PrimitiveType(REQUIRED, INT64, "DocId"),
       new PrimitiveType(REQUIRED, INT32, "Num"));
 
     conf.set(GroupWriteSupport.PARQUET_EXAMPLE_SCHEMA, schema.toString());
 
-    String file = parquetFile().getAbsolutePath();
+    String file = randomParquetFile().getAbsolutePath();
     ExampleParquetWriter.Builder builder = ExampleParquetWriter.builder(new Path(file)).withConf(conf);
     Random rnd = new Random();
     try (ParquetWriter writer = builder.build()) {

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ColumnSizeCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ColumnSizeCommandTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.simple.SimpleGroup;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Random;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ColumnSizeCommandTest extends ParquetFileTest {
+
+  private final int numRecord = 10000;
+  private ColumnSizeCommand command = new ColumnSizeCommand(createLogger());
+  private Configuration conf = new Configuration();
+
+  @Test
+  public void testColumnSizeCommand() throws IOException {
+    File file = parquetFile();
+    ColumnSizeCommand command = new ColumnSizeCommand(createLogger());
+    command.target = file.getAbsolutePath();
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
+
+  @Test
+  public void testColumnSize() throws Exception {
+    String inputFile = createParquetFile("input");
+    Map<String, Long> columnSizeInBytes = command.getColumnSizeInBytes(new Path(inputFile));
+    assertEquals(columnSizeInBytes.size(), 2);
+    assertTrue(columnSizeInBytes.get("DocId") > columnSizeInBytes.get("Num"));
+    Map<String, Float> columnPercentage = command.getColumnPercentage(columnSizeInBytes);
+    assertTrue(columnPercentage.get("DocId") > columnPercentage.get("Num"));
+  }
+
+  private String createParquetFile(String prefix) throws IOException {
+    MessageType schema = new MessageType("schema",
+      new PrimitiveType(REQUIRED, INT64, "DocId"),
+      new PrimitiveType(REQUIRED, INT32, "Num"));
+
+    conf.set(GroupWriteSupport.PARQUET_EXAMPLE_SCHEMA, schema.toString());
+
+    String file = createTempFile(prefix);
+    ExampleParquetWriter.Builder builder = ExampleParquetWriter.builder(new Path(file)).withConf(conf);
+    Random rnd = new Random();
+    try (ParquetWriter writer = builder.build()) {
+      for (int i = 0; i < numRecord; i++) {
+        SimpleGroup g = new SimpleGroup(schema);
+        g.add("DocId", rnd.nextLong());
+        g.add("Num", rnd.nextInt());
+        writer.write(g);
+      }
+    }
+
+    return file;
+  }
+
+  private static String createTempFile(String prefix) {
+    try {
+      return Files.createTempDirectory(prefix).toAbsolutePath().toString() + "/test.parquet";
+    } catch (IOException e) {
+      throw new AssertionError("Unable to create temporary file", e);
+    }
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ColumnSizeCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ColumnSizeCommandTest.java
@@ -74,7 +74,7 @@ public class ColumnSizeCommandTest extends ParquetFileTest {
 
     conf.set(GroupWriteSupport.PARQUET_EXAMPLE_SCHEMA, schema.toString());
 
-    String file = createTempFile(prefix);
+    String file = parquetFile().getAbsolutePath();
     ExampleParquetWriter.Builder builder = ExampleParquetWriter.builder(new Path(file)).withConf(conf);
     Random rnd = new Random();
     try (ParquetWriter writer = builder.build()) {
@@ -87,13 +87,5 @@ public class ColumnSizeCommandTest extends ParquetFileTest {
     }
 
     return file;
-  }
-
-  private static String createTempFile(String prefix) {
-    try {
-      return Files.createTempDirectory(prefix).toAbsolutePath().toString() + "/test.parquet";
-    } catch (IOException e) {
-      throw new AssertionError("Unable to create temporary file", e);
-    }
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ColumnSizeCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ColumnSizeCommandTest.java
@@ -63,8 +63,8 @@ public class ColumnSizeCommandTest extends ParquetFileTest {
     Map<String, Long> columnSizeInBytes = command.getColumnSizeInBytes(new Path(inputFile));
     assertEquals(columnSizeInBytes.size(), 2);
     assertTrue(columnSizeInBytes.get("DocId") > columnSizeInBytes.get("Num"));
-    Map<String, Float> columnPercentage = command.getColumnPercentage(columnSizeInBytes);
-    assertTrue(columnPercentage.get("DocId") > columnPercentage.get("Num"));
+    Map<String, Float> columnRatio = command.getColumnRatio(columnSizeInBytes);
+    assertTrue(columnRatio.get("DocId") > columnRatio.get("Num"));
   }
 
   private String createParquetFile(String prefix) throws IOException {

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetFileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetFileTest.java
@@ -33,12 +33,15 @@ import org.junit.Before;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.parquet.schema.Type.Repetition.*;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 
 public abstract class ParquetFileTest extends FileTest {
+
+  private Random rnd = new Random();
 
   @Before
   public void setUp() throws IOException {
@@ -48,6 +51,11 @@ public abstract class ParquetFileTest extends FileTest {
   protected File parquetFile() {
     File tmpDir = getTempFolder();
     return new File(tmpDir, getClass().getSimpleName() + ".parquet");
+  }
+
+  protected File randomParquetFile() {
+    File tmpDir = getTempFolder();
+    return new File(tmpDir, getClass().getSimpleName() + rnd.nextLong() + ".parquet");
   }
 
   private static MessageType createSchema() {

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/ColumnSizeCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/ColumnSizeCommand.java
@@ -37,9 +37,9 @@ public class ColumnSizeCommand extends ArgsOnlyCommand {
 
   public static final String[] USAGE = new String[] {
     "<input>",
-    "where <input> is the parquet file to calculate teh column size" +
+    "where <input> is the parquet file to calculate the column size" +
     "     [<column> ...] are the columns in the case sensitive dot format" +
-    "     to be calculated, for example a.b.c. If no columns are input, all the" +
+    "     to be calculated, for example a.b.c. If no columns are set, all the" +
     "     columns will be printed out"
   };
 
@@ -118,4 +118,3 @@ public class ColumnSizeCommand extends ArgsOnlyCommand {
     return colPercentage;
   }
 }
-

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/ColumnSizeCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/ColumnSizeCommand.java
@@ -59,7 +59,7 @@ public class ColumnSizeCommand extends ArgsOnlyCommand {
 
   @Override
   public String getCommandDescription() {
-    return "Print out the size in bytes and percentage of column(s) in the input Parquet file";
+    return "Print out the size in bytes and ratio of column(s) in the input Parquet file";
   }
 
   @Override
@@ -69,24 +69,24 @@ public class ColumnSizeCommand extends ArgsOnlyCommand {
     Path inputFile = new Path(args.get(0));
 
     Map<String, Long> columnSizes = getColumnSizeInBytes(inputFile);
-    Map<String, Float> columnPercentage = getColumnPercentage(columnSizes);
+    Map<String, Float> columnRatio = getColumnRatio(columnSizes);
 
     if (args.size() > 1) {
       for (String inputColumn : args.subList(1, args.size())) {
         long size = 0;
-        float percentage = 0;
+        float ratio = 0;
         for (String column : columnSizes.keySet()) {
-          if (column.startsWith(inputColumn)) {
+          if (column.equals(inputColumn) || column.startsWith(inputColumn + ".")) {
             size += columnSizes.get(column);
-            percentage += columnPercentage.get(column);
+            ratio += columnRatio.get(column);
           }
         }
-        Main.out.println(inputColumn + "->" + " Size In Bytes: " + size + " Size In Percentage: " + percentage);
+        Main.out.println(inputColumn + "->" + " Size In Bytes: " + size + " Size In Ratio: " + ratio);
       }
     } else {
       for (String column : columnSizes.keySet()) {
         Main.out.println(column + "->" + " Size In Bytes: " + columnSizes.get(column)
-          + " Size In Percentage: " + columnPercentage.get(column));
+          + " Size In Ratio: " + columnRatio.get(column));
       }
     }
   }
@@ -107,14 +107,14 @@ public class ColumnSizeCommand extends ArgsOnlyCommand {
   }
 
   // Make it public to allow some automation tools to call it
-  public Map<String, Float> getColumnPercentage(Map<String, Long> colSizes) {
+  public Map<String, Float> getColumnRatio(Map<String, Long> colSizes) {
     long totalSize = colSizes.values().stream().reduce(0L, Long::sum);
-    Map<String, Float> colPercentage = new HashMap<>();
+    Map<String, Float> colRatio = new HashMap<>();
 
     for (Map.Entry<String, Long> entry : colSizes.entrySet()) {
-      colPercentage.put(entry.getKey(), ((float) entry.getValue()) / ((float) totalSize));
+      colRatio.put(entry.getKey(), ((float) entry.getValue()) / ((float) totalSize));
     }
 
-    return colPercentage;
+    return colRatio;
   }
 }

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/ColumnSizeCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/ColumnSizeCommand.java
@@ -82,7 +82,7 @@ public class ColumnSizeCommand extends ArgsOnlyCommand {
             ratio += columnRatio.get(column);
           }
         }
-        Main.out.println(inputColumn + "->" + " Size In Bytes: " + size + " Size In Ratio: " + ratio);
+        Main.out.println(inputColumn + "-> Size In Bytes: " + size + " Size In Ratio: " + ratio);
       }
     } else {
       for (String column : columnSizes.keySet()) {

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/ColumnSizeCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/ColumnSizeCommand.java
@@ -39,8 +39,9 @@ public class ColumnSizeCommand extends ArgsOnlyCommand {
     "<input>",
     "where <input> is the parquet file to calculate the column size" +
     "     [<column> ...] are the columns in the case sensitive dot format" +
-    "     to be calculated, for example a.b.c. If no columns are set, all the" +
-    "     columns will be printed out"
+    "     to be calculated, for example a.b.c. If an input column is intermediate" +
+    "     column, all the child columns will be printed out. If no columns are" +
+    "     set, all the columns will be printed out."
   };
 
   /**

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/ColumnSizeCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/ColumnSizeCommand.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.tools.command;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.tools.Main;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ColumnSizeCommand extends ArgsOnlyCommand {
+
+  public static final String[] USAGE = new String[] {
+    "<input>",
+    "where <input> is the parquet file to calculate teh column size" +
+    "     [<column> ...] are the columns in the case sensitive dot format" +
+    "     to be calculated, for example a.b.c. If no columns are input, all the" +
+    "     columns will be printed out"
+  };
+
+  /**
+   * Biggest number of columns we can calculate.
+   */
+  private static final int MAX_COL_NUM = 100;
+
+  public ColumnSizeCommand() {
+    super(1, 1 + MAX_COL_NUM);
+  }
+
+  @Override
+  public String[] getUsageDescription() {
+    return USAGE;
+  }
+
+  @Override
+  public String getCommandDescription() {
+    return "Print out the size in bytes and percentage of column(s) in the input Parquet file";
+  }
+
+  @Override
+  public void execute(CommandLine options) throws Exception {
+    super.execute(options);
+    List<String> args = options.getArgList();
+    Path inputFile = new Path(args.get(0));
+
+    Map<String, Long> columnSizes = getColumnSizeInBytes(inputFile);
+    Map<String, Float> columnPercentage = getColumnPercentage(columnSizes);
+
+    if (args.size() > 1) {
+      for (String inputColumn : args.subList(1, args.size())) {
+        long size = 0;
+        float percentage = 0;
+        for (String column : columnSizes.keySet()) {
+          if (column.startsWith(inputColumn)) {
+            size += columnSizes.get(column);
+            percentage += columnPercentage.get(column);
+          }
+        }
+        Main.out.println(inputColumn + "->" + " Size In Bytes: " + size + " Size In Percentage: " + percentage);
+      }
+    } else {
+      for (String column : columnSizes.keySet()) {
+        Main.out.println(column + "->" + " Size In Bytes: " + columnSizes.get(column)
+          + " Size In Percentage: " + columnPercentage.get(column));
+      }
+    }
+  }
+
+  // Make it public to allow some automation tools to call it
+  public Map<String, Long> getColumnSizeInBytes(Path inputFile) throws IOException {
+    Map<String, Long> colSizes = new HashMap<>();
+    ParquetMetadata pmd = ParquetFileReader.readFooter(new Configuration(), inputFile, ParquetMetadataConverter.NO_FILTER);
+
+    for (BlockMetaData block : pmd.getBlocks()) {
+      for (ColumnChunkMetaData column : block.getColumns()) {
+        String colName = column.getPath().toDotString();
+        colSizes.put(colName, column.getTotalSize() + colSizes.getOrDefault(colName, 0L));
+      }
+    }
+
+    return colSizes;
+  }
+
+  // Make it public to allow some automation tools to call it
+  public Map<String, Float> getColumnPercentage(Map<String, Long> colSizes) {
+    long totalSize = colSizes.values().stream().reduce(0L, Long::sum);
+    Map<String, Float> colPercentage = new HashMap<>();
+
+    for (Map.Entry<String, Long> entry : colSizes.entrySet()) {
+      colPercentage.put(entry.getKey(), ((float) entry.getValue()) / ((float) totalSize));
+    }
+
+    return colPercentage;
+  }
+}
+

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/Registry.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/Registry.java
@@ -36,6 +36,7 @@ public final class Registry {
     registry.put("size", SizeCommand.class);
     registry.put("column-index", ColumnIndexCommand.class);
     registry.put("prune", PruneColumnsCommand.class);
+    registry.put("column-size", ColumnSizeCommand.class);
   }
 
   public static Map<String,Command> allCommands() {

--- a/parquet-tools/src/test/java/org/apache/parquet/tools/command/TestColumnSizeCommand.java
+++ b/parquet-tools/src/test/java/org/apache/parquet/tools/command/TestColumnSizeCommand.java
@@ -27,10 +27,12 @@ import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.example.GroupWriteSupport;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Map;
 import java.util.Random;
 
@@ -45,6 +47,9 @@ public class TestColumnSizeCommand {
   private final int numRecord = 10000;
   private ColumnSizeCommand command = new ColumnSizeCommand();
   private Configuration conf = new Configuration();
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
 
   @Test
   public void testColumnSize() throws Exception {
@@ -63,7 +68,7 @@ public class TestColumnSizeCommand {
 
     conf.set(GroupWriteSupport.PARQUET_EXAMPLE_SCHEMA, schema.toString());
 
-    String file = createTempFile(prefix);
+    String file = parquetFile().getAbsolutePath();
     ExampleParquetWriter.Builder builder = ExampleParquetWriter.builder(new Path(file)).withConf(conf);
     Random rnd = new Random();
     try (ParquetWriter writer = builder.build()) {
@@ -78,11 +83,12 @@ public class TestColumnSizeCommand {
     return file;
   }
 
-  private static String createTempFile(String prefix) {
-    try {
-      return Files.createTempDirectory(prefix).toAbsolutePath().toString() + "/test.parquet";
-    } catch (IOException e) {
-      throw new AssertionError("Unable to create temporary file", e);
-    }
+  private File getTempFolder() {
+    return this.tempFolder.getRoot();
+  }
+
+  private File parquetFile() {
+    File tmpDir = getTempFolder();
+    return new File(tmpDir, getClass().getSimpleName() + ".parquet");
   }
 }

--- a/parquet-tools/src/test/java/org/apache/parquet/tools/command/TestColumnSizeCommand.java
+++ b/parquet-tools/src/test/java/org/apache/parquet/tools/command/TestColumnSizeCommand.java
@@ -47,13 +47,14 @@ public class TestColumnSizeCommand {
   private final int numRecord = 10000;
   private ColumnSizeCommand command = new ColumnSizeCommand();
   private Configuration conf = new Configuration();
+  private Random rnd = new Random();
 
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();
 
   @Test
   public void testColumnSize() throws Exception {
-    String inputFile = createParquetFile("input");
+    String inputFile = createParquetFile();
     Map<String, Long> columnSizeInBytes = command.getColumnSizeInBytes(new Path(inputFile));
     assertEquals(columnSizeInBytes.size(), 2);
     assertTrue(columnSizeInBytes.get("DocId") > columnSizeInBytes.get("Num"));
@@ -61,14 +62,14 @@ public class TestColumnSizeCommand {
     assertTrue(columnRatio.get("DocId") > columnRatio.get("Num"));
   }
 
-  private String createParquetFile(String prefix) throws IOException {
+  private String createParquetFile() throws IOException {
     MessageType schema = new MessageType("schema",
       new PrimitiveType(REQUIRED, INT64, "DocId"),
       new PrimitiveType(REQUIRED, INT32, "Num"));
 
     conf.set(GroupWriteSupport.PARQUET_EXAMPLE_SCHEMA, schema.toString());
 
-    String file = parquetFile().getAbsolutePath();
+    String file = randomParquetFile().getAbsolutePath();
     ExampleParquetWriter.Builder builder = ExampleParquetWriter.builder(new Path(file)).withConf(conf);
     Random rnd = new Random();
     try (ParquetWriter writer = builder.build()) {
@@ -87,8 +88,8 @@ public class TestColumnSizeCommand {
     return this.tempFolder.getRoot();
   }
 
-  private File parquetFile() {
+  private File randomParquetFile() {
     File tmpDir = getTempFolder();
-    return new File(tmpDir, getClass().getSimpleName() + ".parquet");
+    return new File(tmpDir, getClass().getSimpleName() + rnd.nextLong() + ".parquet");
   }
 }

--- a/parquet-tools/src/test/java/org/apache/parquet/tools/command/TestColumnSizeCommand.java
+++ b/parquet-tools/src/test/java/org/apache/parquet/tools/command/TestColumnSizeCommand.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.tools.command;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.simple.SimpleGroup;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Random;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestColumnSizeCommand {
+
+  private final int numRecord = 10000;
+  private ColumnSizeCommand command = new ColumnSizeCommand();
+  private Configuration conf = new Configuration();
+
+  @Test
+  public void testColumnSize() throws Exception {
+    String inputFile = createParquetFile("input");
+    Map<String, Long> columnSizeInBytes = command.getColumnSizeInBytes(new Path(inputFile));
+    assertEquals(columnSizeInBytes.size(), 2);
+    assertTrue(columnSizeInBytes.get("DocId") > columnSizeInBytes.get("Num"));
+    Map<String, Float> columnPercentage = command.getColumnPercentage(columnSizeInBytes);
+    assertTrue(columnPercentage.get("DocId") > columnPercentage.get("Num"));
+  }
+
+  private String createParquetFile(String prefix) throws IOException {
+    MessageType schema = new MessageType("schema",
+      new PrimitiveType(REQUIRED, INT64, "DocId"),
+      new PrimitiveType(REQUIRED, INT32, "Num"));
+
+    conf.set(GroupWriteSupport.PARQUET_EXAMPLE_SCHEMA, schema.toString());
+
+    String file = createTempFile(prefix);
+    ExampleParquetWriter.Builder builder = ExampleParquetWriter.builder(new Path(file)).withConf(conf);
+    Random rnd = new Random();
+    try (ParquetWriter writer = builder.build()) {
+      for (int i = 0; i < numRecord; i++) {
+        SimpleGroup g = new SimpleGroup(schema);
+        g.add("DocId", rnd.nextLong());
+        g.add("Num", rnd.nextInt());
+        writer.write(g);
+      }
+    }
+
+    return file;
+  }
+
+  private static String createTempFile(String prefix) {
+    try {
+      return Files.createTempDirectory(prefix).toAbsolutePath().toString() + "/test.parquet";
+    } catch (IOException e) {
+      throw new AssertionError("Unable to create temporary file", e);
+    }
+  }
+}

--- a/parquet-tools/src/test/java/org/apache/parquet/tools/command/TestColumnSizeCommand.java
+++ b/parquet-tools/src/test/java/org/apache/parquet/tools/command/TestColumnSizeCommand.java
@@ -52,8 +52,8 @@ public class TestColumnSizeCommand {
     Map<String, Long> columnSizeInBytes = command.getColumnSizeInBytes(new Path(inputFile));
     assertEquals(columnSizeInBytes.size(), 2);
     assertTrue(columnSizeInBytes.get("DocId") > columnSizeInBytes.get("Num"));
-    Map<String, Float> columnPercentage = command.getColumnPercentage(columnSizeInBytes);
-    assertTrue(columnPercentage.get("DocId") > columnPercentage.get("Num"));
+    Map<String, Float> columnRatio = command.getColumnRatio(columnSizeInBytes);
+    assertTrue(columnRatio.get("DocId") > columnRatio.get("Num"));
   }
 
   private String createParquetFile(String prefix) throws IOException {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
