### PR TITLE
PARQUET-1887: Allow writing after an exception

### DIFF
--- a/parquet-avro/src/test/resources/persons.json
+++ b/parquet-avro/src/test/resources/persons.json
@@ -1,0 +1,17 @@
+{
+  "type": "record",
+  "name": "person",
+  "fields": [
+    {
+      "name": "address",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -390,7 +390,9 @@ public class MessageColumnIO extends GroupColumnIO {
 
     @Override
     public void startGroup() {
-      if (DEBUG) log("startGroup()");
+      if (DEBUG) {
+        log("startGroup()");
+      }
       GroupColumnIO group = (GroupColumnIO) currentColumnIO;
 
       // current group is not null, need to flush all the nulls that were cached before
@@ -403,7 +405,9 @@ public class MessageColumnIO extends GroupColumnIO {
 
       int fieldsCount = ((GroupColumnIO) currentColumnIO).getChildrenCount();
       fieldsWritten[currentLevel].reset(fieldsCount);
-      if (DEBUG) printState();
+      if (DEBUG) {
+        printState();
+      }
     }
 
     private boolean hasNullCache(GroupColumnIO group) {


### PR DESCRIPTION
After having an exception when writing, the subsequent writes would also fail. This was because the group wasn't closed properly.

And some minor refactoring for readability, that I've did along the way during the debugging.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1887
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
