### PR TITLE
PARQUET-1914: Allow ProtoParquetReader To Support InputFile

### DIFF
--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetReader.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetReader.java
@@ -20,21 +20,26 @@ package org.apache.parquet.proto;
 
 import java.io.IOException;
 
-import com.google.protobuf.MessageOrBuilder;
-
 import org.apache.hadoop.fs.Path;
-
 import org.apache.parquet.filter.UnboundRecordFilter;
 import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.api.ReadSupport;
+import org.apache.parquet.io.InputFile;
+
+import com.google.protobuf.MessageOrBuilder;
 
 /**
  * Read Protobuf records from a Parquet file.
  */
-public class ProtoParquetReader<T extends MessageOrBuilder> extends ParquetReader<T> {
+public class ProtoParquetReader<T extends MessageOrBuilder>
+    extends ParquetReader<T> {
 
-  @SuppressWarnings("unchecked")
-  public static <T> Builder<T> builder(Path file) {
-    return ParquetReader.builder(new ProtoReadSupport(), file);
+  public static <T> ParquetReader.Builder<T> builder(Path file) {
+    return new ProtoParquetReader.Builder<T>(file);
+  }
+
+  public static <T> ParquetReader.Builder<T> builder(InputFile file) {
+    return new ProtoParquetReader.Builder<T>(file);
   }
 
   /**
@@ -56,7 +61,25 @@ public class ProtoParquetReader<T extends MessageOrBuilder> extends ParquetReade
    */
   @Deprecated
   @SuppressWarnings("unchecked")
-  public ProtoParquetReader(Path file, UnboundRecordFilter recordFilter) throws IOException {
+  public ProtoParquetReader(Path file, UnboundRecordFilter recordFilter)
+      throws IOException {
     super(file, new ProtoReadSupport(), recordFilter);
+  }
+
+  private static class Builder<T> extends ParquetReader.Builder<T> {
+
+    protected Builder(InputFile file) {
+      super(file);
+    }
+
+    protected Builder(Path path) {
+      super(path);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    protected ReadSupport<T> getReadSupport() {
+      return new ProtoReadSupport();
+    }
   }
 }

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetReader.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetReader.java
@@ -61,8 +61,7 @@ public class ProtoParquetReader<T extends MessageOrBuilder>
    */
   @Deprecated
   @SuppressWarnings("unchecked")
-  public ProtoParquetReader(Path file, UnboundRecordFilter recordFilter)
-      throws IOException {
+  public ProtoParquetReader(Path file, UnboundRecordFilter recordFilter) throws IOException {
     super(file, new ProtoReadSupport(), recordFilter);
   }
 

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/TestUtils.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/TestUtils.java
@@ -22,8 +22,12 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
 import com.twitter.elephantbird.util.Protobufs;
+
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.apache.parquet.io.InputFile;
 
 import java.io.File;
 import java.io.IOException;
@@ -170,7 +174,8 @@ public class TestUtils {
    * @return List of protobuf messages for the given type.
    */
   public static <T extends MessageOrBuilder> List<T> readMessages(Path file, Class<T> messageClass) throws IOException {
-    ParquetReader.Builder readerBuilder = ProtoParquetReader.builder(file);
+    InputFile inputFile = HadoopInputFile.fromPath(file, new Configuration());
+    ParquetReader.Builder readerBuilder = ProtoParquetReader.builder(inputFile);
     if (messageClass != null) {
       readerBuilder.set(ProtoReadSupport.PB_CLASS, messageClass.getName()).build();
     }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [PARQUET-1914](https://issues.apache.org/jira/browse/PARQUET-1914) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
