### PR TITLE
PARQUET-1922: Deprecate IOExceptionUtils

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesWriter.java
@@ -126,9 +126,8 @@ public class PlainValuesWriter extends ValuesWriter {
 
   @Override
   public void close() {
-    // Need only close 'arrayOut' as 'out' simply closes 'arrayOut' but raises
-    // an IOException by signature
     arrayOut.close();
+    out.close();
   }
 
   @Override

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesWriter.java
@@ -127,7 +127,6 @@ public class PlainValuesWriter extends ValuesWriter {
   @Override
   public void close() {
     arrayOut.close();
-    out.close();
   }
 
   @Override

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesWriter.java
@@ -126,6 +126,8 @@ public class PlainValuesWriter extends ValuesWriter {
 
   @Override
   public void close() {
+    // Need only close 'arrayOut' as 'out' simply closes 'arrayOut' but raises
+    // an IOException by signature
     arrayOut.close();
   }
 

--- a/parquet-common/src/main/java/org/apache/parquet/IOExceptionUtils.java
+++ b/parquet-common/src/main/java/org/apache/parquet/IOExceptionUtils.java
@@ -23,7 +23,9 @@ import java.io.IOException;
 
 /**
  * Utilities for managing I/O resources.
+ * @deprecated
  */
+@Deprecated
 public class IOExceptionUtils {
 
 	/**

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/LittleEndianDataOutputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/LittleEndianDataOutputStream.java
@@ -18,9 +18,6 @@
  */
 package org.apache.parquet.bytes;
 
-import org.apache.parquet.IOExceptionUtils;
-import org.apache.parquet.ParquetRuntimeException;
-
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -210,8 +207,8 @@ public class LittleEndianDataOutputStream extends OutputStream {
     writeLong(Double.doubleToLongBits(v));
   }
 
-  public void close() {
-    IOExceptionUtils.closeQuietly(out);
+  public void close() throws IOException {
+    out.close();
   }
 
 }

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/LittleEndianDataOutputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/LittleEndianDataOutputStream.java
@@ -207,8 +207,12 @@ public class LittleEndianDataOutputStream extends OutputStream {
     writeLong(Double.doubleToLongBits(v));
   }
 
-  public void close() throws IOException {
-    out.close();
+  public void close() {
+    try {
+      out.close();
+    } catch (IOException e) {
+      // swallow exception
+    }
   }
 
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [PARQUET-1922](https://issues.apache.org/jira/browse/PARQUET-1922) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
