### PR TITLE
PARQUET-1917: Don't write values for oneOf fields that aren't set

### DIFF
--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -337,6 +337,12 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
         List<FieldDescriptor> fieldDescriptors = messageDescriptor.getFields();
         for (FieldDescriptor fieldDescriptor : fieldDescriptors) {
           FieldDescriptor.Type type = fieldDescriptor.getType();
+
+          //For a field in a oneOf that isn't set don't write anything
+          if (fieldDescriptor.getContainingOneof() != null && !pb.hasField(fieldDescriptor)) {
+            continue;
+          }
+
           if (!fieldDescriptor.isRepeated() && FieldDescriptor.Type.MESSAGE.equals(type) && !pb.hasField(fieldDescriptor)) {
             continue;
           }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
@@ -22,6 +22,7 @@ import com.google.protobuf.Message;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
+import static org.junit.Assert.*;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.apache.parquet.io.api.Binary;
@@ -952,19 +953,29 @@ public class ProtoWriteSupportTest {
     TestProto3.OneOfTestMessage.Builder msgBuilder2 = TestProto3.OneOfTestMessage.newBuilder();
     TestProto3.OneOfTestMessage theMessageNothingSet = msgBuilder2.build();
 
-    //Write them out
-    Path tmpFilePath = TestUtils.writeMessages(theMessage, theMessageNothingSet);
+    TestProto3.OneOfTestMessage.Builder msgBuilder3 = TestProto3.OneOfTestMessage.newBuilder();
+    msgBuilder3.setFirst(42);
+    TestProto3.OneOfTestMessage theMessageFirstSet = msgBuilder3.build();
 
-    //Read it back!
+    //Write them out
+    Path tmpFilePath = TestUtils.writeMessages(theMessage, theMessageNothingSet, theMessageFirstSet);
+
+    //Read them back!
     List<TestProto3.OneOfTestMessage> gotBack = TestUtils.readMessages(tmpFilePath, TestProto3.OneOfTestMessage.class);
 
     //First message
     TestProto3.OneOfTestMessage gotBackFirst = gotBack.get(0);
-    assert gotBackFirst.getSecond() == 99;
-    assert gotBackFirst.getTheOneofCase() == TestProto3.OneOfTestMessage.TheOneofCase.SECOND;
+    assertEquals(gotBackFirst.getSecond(), 99);
+    assertEquals(gotBackFirst.getTheOneofCase(), TestProto3.OneOfTestMessage.TheOneofCase.SECOND);
 
     //Second message with nothing set
     TestProto3.OneOfTestMessage gotBackSecond = gotBack.get(1);
-    assert gotBackSecond.getTheOneofCase() == TestProto3.OneOfTestMessage.TheOneofCase.THEONEOF_NOT_SET;
+    assertEquals(gotBackSecond.getTheOneofCase(), TestProto3.OneOfTestMessage.TheOneofCase.THEONEOF_NOT_SET);
+
+    //Third message with opposite field set
+    TestProto3.OneOfTestMessage gotBackThird = gotBack.get(2);
+    assertEquals(gotBackThird.getFirst(), 42);
+    assertEquals(gotBackThird.getTheOneofCase(), TestProto3.OneOfTestMessage.TheOneofCase.FIRST);
+
   }
 }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
@@ -913,4 +913,24 @@ public class ProtoWriteSupportTest {
 
     instance.write(msg.build());
   }
+
+  @Test
+  public void testMessageOneOf() {
+    RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
+    ProtoWriteSupport<TestProto3.OneOfTestMessage> spyWriter = createReadConsumerInstance(TestProto3.OneOfTestMessage.class, readConsumerMock);
+    final int theInt = 99;
+
+    TestProto3.OneOfTestMessage.Builder msg = TestProto3.OneOfTestMessage.newBuilder();
+    msg.setSecond(theInt);
+    spyWriter.write(msg.build());
+
+    InOrder inOrder = Mockito.inOrder(readConsumerMock);
+
+    inOrder.verify(readConsumerMock).startMessage();
+    inOrder.verify(readConsumerMock).startField("second", 1);
+    inOrder.verify(readConsumerMock).addInteger(theInt);
+    inOrder.verify(readConsumerMock).endField("second", 1);
+    inOrder.verify(readConsumerMock).endMessage();
+    Mockito.verifyNoMoreInteractions(readConsumerMock);
+  }
 }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
@@ -957,10 +957,8 @@ public class ProtoWriteSupportTest {
     msgBuilder3.setFirst(42);
     TestProto3.OneOfTestMessage theMessageFirstSet = msgBuilder3.build();
 
-    //Write them out
+    //Write them out and read them back
     Path tmpFilePath = TestUtils.writeMessages(theMessage, theMessageNothingSet, theMessageFirstSet);
-
-    //Read them back!
     List<TestProto3.OneOfTestMessage> gotBack = TestUtils.readMessages(tmpFilePath, TestProto3.OneOfTestMessage.class);
 
     //First message

--- a/parquet-protobuf/src/test/resources/TestProto3.proto
+++ b/parquet-protobuf/src/test/resources/TestProto3.proto
@@ -107,7 +107,7 @@ message IOFormatMessage {
 
 //end protocol buffers for ProtoInputOutputFormatTest
 
-//being protocol buffers for ProtoWriteSupport
+//begin protocol buffers for ProtoWriteSupport
 message OneOfTestMessage {
   oneof the_oneof {
     int32 first  = 1;
@@ -115,7 +115,7 @@ message OneOfTestMessage {
   }
 }
 
-//being protocol buffers for ProtoWriteSupport
+//end protocol buffers for ProtoWriteSupport
 
 message InnerMessage {
     string one = 1;

--- a/parquet-protobuf/src/test/resources/TestProto3.proto
+++ b/parquet-protobuf/src/test/resources/TestProto3.proto
@@ -107,6 +107,15 @@ message IOFormatMessage {
 
 //end protocol buffers for ProtoInputOutputFormatTest
 
+//being protocol buffers for ProtoWriteSupport
+message OneOfTestMessage {
+  oneof the_oneof {
+    int32 first  = 1;
+    int32 second = 2;
+  }
+}
+
+//being protocol buffers for ProtoWriteSupport
 
 message InnerMessage {
     string one = 1;

--- a/parquet-protobuf/src/test/resources/TestProtobuf.proto
+++ b/parquet-protobuf/src/test/resources/TestProtobuf.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/parquet-protobuf/src/test/resources/TestProtobuf.proto
+++ b/parquet-protobuf/src/test/resources/TestProtobuf.proto
@@ -1,4 +1,3 @@
-syntax = "proto2";
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
https://issues.apache.org/jira/browse/PARQUET-1917

### Jira

- [X] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET-1917/) issues and references them in the PR title. 

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
