### PR TITLE
PARQUET-1850: Fix dictionaryPageOffset flag setting in toParquetMetadata method

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -480,6 +480,10 @@ public class ParquetMetadataConverter {
           columnMetaData.getTotalSize(),
           columnMetaData.getFirstDataPageOffset());
       columnChunk.meta_data.dictionary_page_offset = columnMetaData.getDictionaryPageOffset();
+      if (columnMetaData.getEncodingStats() != null && columnMetaData
+        .getEncodingStats().hasDictionaryPages()) {
+        columnChunk.meta_data.setDictionary_page_offsetIsSet(true);
+      }
       columnChunk.meta_data.setBloom_filter_offset(columnMetaData.getBloomFilterOffset());
       if (!columnMetaData.getStatistics().isEmpty()) {
         columnChunk.meta_data.setStatistics(toParquetStatistics(columnMetaData.getStatistics(), this.statisticsTruncateLength));

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -479,10 +479,8 @@ public class ParquetMetadataConverter {
           columnMetaData.getTotalUncompressedSize(),
           columnMetaData.getTotalSize(),
           columnMetaData.getFirstDataPageOffset());
-      columnChunk.meta_data.dictionary_page_offset = columnMetaData.getDictionaryPageOffset();
-      if (columnMetaData.getEncodingStats() != null && columnMetaData
-        .getEncodingStats().hasDictionaryPages()) {
-        columnChunk.meta_data.setDictionary_page_offsetIsSet(true);
+      if (columnMetaData.getEncodingStats() != null && columnMetaData.getEncodingStats().hasDictionaryPages()) {
+        columnChunk.meta_data.setDictionary_page_offset(columnMetaData.getDictionaryPageOffset());
       }
       columnChunk.meta_data.setBloom_filter_offset(columnMetaData.getBloomFilterOffset());
       if (!columnMetaData.getStatistics().isEmpty()) {


### PR DESCRIPTION
### Issue

toParquetMetadata method converts org.apache.parquet.hadoop.metadata.ParquetMetadata to org.apache.parquet.format.FileMetaData but this does not set the dictionary page offset bit in FileMetaData.

When a FileMetaData object is serialized while writing to the footer and then deserialized, the dictionary offset is lost as the dictionary page offset bit was never set.

### Fix

The flag is set to true when a dictionary page is used for encoding.

### Tests

A ParquetMetadata object is created with PLAIN_DICTIONARY encoding and dictionaryPageOffset is set to a non zero value. 

The ParquetMetadata object is converted to FileMetaData using toParquetMetadata method.
The FileMetaData object is then serialized and deserialized to FileMetaData and converted back to ParquetMetadata using fromParquetMetadata method. 

The new ParquetMetadata should have the same dictionaryPageOffset as the original ParquetMetadata object.