### PR TITLE
PARQUET-1868: Fix bloom filter toggle in reader options builder

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
@@ -233,7 +233,7 @@ public class ParquetReadOptions {
     }
 
     public Builder useBloomFilter(boolean useBloomFilter) {
-      this.useDictionaryFilter = useBloomFilter;
+      this.useBloomFilter = useBloomFilter;
       return this;
     }
 


### PR DESCRIPTION
Fixes [PARQUET-1868](https://issues.apache.org/jira/browse/PARQUET-1868)