### PR TITLE
PARQUET-1853: Minimize shaded fastutil

### DIFF
--- a/parquet-avro/pom.xml
+++ b/parquet-avro/pom.xml
@@ -170,6 +170,7 @@
         <executions>
           <execution>
             <configuration combine.self="override">
+              <minimizeJar>true</minimizeJar>
               <artifactSet>
                 <includes>
                   <include>it.unimi.dsi:fastutil</include>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <thrift-maven-plugin.version>0.10.0</thrift-maven-plugin.version>
     <thrift.version>0.12.0</thrift.version>
     <format.thrift.version>0.12.0</format.thrift.version>
-    <fastutil.version>8.3.2</fastutil.version>
+    <fastutil.version>8.2.3</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>
     <slf4j.version>1.7.22</slf4j.version>
     <avro.version>1.9.2</avro.version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <thrift-maven-plugin.version>0.10.0</thrift-maven-plugin.version>
     <thrift.version>0.12.0</thrift.version>
     <format.thrift.version>0.12.0</format.thrift.version>
-    <fastutil.version>8.2.3</fastutil.version>
+    <fastutil.version>8.3.2</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>
     <slf4j.version>1.7.22</slf4j.version>
     <avro.version>1.9.2</avro.version>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

This makes the binary 70MB bigger (uncompressed).

https://mvnrepository.com/artifact/org.apache.parquet/parquet-avro/1.11.0 (18.6MB)
https://mvnrepository.com/artifact/org.apache.parquet/parquet-avro/1.10.1 (123KB)

@gszadovszky Maybe we can unshade fastutil? For me, I didn't have any issues with it. Would like to get your opinion on this. https://issues.apache.org/jira/browse/PARQUET-1529

It doesn't come up with the versions.lock in Iceberg: https://github.com/apache/incubator-iceberg/blob/master/versions.lock

Master:
```
root@4596b23fcb36:/app# find . | grep "1.12.0-SNAPSHOT.jar" | xargs du -h | sort -h
8.0K	./parquet-hive/parquet-hive-binding/parquet-hive-0.10-binding/target/parquet-hive-0.10-binding-1.12.0-SNAPSHOT.jar
8.0K	./parquet-hive/parquet-hive-binding/parquet-hive-0.12-binding/target/parquet-hive-0.12-binding-1.12.0-SNAPSHOT.jar
8.0K	./parquet-hive/parquet-hive-binding/parquet-hive-binding-factory/target/parquet-hive-binding-factory-1.12.0-SNAPSHOT.jar
8.0K	./parquet-hive/parquet-hive-binding/parquet-hive-binding-interface/target/parquet-hive-binding-interface-1.12.0-SNAPSHOT.jar
20K	./parquet-scrooge/target/parquet-scrooge_2.12-1.12.0-SNAPSHOT.jar
24K	./parquet-cascading/target/parquet-cascading-1.12.0-SNAPSHOT.jar
24K	./parquet-cascading3/target/parquet-cascading3-1.12.0-SNAPSHOT.jar
24K	./parquet-hive/parquet-hive-binding/parquet-hive-binding-bundle/target/archive-tmp/parquet-hive-binding-bundle-1.12.0-SNAPSHOT.jar
24K	./parquet-hive/parquet-hive-binding/parquet-hive-binding-bundle/target/parquet-hive-binding-bundle-1.12.0-SNAPSHOT.jar
28K	./parquet-generator/target/parquet-generator-1.12.0-SNAPSHOT.jar
32K	./parquet-scala/target/parquet-scala_2.12-1.12.0-SNAPSHOT.jar
36K	./parquet-arrow/target/parquet-arrow-1.12.0-SNAPSHOT.jar
60K	./parquet-protobuf/target/original-parquet-protobuf-1.12.0-SNAPSHOT.jar
60K	./parquet-protobuf/target/parquet-protobuf-1.12.0-SNAPSHOT.jar
92K	./parquet-pig/target/original-parquet-pig-1.12.0-SNAPSHOT.jar
92K	./parquet-pig/target/parquet-pig-1.12.0-SNAPSHOT.jar
132K	./parquet-avro/target/original-parquet-avro-1.12.0-SNAPSHOT.jar
132K	./parquet-common/target/parquet-common-1.12.0-SNAPSHOT.jar
132K	./parquet-hive/parquet-hive-storage-handler/target/parquet-hive-storage-handler-1.12.0-SNAPSHOT.jar
132K	./parquet-tools/target/original-parquet-tools-1.12.0-SNAPSHOT.jar
196K	./parquet-cli/target/parquet-cli-1.12.0-SNAPSHOT.jar
208K	./parquet-thrift/target/original-parquet-thrift-1.12.0-SNAPSHOT.jar
208K	./parquet-thrift/target/parquet-thrift-1.12.0-SNAPSHOT.jar
388K	./parquet-hadoop/target/original-parquet-hadoop-1.12.0-SNAPSHOT.jar
444K	./parquet-hadoop/target/parquet-hadoop-1.12.0-SNAPSHOT.jar
452K	./parquet-benchmarks/target/parquet-benchmarks-1.12.0-SNAPSHOT.jar
688K	./parquet-format-structures/target/original-parquet-format-structures-1.12.0-SNAPSHOT.jar
688K	./parquet-format-structures/target/parquet-format-structures-1.12.0-SNAPSHOT.jar
708K	./parquet-column/target/original-parquet-column-1.12.0-SNAPSHOT.jar
836K	./parquet-encoding/target/parquet-encoding-1.12.0-SNAPSHOT.jar
1.7M	./parquet-column/target/parquet-column-1.12.0-SNAPSHOT.jar
1.8M	./parquet-jackson/target/original-parquet-jackson-1.12.0-SNAPSHOT.jar
2.7M	./parquet-jackson/target/parquet-jackson-1.12.0-SNAPSHOT.jar
5.4M	./parquet-pig-bundle/target/original-parquet-pig-bundle-1.12.0-SNAPSHOT.jar
5.4M	./parquet-pig-bundle/target/parquet-pig-bundle-1.12.0-SNAPSHOT.jar
5.6M	./parquet-hadoop-bundle/target/parquet-hadoop-bundle-1.12.0-SNAPSHOT.jar
5.9M	./parquet-hive-bundle/target/parquet-hive-bundle-1.12.0-SNAPSHOT.jar
6.0M	./parquet-hadoop-bundle/target/original-parquet-hadoop-bundle-1.12.0-SNAPSHOT.jar
6.0M	./parquet-hive-bundle/target/original-parquet-hive-bundle-1.12.0-SNAPSHOT.jar
20M	./parquet-avro/target/parquet-avro-1.12.0-SNAPSHOT.jar
29M	./parquet-tools/target/parquet-tools-1.12.0-SNAPSHOT.jar
```

This branch:
```
root@4596b23fcb36:/app# find . | grep "1.12.0-SNAPSHOT.jar" | xargs du -h | sort -h
4.0K	./parquet-hive/parquet-hive-binding/parquet-hive-binding-bundle/target/archive-tmp/parquet-hive-binding-bundle-1.12.0-SNAPSHOT.jar
8.0K	./parquet-hadoop-bundle/target/original-parquet-hadoop-bundle-1.12.0-SNAPSHOT.jar
8.0K	./parquet-hive-bundle/target/original-parquet-hive-bundle-1.12.0-SNAPSHOT.jar
8.0K	./parquet-hive/parquet-hive-binding/parquet-hive-0.10-binding/target/parquet-hive-0.10-binding-1.12.0-SNAPSHOT.jar
8.0K	./parquet-hive/parquet-hive-binding/parquet-hive-0.12-binding/target/parquet-hive-0.12-binding-1.12.0-SNAPSHOT.jar
8.0K	./parquet-hive/parquet-hive-binding/parquet-hive-binding-factory/target/parquet-hive-binding-factory-1.12.0-SNAPSHOT.jar
8.0K	./parquet-hive/parquet-hive-binding/parquet-hive-binding-interface/target/parquet-hive-binding-interface-1.12.0-SNAPSHOT.jar
8.0K	./parquet-jackson/target/original-parquet-jackson-1.12.0-SNAPSHOT.jar
8.0K	./parquet-pig-bundle/target/original-parquet-pig-bundle-1.12.0-SNAPSHOT.jar
20K	./parquet-scrooge/target/parquet-scrooge_2.12-1.12.0-SNAPSHOT.jar
24K	./parquet-cascading/target/parquet-cascading-1.12.0-SNAPSHOT.jar
24K	./parquet-cascading3/target/parquet-cascading3-1.12.0-SNAPSHOT.jar
24K	./parquet-hive/parquet-hive-binding/parquet-hive-binding-bundle/target/parquet-hive-binding-bundle-1.12.0-SNAPSHOT.jar
28K	./parquet-generator/target/parquet-generator-1.12.0-SNAPSHOT.jar
32K	./parquet-scala/target/parquet-scala_2.12-1.12.0-SNAPSHOT.jar
36K	./parquet-arrow/target/parquet-arrow-1.12.0-SNAPSHOT.jar
56K	./parquet-protobuf/target/original-parquet-protobuf-1.12.0-SNAPSHOT.jar
60K	./parquet-protobuf/target/parquet-protobuf-1.12.0-SNAPSHOT.jar
92K	./parquet-pig/target/parquet-pig-1.12.0-SNAPSHOT.jar
132K	./parquet-avro/target/original-parquet-avro-1.12.0-SNAPSHOT.jar
132K	./parquet-common/target/parquet-common-1.12.0-SNAPSHOT.jar
132K	./parquet-hive/parquet-hive-storage-handler/target/parquet-hive-storage-handler-1.12.0-SNAPSHOT.jar
132K	./parquet-pig/target/original-parquet-pig-1.12.0-SNAPSHOT.jar
132K	./parquet-tools/target/original-parquet-tools-1.12.0-SNAPSHOT.jar
196K	./parquet-cli/target/parquet-cli-1.12.0-SNAPSHOT.jar
208K	./parquet-thrift/target/parquet-thrift-1.12.0-SNAPSHOT.jar
260K	./parquet-thrift/target/original-parquet-thrift-1.12.0-SNAPSHOT.jar
388K	./parquet-hadoop/target/original-parquet-hadoop-1.12.0-SNAPSHOT.jar
444K	./parquet-hadoop/target/parquet-hadoop-1.12.0-SNAPSHOT.jar
452K	./parquet-benchmarks/target/parquet-benchmarks-1.12.0-SNAPSHOT.jar
668K	./parquet-avro/target/parquet-avro-1.12.0-SNAPSHOT.jar
688K	./parquet-format-structures/target/original-parquet-format-structures-1.12.0-SNAPSHOT.jar
688K	./parquet-format-structures/target/parquet-format-structures-1.12.0-SNAPSHOT.jar
708K	./parquet-column/target/original-parquet-column-1.12.0-SNAPSHOT.jar
836K	./parquet-encoding/target/parquet-encoding-1.12.0-SNAPSHOT.jar
1.8M	./parquet-jackson/target/parquet-jackson-1.12.0-SNAPSHOT.jar
2.4M	./parquet-column/target/parquet-column-1.12.0-SNAPSHOT.jar
5.4M	./parquet-pig-bundle/target/parquet-pig-bundle-1.12.0-SNAPSHOT.jar
6.0M	./parquet-hadoop-bundle/target/parquet-hadoop-bundle-1.12.0-SNAPSHOT.jar
6.0M	./parquet-hive-bundle/target/parquet-hive-bundle-1.12.0-SNAPSHOT.jar
30M	./parquet-tools/target/parquet-tools-1.12.0-SNAPSHOT.jar
```

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1853
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
