### PR TITLE
PARQUET-1920: Fix Parquet writer's memory check interval calculation

### DIFF
--- a/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
@@ -217,10 +217,10 @@ abstract public class BytesInput {
   public byte[] toByteArray() throws IOException {
     long size = size();
     if (size > Integer.MAX_VALUE) {
-      throw new IOException("Page size, " + size + ", is larger than allowed " + Integer.MAX_VALUE +"." +
+      throw new IOException("Page size, " + size + ", is larger than allowed " + Integer.MAX_VALUE + "." +
         " Usually caused by a Parquet writer writing too big column chunks on encountering highly skewed dataset." +
         " Please set page.size.row.check.max to a lower value on the writer, default value is 10000." +
-        " You can try setting it to " + (10000 / (size/ Integer.MAX_VALUE)) + " or lower.");
+        " You can try setting it to " + (10000 / (size / Integer.MAX_VALUE)) + " or lower.");
     }
     BAOS baos = new BAOS((int)size());
     this.writeAllTo(baos);

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -215,6 +215,13 @@ abstract public class BytesInput {
    * @throws IOException if there is an exception reading
    */
   public byte[] toByteArray() throws IOException {
+    long size = size();
+    if (size > Integer.MAX_VALUE) {
+      throw new IOException("Page size, " + size + ", is larger than allowed " + Integer.MAX_VALUE +"." +
+        " Usually caused by a Parquet writer writing too big column chunks on encountering highly skewed dataset." +
+        " Please set page.size.row.check.max to a lower value on the writer, default value is 10000." +
+        " You can try setting it to " + (10000 / (size/ Integer.MAX_VALUE)) + " or lower.");
+    }
     BAOS baos = new BAOS((int)size());
     this.writeAllTo(baos);
     LOG.debug("converted {} to byteArray of {} bytes", size() , baos.size());


### PR DESCRIPTION
Fix Parquet writer's memory check interval calculation and throw helpful message while dealing with too large column chunks.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses [PARQUET-1920](https://issues.apache.org/jira/browse/PARQUET-1920).
  - https://issues.apache.org/jira/browse/PARQUET-1920

### Tests

- [ ] My PR does not necessarily needs any specific test as it is removing hard coded values in favor of configs. However, I can think of ways to test if insisted.


