### PR TITLE
PARQUET-1528:  Add JSON support to `parquet-tools head`

### DIFF
--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/HeadCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/HeadCommand.java
@@ -22,7 +22,6 @@ import java.io.PrintWriter;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -48,14 +47,16 @@ public class HeadCommand extends ArgsOnlyCommand {
 
   static {
     OPTIONS = new Options();
-    Option help = OptionBuilder.withLongOpt("records")
-      .withDescription("The number of records to show (default: " + DEFAULT + ")")
-      .hasOptionalArg()
-      .create('n');
+    Option help = Option.builder("n")
+      .longOpt("records")
+      .desc("The number of records to show (default: " + DEFAULT + ")")
+      .optionalArg(true)
+      .build();
 
-    Option json = OptionBuilder.withLongOpt("json")
-      .withDescription("Show records in JSON format.")
-      .create('j');
+    Option json = Option.builder("j")
+      .longOpt("json")
+      .desc("Show records in JSON format.")
+      .build();
 
     OPTIONS.addOption(help);
     OPTIONS.addOption(json);

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/HeadCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/HeadCommand.java
@@ -24,29 +24,41 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
+import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.tools.Main;
+import org.apache.parquet.tools.json.JsonRecordFormatter;
 import org.apache.parquet.tools.read.SimpleReadSupport;
 import org.apache.parquet.tools.read.SimpleRecord;
 
 public class HeadCommand extends ArgsOnlyCommand {
   private static final long DEFAULT = 5;
 
-  public static final String[] USAGE = new String[] {
+  public static final String[] USAGE = new String[]{
     "<input>",
     "where <input> is the parquet file to print to stdout"
   };
 
   public static final Options OPTIONS;
+
   static {
     OPTIONS = new Options();
     Option help = OptionBuilder.withLongOpt("records")
-                               .withDescription("The number of records to show (default: " + DEFAULT + ")")
-                               .hasOptionalArg()
-                               .create('n');
+      .withDescription("The number of records to show (default: " + DEFAULT + ")")
+      .hasOptionalArg()
+      .create('n');
+
+    Option json = OptionBuilder.withLongOpt("json")
+      .withDescription("Show records in JSON format.")
+      .create('j');
+
     OPTIONS.addOption(help);
+    OPTIONS.addOption(json);
   }
 
   public HeadCommand() {
@@ -84,8 +96,16 @@ public class HeadCommand extends ArgsOnlyCommand {
     try {
       PrintWriter writer = new PrintWriter(Main.out, true);
       reader = ParquetReader.builder(new SimpleReadSupport(), new Path(input)).build();
+      ParquetFileReader fileReader = ParquetFileReader.open(HadoopInputFile.fromPath(new Path(input), new Configuration()));
+      FileMetaData fileMetaData = fileReader.getFooter().getFileMetaData();
+      JsonRecordFormatter.JsonGroupFormatter jsonFormatter = JsonRecordFormatter.fromSchema(fileMetaData.getSchema());
+
       for (SimpleRecord value = reader.read(); value != null && num-- > 0; value = reader.read()) {
-        value.prettyPrint(writer);
+        if (options.hasOption('j')) {
+          writer.write(jsonFormatter.formatRecord(value));
+        } else {
+          value.prettyPrint(writer);
+        }
         writer.println();
       }
     } finally {


### PR DESCRIPTION
### Jira

- [X] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/projects/PARQUET) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1528
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: testing options parsing would add very little value and formatting is already tested via `JsonRecordFormatter`

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
