### PR TITLE
PARQUET-1926: Add LogicalType support to ThriftType

### DIFF
--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
@@ -57,8 +57,6 @@ import org.apache.parquet.thrift.struct.ThriftType.StructType.StructOrUnionType;
 import static org.apache.parquet.schema.ConversionPatterns.listOfElements;
 import static org.apache.parquet.schema.ConversionPatterns.listType;
 import static org.apache.parquet.schema.ConversionPatterns.mapType;
-import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
-import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
@@ -325,7 +323,7 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
 
   @Override
   public ConvertedField visit(EnumType enumType, State state) {
-    return visitPrimitiveType(BINARY, enumType(), state);
+    return visitPrimitiveType(BINARY, LogicalTypeAnnotation.enumType(), state);
   }
 
   @Override
@@ -350,7 +348,7 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
 
   @Override
   public ConvertedField visit(I32Type i32Type, State state) {
-    return visitPrimitiveType(INT32, state);
+    return i32Type.hasLogicalTypeAnnotation() ? visitPrimitiveType(INT32, i32Type.getLogicalTypeAnnotation(), state) : visitPrimitiveType(INT32, state);
   }
 
   @Override
@@ -360,7 +358,11 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
 
   @Override
   public ConvertedField visit(StringType stringType, State state) {
-    return stringType.isBinary() ? visitPrimitiveType(BINARY, state) : visitPrimitiveType(BINARY, stringType(), state);
+    if (stringType.isBinary()) {
+      return stringType.hasLogicalTypeAnnotation() ? visitPrimitiveType(BINARY, stringType.getLogicalTypeAnnotation(), state) : visitPrimitiveType(BINARY, state);
+    } else {
+      return visitPrimitiveType(BINARY, LogicalTypeAnnotation.stringType(), state);
+    }
   }
 
   private static boolean isUnion(StructOrUnionType s) {

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
@@ -355,7 +355,7 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
 
   @Override
   public ConvertedField visit(I64Type i64Type, State state) {
-    return visitPrimitiveType(INT64, state);
+    return i64Type.hasLogicalTypeAnnotation() ? visitPrimitiveType(INT64, i64Type.getLogicalTypeAnnotation(), state) : visitPrimitiveType(INT64, state);
   }
 
   @Override

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/ThriftType.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/ThriftType.java
@@ -31,6 +31,8 @@ import static org.apache.parquet.thrift.struct.ThriftTypeID.SET;
 import static org.apache.parquet.thrift.struct.ThriftTypeID.STRING;
 import static org.apache.parquet.thrift.struct.ThriftTypeID.STRUCT;
 
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -619,11 +621,25 @@ public abstract class ThriftType {
   }
 
   public static class I64Type extends ThriftType {
+    private LogicalTypeAnnotation logicalTypeAnnotation;
 
     @JsonCreator
     public I64Type() {
       super(I64);
     }
+
+    public boolean hasLogicalTypeAnnotation() {
+      return logicalTypeAnnotation != null;
+    }
+
+    public LogicalTypeAnnotation getLogicalTypeAnnotation() {
+      return logicalTypeAnnotation;
+    }
+
+    public void setLogicalTypeAnnotation(LogicalTypeAnnotation logicalTypeAnnotation) {
+      this.logicalTypeAnnotation = logicalTypeAnnotation;
+    }
+
     @Override
     public <R, S> R accept(StateVisitor<R, S> visitor, S state) {
       return visitor.visit(this, state);

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/ThriftType.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/struct/ThriftType.java
@@ -66,6 +66,19 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(value=ThriftType.StructType.class, name="STRUCT")
 })
 public abstract class ThriftType {
+  private LogicalTypeAnnotation logicalTypeAnnotation;
+
+  public boolean hasLogicalTypeAnnotation() {
+    return this.logicalTypeAnnotation != null;
+  }
+
+  public LogicalTypeAnnotation getLogicalTypeAnnotation() {
+    return this.logicalTypeAnnotation;
+  }
+
+  public void setLogicalTypeAnnotation(LogicalTypeAnnotation logicalTypeAnnotation) {
+    this.logicalTypeAnnotation = logicalTypeAnnotation;
+  }
 
   @Override
   public boolean equals(Object o) {
@@ -621,23 +634,10 @@ public abstract class ThriftType {
   }
 
   public static class I64Type extends ThriftType {
-    private LogicalTypeAnnotation logicalTypeAnnotation;
 
     @JsonCreator
     public I64Type() {
       super(I64);
-    }
-
-    public boolean hasLogicalTypeAnnotation() {
-      return logicalTypeAnnotation != null;
-    }
-
-    public LogicalTypeAnnotation getLogicalTypeAnnotation() {
-      return logicalTypeAnnotation;
-    }
-
-    public void setLogicalTypeAnnotation(LogicalTypeAnnotation logicalTypeAnnotation) {
-      this.logicalTypeAnnotation = logicalTypeAnnotation;
     }
 
     @Override

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftMetaData.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftMetaData.java
@@ -45,7 +45,8 @@ public class TestThriftMetaData {
     assertEquals("ThriftMetaData(thriftClassName: non existent class!!!, descriptor: {\n" +
         "  \"id\" : \"STRUCT\",\n" +
         "  \"children\" : [ ],\n" +
-        "  \"structOrUnionType\" : \"STRUCT\"\n" +
+        "  \"structOrUnionType\" : \"STRUCT\",\n" +
+        "  \"logicalTypeAnnotation\" : null\n" +
         "})", tmd.toString());
 
     tmd = new ThriftMetaData("non existent class!!!", null);

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftRecordConverter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftRecordConverter.java
@@ -69,7 +69,8 @@ public class TestThriftRecordConverter {
           "    \"values\" : [ {\n" +
           "      \"id\" : 77,\n" +
           "      \"name\" : \"hello\"\n" +
-          "    } ]\n" +
+          "    } ],\n" +
+          "    \"logicalTypeAnnotation\" : null\n" +
           "  }\n" +
           "}", e.getMessage());
     }

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConvertVisitor.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.thrift;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
+import org.apache.parquet.schema.Type;
+
+import org.apache.parquet.thrift.projection.FieldProjectionFilter;
+import org.apache.parquet.thrift.struct.ThriftField;
+import org.apache.parquet.thrift.struct.ThriftType;
+import org.apache.parquet.thrift.struct.ThriftType.StructType;
+import org.apache.parquet.thrift.struct.ThriftType.StructType.StructOrUnionType;
+
+import org.junit.Test;
+
+import static org.apache.parquet.schema.Type.Repetition;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
+import static org.apache.parquet.thrift.struct.ThriftField.Requirement;
+import static org.junit.Assert.assertEquals;
+
+public class TestThriftSchemaConvertVisitor {
+
+  @Test
+  public void testConvertBasicI64Type() {
+    String fieldName = "i64Type";
+    Short fieldId = 0;
+
+    ThriftType.I64Type timestampI64Type = new ThriftType.I64Type();
+    ThriftField field = new ThriftField(fieldName, fieldId, Requirement.REQUIRED, timestampI64Type);
+    List<ThriftField> thriftFields = new ArrayList<ThriftField>(1);
+    thriftFields.add(field);
+    StructType thriftStruct = new StructType(thriftFields, StructOrUnionType.STRUCT);
+    MessageType actual = ThriftSchemaConvertVisitor.convert(thriftStruct, FieldProjectionFilter.ALL_COLUMNS);
+
+    Type expectedParquetField = Types.primitive(PrimitiveTypeName.INT64, Repetition.REQUIRED)
+      .named(fieldName)
+      .withId(fieldId);
+
+    MessageType expected = Types
+      .buildMessage()
+      .addFields(expectedParquetField)
+      .named("ParquetSchema");
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testConvertLogicalI64Type() {
+    LogicalTypeAnnotation timestampLogicalType = timestampType(true, TimeUnit.MILLIS);
+    String fieldName = "logicalI64Type";
+    Short fieldId = 0;
+
+    ThriftType.I64Type timestampI64Type = new ThriftType.I64Type();
+    timestampI64Type.setLogicalTypeAnnotation(timestampLogicalType);
+    ThriftField field = new ThriftField(fieldName, fieldId, Requirement.REQUIRED, timestampI64Type);
+    List<ThriftField> thriftFields = new ArrayList<ThriftField>(1);
+    thriftFields.add(field);
+    StructType thriftStruct = new StructType(thriftFields, StructOrUnionType.STRUCT);
+    MessageType actual = ThriftSchemaConvertVisitor.convert(thriftStruct, FieldProjectionFilter.ALL_COLUMNS);
+
+    Type expectedParquetField = Types.primitive(PrimitiveTypeName.INT64, Repetition.REQUIRED)
+      .as(timestampLogicalType)
+      .named(fieldName)
+      .withId(fieldId);
+
+    MessageType expected = Types
+      .buildMessage()
+      .addFields(expectedParquetField)
+      .named("ParquetSchema");
+
+    assertEquals(expected, actual);
+  }
+}

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConvertVisitor.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
-import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
@@ -38,59 +37,141 @@ import org.apache.parquet.thrift.struct.ThriftType.StructType.StructOrUnionType;
 import org.junit.Test;
 
 import static org.apache.parquet.schema.Type.Repetition;
-import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
 import static org.apache.parquet.thrift.struct.ThriftField.Requirement;
 import static org.junit.Assert.assertEquals;
 
 public class TestThriftSchemaConvertVisitor {
+
+  private MessageType buildOneFieldParquetMessage(Type expectedParquetField) {
+    return Types.buildMessage()
+      .addFields(expectedParquetField)
+      .named("ParquetSchema");
+  }
+
+  private StructType buildOneFieldThriftStructType(String fieldName, Short fieldId, ThriftType thriftType) {
+    ThriftField inputThriftField = new ThriftField(fieldName, fieldId, Requirement.REQUIRED, thriftType);
+    List<ThriftField> fields = new ArrayList<ThriftField>(1);
+    fields.add(inputThriftField);
+    return new StructType(fields, StructOrUnionType.STRUCT);
+  }
+
+  @Test
+  public void testConvertBasicI32Type() {
+    String fieldName = "i32Type";
+    Short fieldId = 0;
+
+    ThriftType i32Type = new ThriftType.I32Type();
+
+    StructType thriftStruct = buildOneFieldThriftStructType(fieldName, fieldId, i32Type);
+    MessageType actual = ThriftSchemaConvertVisitor.convert(thriftStruct, FieldProjectionFilter.ALL_COLUMNS);
+
+    Type expectedParquetField = Types.primitive(PrimitiveTypeName.INT32, Repetition.REQUIRED)
+      .named(fieldName)
+      .withId(fieldId);
+    MessageType expected = buildOneFieldParquetMessage(expectedParquetField);
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testConvertLogicalI32Type() {
+    LogicalTypeAnnotation timeLogicalType = LogicalTypeAnnotation.timeType(true, TimeUnit.MILLIS);
+    String fieldName = "timeI32Type";
+    Short fieldId = 0;
+
+    ThriftType timeI32Type = new ThriftType.I32Type();
+    timeI32Type.setLogicalTypeAnnotation(timeLogicalType);
+
+    StructType thriftStruct = buildOneFieldThriftStructType(fieldName, fieldId, timeI32Type);
+    MessageType actual = ThriftSchemaConvertVisitor.convert(thriftStruct, FieldProjectionFilter.ALL_COLUMNS);
+
+    Type expectedParquetField = Types.primitive(PrimitiveTypeName.INT32, Repetition.REQUIRED)
+      .as(timeLogicalType)
+      .named(fieldName)
+      .withId(fieldId);
+    MessageType expected = buildOneFieldParquetMessage(expectedParquetField);
+
+    assertEquals(expected, actual);
+  }
 
   @Test
   public void testConvertBasicI64Type() {
     String fieldName = "i64Type";
     Short fieldId = 0;
 
-    ThriftType.I64Type timestampI64Type = new ThriftType.I64Type();
-    ThriftField field = new ThriftField(fieldName, fieldId, Requirement.REQUIRED, timestampI64Type);
-    List<ThriftField> thriftFields = new ArrayList<ThriftField>(1);
-    thriftFields.add(field);
-    StructType thriftStruct = new StructType(thriftFields, StructOrUnionType.STRUCT);
+    ThriftType i64Type = new ThriftType.I64Type();
+    
+    StructType thriftStruct = buildOneFieldThriftStructType(fieldName, fieldId, i64Type);
     MessageType actual = ThriftSchemaConvertVisitor.convert(thriftStruct, FieldProjectionFilter.ALL_COLUMNS);
 
     Type expectedParquetField = Types.primitive(PrimitiveTypeName.INT64, Repetition.REQUIRED)
       .named(fieldName)
       .withId(fieldId);
-
-    MessageType expected = Types
-      .buildMessage()
-      .addFields(expectedParquetField)
-      .named("ParquetSchema");
+    MessageType expected = buildOneFieldParquetMessage(expectedParquetField);
 
     assertEquals(expected, actual);
   }
 
   @Test
   public void testConvertLogicalI64Type() {
-    LogicalTypeAnnotation timestampLogicalType = timestampType(true, TimeUnit.MILLIS);
+    LogicalTypeAnnotation timestampLogicalType = LogicalTypeAnnotation.timestampType(true, TimeUnit.MILLIS);
     String fieldName = "logicalI64Type";
     Short fieldId = 0;
 
-    ThriftType.I64Type timestampI64Type = new ThriftType.I64Type();
+    ThriftType timestampI64Type = new ThriftType.I64Type();
     timestampI64Type.setLogicalTypeAnnotation(timestampLogicalType);
-    ThriftField field = new ThriftField(fieldName, fieldId, Requirement.REQUIRED, timestampI64Type);
-    List<ThriftField> thriftFields = new ArrayList<ThriftField>(1);
-    thriftFields.add(field);
-    StructType thriftStruct = new StructType(thriftFields, StructOrUnionType.STRUCT);
+    
+    StructType thriftStruct = buildOneFieldThriftStructType(fieldName, fieldId, timestampI64Type);
     MessageType actual = ThriftSchemaConvertVisitor.convert(thriftStruct, FieldProjectionFilter.ALL_COLUMNS);
 
     Type expectedParquetField = Types.primitive(PrimitiveTypeName.INT64, Repetition.REQUIRED)
       .as(timestampLogicalType)
       .named(fieldName)
       .withId(fieldId);
+    MessageType expected = buildOneFieldParquetMessage(expectedParquetField);
 
-    MessageType expected = Types
-      .buildMessage()
-      .addFields(expectedParquetField)
-      .named("ParquetSchema");
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testConvertStringType() {
+    LogicalTypeAnnotation stringLogicalType = LogicalTypeAnnotation.stringType();
+    String fieldName = "stringType";
+    Short fieldId = 0;
+
+    ThriftType stringType = new ThriftType.StringType();
+    
+    StructType thriftStruct = buildOneFieldThriftStructType(fieldName, fieldId, stringType);
+    MessageType actual = ThriftSchemaConvertVisitor.convert(thriftStruct, FieldProjectionFilter.ALL_COLUMNS);
+
+    Type expectedParquetField = Types.primitive(PrimitiveTypeName.BINARY, Repetition.REQUIRED)
+      .as(stringLogicalType)
+      .named(fieldName)
+      .withId(fieldId);
+    MessageType expected = buildOneFieldParquetMessage(expectedParquetField);
+
+    assertEquals(expected, actual);
+
+  }
+
+  @Test
+  public void testConvertLogicalBinaryType() {
+    LogicalTypeAnnotation jsonLogicalType = LogicalTypeAnnotation.jsonType();
+    String fieldName = "logicalBinaryType";
+    Short fieldId = 0;
+
+    ThriftType.StringType jsonBinaryType = new ThriftType.StringType();
+    jsonBinaryType.setBinary(true);
+    jsonBinaryType.setLogicalTypeAnnotation(jsonLogicalType);
+    
+    StructType thriftStruct = buildOneFieldThriftStructType(fieldName, fieldId, jsonBinaryType);
+    MessageType actual = ThriftSchemaConvertVisitor.convert(thriftStruct, FieldProjectionFilter.ALL_COLUMNS);
+
+    Type expectedParquetField = Types.primitive(PrimitiveTypeName.BINARY, Repetition.REQUIRED)
+      .as(jsonLogicalType)
+      .named(fieldName)
+      .withId(fieldId);
+    MessageType expected = buildOneFieldParquetMessage(expectedParquetField);
 
     assertEquals(expected, actual);
   }

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/TestThriftType.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/TestThriftType.java
@@ -35,21 +35,24 @@ public class TestThriftType {
     assertEquals("{\n"
                 +"  \"id\" : \"STRUCT\",\n"
                 +"  \"children\" : [ ],\n"
-                +"  \"structOrUnionType\" : \"STRUCT\"\n"
+                +"  \"structOrUnionType\" : \"STRUCT\",\n"
+                +"  \"logicalTypeAnnotation\" : null\n"
                 +"}", st.toJSON());
 
     st = new StructType(new LinkedList<ThriftField>(), StructOrUnionType.UNION);
     assertEquals("{\n"
         +"  \"id\" : \"STRUCT\",\n"
         +"  \"children\" : [ ],\n"
-        +"  \"structOrUnionType\" : \"UNION\"\n"
+        +"  \"structOrUnionType\" : \"UNION\",\n"
+        +"  \"logicalTypeAnnotation\" : null\n"
         +"}", st.toJSON());
 
     st = new StructType(new LinkedList<ThriftField>(), StructOrUnionType.STRUCT);
     assertEquals("{\n"
         +"  \"id\" : \"STRUCT\",\n"
         +"  \"children\" : [ ],\n"
-        +"  \"structOrUnionType\" : \"STRUCT\"\n"
+        +"  \"structOrUnionType\" : \"STRUCT\",\n"
+        +"  \"logicalTypeAnnotation\" : null\n"
         +"}", st.toJSON());
   }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET-1926/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1926
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
