### PR TITLE
PARQUET-1924: Do not Instantiate a New LongHashFunction

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/XxHash.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/XxHash.java
@@ -30,11 +30,11 @@ import java.nio.ByteBuffer;
 public class XxHash implements HashFunction {
   @Override
   public long hashBytes(byte[] input) {
-    return LongHashFunction.xx(0).hashBytes(input);
+    return LongHashFunction.xx().hashBytes(input);
   }
 
   @Override
   public long hashByteBuffer(ByteBuffer input) {
-    return LongHashFunction.xx(0).hashBytes(input);
+    return LongHashFunction.xx().hashBytes(input);
   }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
