### PR TITLE
PARQUET-1928: Interpret Parquet INT96 type as FIXED[12] AVRO Schema

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * 
  *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
@@ -1,4 +1,4 @@
-/*
+/* 
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -50,6 +50,10 @@ public class AvroReadSupport<T> extends ReadSupport<T> {
 
   public static final String AVRO_COMPATIBILITY = "parquet.avro.compatible";
   public static final boolean AVRO_DEFAULT_COMPATIBILITY = true;
+
+  // Support reading Parquet INT96 as a 12-byte array.
+  public static final String READ_INT96_AS_FIXED = "parquet.avro.readInt96AsFixed";
+  public static final boolean READ_INT96_AS_FIXED_DEFAULT = false;
 
   /**
    * @param configuration a configuration

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
@@ -305,7 +305,7 @@ public class AvroSchemaConverter {
             }
             @Override
             public Schema convertINT96(PrimitiveTypeName primitiveTypeName) {
-              throw new IllegalArgumentException("INT96 not implemented and is deprecated");
+              return Schema.createFixed("INT96", "INT96 represented as byte[12]", null, 12);
             }
             @Override
             public Schema convertFLOAT(PrimitiveTypeName primitiveTypeName) {

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
@@ -314,7 +314,7 @@ public class AvroSchemaConverter {
                 return Schema.createFixed("INT96", "INT96 represented as byte[12]", null, 12);
               }
               throw new IllegalArgumentException(
-                "INT96 is deprecated. As interim READ_INT96_AS_FIXED configuration flag to enable reading as 12-byte fixed byte array.");
+                "INT96 is deprecated. As interim enable READ_INT96_AS_FIXED  flag to read as byte array.");
             }
             @Override
             public Schema convertFLOAT(PrimitiveTypeName primitiveTypeName) {

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
@@ -586,6 +586,18 @@ public class TestAvroSchemaConverter {
   }
 
   @Test
+  public void testParquetInt96AsFixed12AvroType() throws Exception {
+    Schema schema = Schema.createRecord("myrecord", null, null, false);
+    Schema int96schema = Schema.createFixed("INT96", "INT96 represented as byte[12]", null, 12);
+    schema.setFields(Collections.singletonList(
+      new Schema.Field("int96_field", int96schema, null, null)));
+
+    testParquetToAvroConversion(schema, "message myrecord {\n" +
+      "  required int96 int96_field;\n" +
+      "}\n");
+  }
+
+  @Test
   public void testDateType() throws Exception {
     Schema date = LogicalTypes.date().addToSchema(Schema.create(INT));
     Schema expected = Schema.createRecord("myrecord", null, null, false,

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
@@ -587,14 +587,28 @@ public class TestAvroSchemaConverter {
 
   @Test
   public void testParquetInt96AsFixed12AvroType() throws Exception {
+    Configuration enableInt96ReadingConfig = new Configuration();
+    enableInt96ReadingConfig.setBoolean(AvroReadSupport.READ_INT96_AS_FIXED, true);
+
     Schema schema = Schema.createRecord("myrecord", null, null, false);
     Schema int96schema = Schema.createFixed("INT96", "INT96 represented as byte[12]", null, 12);
     schema.setFields(Collections.singletonList(
       new Schema.Field("int96_field", int96schema, null, null)));
 
-    testParquetToAvroConversion(schema, "message myrecord {\n" +
+    testParquetToAvroConversion(enableInt96ReadingConfig, schema, "message myrecord {\n" +
       "  required int96 int96_field;\n" +
       "}\n");
+  }
+
+  @Test
+  public void testParquetInt96DefaultFail() throws Exception {
+    Schema schema = Schema.createRecord("myrecord", null, null, false);
+
+    MessageType parquetSchemaWithInt96 = MessageTypeParser.parseMessageType("message myrecord {\n  required int96 int96_field;\n}\n");
+
+    assertThrows("INT96 is deprecated. As interim enable READ_INT96_AS_FIXED  flag to read as byte array.",
+      IllegalArgumentException.class,
+      () -> new AvroSchemaConverter().convert(parquetSchemaWithInt96));
   }
 
   @Test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

Reading Parquet files in Apache Beam using ParquetIO uses `AvroParquetReader` causing it to throw `IllegalArgumentException("INT96 not implemented and is deprecated")`

Customers have large datasets which can't be reprocessed again to convert into a supported type. An easier approach would be to convert into a byte array of 12 bytes, that can then be interpreted by the developer in any way they want to interpret it.

This patch interprets the INT96 parquet type as a byte array of 12-bytes. the developer/user can then handle it appropriate to interpret into a timestamp or simple some bytes.

- [x ] My PR adds the following unit tests `testParquetInt96AsFixed12AvroType` and `testParquetInt96DefaultFail`

https://issues.apache.org/jira/browse/PARQUET-1928
