### PR TITLE
Parquet-1860: Add missing Builder Class to ProtoParquetWriter Class

### DIFF
--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.OutputFile;
 
 import java.io.IOException;
 

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
@@ -80,5 +80,42 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
     this(file, protoMessage, CompressionCodecName.UNCOMPRESSED,
             DEFAULT_BLOCK_SIZE, DEFAULT_PAGE_SIZE);
   }
+  
+  public static <T> Builder<T> builder(Path file) {
+	    return new Builder<T>(file);
+	}
 
+	public static <T> Builder<T> builder(OutputFile file) {
+	    return new Builder<T>(file);
+	}
+	
+	private static <T extends MessageOrBuilder> WriteSupport<T> writeSupport(Class<? extends Message> protoMessage) {
+		return new ProtoWriteSupport<T>(protoMessage);
+	}
+	  
+	public static class Builder<T> extends ParquetWriter.Builder<T, Builder<T>> {
+		  
+		Class<? extends Message> protoMessage = null;
+
+		private Builder(Path file) {
+			super(file);
+		}
+
+		private Builder(OutputFile file) {
+		    super(file);
+		}
+
+		protected Builder<T> self() {
+		    return this;
+		}
+		
+		public Builder<T> withMessage(Class<? extends Message> protoMessage){
+			this.protoMessage = protoMessage;
+			return this;
+		}
+
+		protected WriteSupport<T> getWriteSupport(Configuration conf) {
+		    return (WriteSupport<T>) ProtoParquetWriter.writeSupport(protoMessage);
+		}    
+	}
 }

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
@@ -25,6 +25,7 @@ import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.OutputFile;
+import org.apache.hadoop.conf.Configuration;
 
 import java.io.IOException;
 


### PR DESCRIPTION
Added Builder support to build ProtoParquetWriter instances through Builder class

ProtoParquetWriter only has basic constructors, that which call deprecated super constructors. We cannot set many other options (Write mode, encoding etc) as well. 

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: No addition of feature. Simply provided an API to more effectively use the class

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
