### PR TITLE
[PARQUET-1930] Bump Apache Thrift to 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ Parquet-MR uses Maven to build and depends on the thrift compiler (protoc is now
 To build and install the thrift compiler, run:
 
 ```
-wget -nv http://archive.apache.org/dist/thrift/0.12.0/thrift-0.12.0.tar.gz
-tar xzf thrift-0.12.0.tar.gz
-cd thrift-0.12.0
+wget -nv http://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz
+tar xzf thrift-0.13.0.tar.gz
+cd thrift-0.13.0
 chmod +x ./configure
 ./configure --disable-libs
 sudo make install
 ```
 
-If you're on OSX and use homebrew, you can instead install Thrift 0.12.0 with `brew` and ensure that it comes first in your `PATH`.
+If you're on OSX and use homebrew, you can instead install Thrift 0.13.0 with `brew` and ensure that it comes first in your `PATH`.
 
 ```
-brew install thrift@0.12
-export PATH="/usr/local/opt/thrift@0.12.0/bin:$PATH"
+brew install thrift@0.13
+export PATH="/usr/local/opt/thrift@0.13.0/bin:$PATH"
 ```
 
 ### Build Parquet with Maven

--- a/dev/travis-before_install.sh
+++ b/dev/travis-before_install.sh
@@ -20,7 +20,7 @@
 # This script gets invoked by .travis.yml in the before_install step
 ################################################################################
 
-export THIFT_VERSION=0.12.0
+export THIFT_VERSION=0.13.0
 
 set -e
 date
@@ -30,7 +30,7 @@ sudo apt-get install -qq --no-install-recommends build-essential pv autoconf aut
    libevent-dev automake libtool flex bison pkg-config g++ libssl-dev xmlstarlet
 date
 pwd
-wget -qO- https://archive.apache.org/dist/thrift/0.12.0/thrift-0.12.0.tar.gz | tar zxf -
+wget -qO- https://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz | tar zxf -
 cd thrift-${THIFT_VERSION}
 chmod +x ./configure
 ./configure --disable-libs

--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,8 @@
     <pig.version>0.16.0</pig.version>
     <pig.classifier>h2</pig.classifier>
     <thrift-maven-plugin.version>0.10.0</thrift-maven-plugin.version>
-    <thrift.version>0.12.0</thrift.version>
-    <format.thrift.version>0.12.0</format.thrift.version>
+    <thrift.version>0.13.0</thrift.version>
+    <format.thrift.version>0.13.0</format.thrift.version>
     <fastutil.version>8.2.3</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>
     <slf4j.version>1.7.22</slf4j.version>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

Changelog: https://github.com/apache/thrift/blob/master/CHANGES.md#0130

Thrift 0.13.0 makes the first steps to be compatible with Java 9+, and it isn't available anymore on Brew: https://github.com/apache/parquet-mr/pull/818 Which is just a minor thing of course, but might be an indicator that we should upgrade to a newer version ;)

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1930
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
