### PR TITLE
PARQUET-1939: Fix remote KMS client ambiguity

### DIFF
--- a/parquet-hadoop/README.md
+++ b/parquet-hadoop/README.md
@@ -418,13 +418,6 @@ If `false`, DEKs are directly encrypted with master keys, KEKs are not used.
 
 ---
 
-**Property:** `parquet.encryption.wrap.locally`  
-**Description:** Wrap keys locally - master keys are fetched from the KMS server and used to encrypt other keys (DEKs or KEKs).
-If `false` - key wrapping will be performed by a KMS server.  
-**Default value:** `false`
-
----
-
 **Property:** `parquet.encryption.key.material.store.internally`  
 **Description:** Store key material inside Parquet file footers; this mode doesn’t produce additional files. 
 If `false`, key material is stored in separate new files, created in the same folder - this mode enables key rotation for immutable Parquet files.  

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/KeyToolkit.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/KeyToolkit.java
@@ -69,11 +69,6 @@ public class KeyToolkit {
    */
   public static final String CACHE_LIFETIME_PROPERTY_NAME = "parquet.encryption.cache.lifetime.seconds";
   /**
-   * Wrap keys locally - master keys are fetched from the KMS server and used to encrypt other keys (DEKs or KEKs).
-   * By default, false - key wrapping will be performed by a KMS server.
-   */
-  public static final String WRAP_LOCALLY_PROPERTY_NAME = "parquet.encryption.wrap.locally";
-  /**
    * Store key material inside Parquet file footers; this mode doesn’t produce additional files.
    * By default, true. If set to false, key material is stored in separate files in the same folder,
    * which enables key rotation for immutable Parquet files.
@@ -87,7 +82,6 @@ public class KeyToolkit {
 
   public static final boolean DOUBLE_WRAPPING_DEFAULT = true;
   public static final long CACHE_LIFETIME_DEFAULT_SECONDS = 10 * 60; // 10 minutes
-  public static final boolean WRAP_LOCALLY_DEFAULT = false;
   public static final boolean KEY_MATERIAL_INTERNAL_DEFAULT = true;
   public static final int DATA_KEY_LENGTH_DEFAULT = 128;
 
@@ -208,10 +202,6 @@ public class KeyToolkit {
 
     if (hadoopConfig.getBoolean(KEY_MATERIAL_INTERNAL_PROPERTY_NAME, KEY_MATERIAL_INTERNAL_DEFAULT)) {
       throw new UnsupportedOperationException("Key rotation is not supported for internal key material");
-    }
-
-    if (hadoopConfig.getBoolean(WRAP_LOCALLY_PROPERTY_NAME, WRAP_LOCALLY_DEFAULT)) {
-      throw new UnsupportedOperationException("Key rotation is not supported for local key wrapping");
     }
 
     // If process wrote files with double-wrapped keys, clean KEK cache (since master keys are changing).

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/LocalWrapKmsClient.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/LocalWrapKmsClient.java
@@ -33,6 +33,13 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+/**
+ * Typically, KMS systems support in-server key wrapping. Their clients should implement KmsClient interface directly.
+ * An extension of the LocalWrapKmsClient class should used only in rare situations where in-server wrapping is not
+ * supported. The wrapping will be done locally then - the MEKs will be fetched from the KMS server via the
+ * getMasterKeyFromServer function, and used to encrypt a DEK or KEK inside the LocalWrapKmsClient code.
+ * Note: master key rotation is not supported with local wrapping.
+ */
 public abstract class LocalWrapKmsClient implements KmsClient {
 
   public static final String LOCAL_WRAP_NO_KEY_VERSION = "NO_VERSION";
@@ -41,7 +48,6 @@ public abstract class LocalWrapKmsClient implements KmsClient {
   protected String kmsInstanceURL;
   protected String kmsToken;
   protected Configuration hadoopConfiguration;
-
 
   // MasterKey cache: master keys per key ID (per KMS Client). For local wrapping only.
   private ConcurrentMap<String, byte[]> masterKeyCache;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/LocalWrapKmsClient.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/LocalWrapKmsClient.java
@@ -35,16 +35,15 @@ import java.util.concurrent.ConcurrentMap;
 
 import static org.apache.parquet.crypto.keytools.KeyToolkit.stringIsEmpty;
 
-public abstract class RemoteKmsClient implements KmsClient {
+public abstract class LocalWrapKmsClient implements KmsClient {
 
   public static final String LOCAL_WRAP_NO_KEY_VERSION = "NO_VERSION";
 
   protected String kmsInstanceID;
   protected String kmsInstanceURL;
   protected String kmsToken;
-  protected Boolean isWrapLocally;
   protected Configuration hadoopConfiguration;
-  protected boolean isDefaultToken;
+
 
   // MasterKey cache: master keys per key ID (per KMS Client). For local wrapping only.
   private ConcurrentMap<String, byte[]> masterKeyCache;
@@ -113,58 +112,39 @@ public abstract class RemoteKmsClient implements KmsClient {
   public void initialize(Configuration configuration, String kmsInstanceID, String kmsInstanceURL, String accessToken) {
     this.kmsInstanceID = kmsInstanceID;
     this.kmsInstanceURL = kmsInstanceURL;
-
-    this.isWrapLocally = configuration.getBoolean(KeyToolkit.WRAP_LOCALLY_PROPERTY_NAME, KeyToolkit.WRAP_LOCALLY_DEFAULT);
-    if (isWrapLocally) {
-      masterKeyCache = new ConcurrentHashMap<>();
-    }
-
+    
+    masterKeyCache = new ConcurrentHashMap<>();
     hadoopConfiguration = configuration;
     kmsToken = accessToken;
-
-    isDefaultToken = kmsToken.equals(KmsClient.KEY_ACCESS_TOKEN_DEFAULT);
 
     initializeInternal();
   }
 
   @Override
   public String wrapKey(byte[] key, String masterKeyIdentifier) throws KeyAccessDeniedException {
-    if (isWrapLocally) {
-      byte[] masterKey =  masterKeyCache.computeIfAbsent(masterKeyIdentifier,
+    byte[] masterKey =  masterKeyCache.computeIfAbsent(masterKeyIdentifier,
           (k) -> getKeyFromServer(masterKeyIdentifier));
-      byte[] AAD = masterKeyIdentifier.getBytes(StandardCharsets.UTF_8);
-      String encryptedEncodedKey =  KeyToolkit.encryptKeyLocally(key, masterKey, AAD);
-      return LocalKeyWrap.createSerialized(encryptedEncodedKey);
-    } else {
-      refreshToken();
-      return wrapKeyInServer(key, masterKeyIdentifier);
-    }
+    byte[] AAD = masterKeyIdentifier.getBytes(StandardCharsets.UTF_8);
+    String encryptedEncodedKey =  KeyToolkit.encryptKeyLocally(key, masterKey, AAD);
+    return LocalKeyWrap.createSerialized(encryptedEncodedKey);
   }
 
   @Override
   public byte[] unwrapKey(String wrappedKey, String masterKeyIdentifier) throws KeyAccessDeniedException {
-    if (isWrapLocally) {
-      LocalKeyWrap keyWrap = LocalKeyWrap.parse(wrappedKey);
-      String masterKeyVersion = keyWrap.getMasterKeyVersion();
-      if (!LOCAL_WRAP_NO_KEY_VERSION.equals(masterKeyVersion)) {
-        throw new ParquetCryptoRuntimeException("Master key versions are not supported for local wrapping: "
-          + masterKeyVersion);
-      }
-      String encryptedEncodedKey = keyWrap.getEncryptedKey();
-      byte[] masterKey = masterKeyCache.computeIfAbsent(masterKeyIdentifier,
-          (k) -> getKeyFromServer(masterKeyIdentifier));
-      byte[] AAD = masterKeyIdentifier.getBytes(StandardCharsets.UTF_8);
-      return KeyToolkit.decryptKeyLocally(encryptedEncodedKey, masterKey, AAD);
-    } else {
-      refreshToken();
-      return unwrapKeyInServer(wrappedKey, masterKeyIdentifier);
+    LocalKeyWrap keyWrap = LocalKeyWrap.parse(wrappedKey);
+    String masterKeyVersion = keyWrap.getMasterKeyVersion();
+    if (!LOCAL_WRAP_NO_KEY_VERSION.equals(masterKeyVersion)) {
+      throw new ParquetCryptoRuntimeException("Master key versions are not supported for local wrapping: "
+        + masterKeyVersion);
     }
+    String encryptedEncodedKey = keyWrap.getEncryptedKey();
+    byte[] masterKey = masterKeyCache.computeIfAbsent(masterKeyIdentifier,
+        (k) -> getKeyFromServer(masterKeyIdentifier));
+    byte[] AAD = masterKeyIdentifier.getBytes(StandardCharsets.UTF_8);
+    return KeyToolkit.decryptKeyLocally(encryptedEncodedKey, masterKey, AAD);
   }
 
   private void refreshToken() {
-    if (isDefaultToken) {
-      return;
-    }
     kmsToken = hadoopConfiguration.getTrimmed(KeyToolkit.KEY_ACCESS_TOKEN_PROPERTY_NAME);
     if (stringIsEmpty(kmsToken)) {
       throw new ParquetCryptoRuntimeException("Empty token");
@@ -177,38 +157,7 @@ public abstract class RemoteKmsClient implements KmsClient {
   }
 
   /**
-   * Wrap a key with the master key in the remote KMS server.
-   * 
-   * If your KMS client code throws runtime exceptions related to access/permission problems
-   * (such as Hadoop AccessControlException), catch them and throw the KeyAccessDeniedException.
-   * 
-   * @param keyBytes: key bytes to be wrapped
-   * @param masterKeyIdentifier: a string that uniquely identifies the master key in a KMS instance
-   * @return wrappedKey: Encrypts key bytes with the master key, encodes the result  and potentially adds a KMS-specific metadata.
-   * @throws KeyAccessDeniedException unauthorized to encrypt with the given master key
-   * @throws UnsupportedOperationException KMS does not support in-server wrapping 
-   */
-  protected abstract String wrapKeyInServer(byte[] keyBytes, String masterKeyIdentifier) 
-      throws KeyAccessDeniedException, UnsupportedOperationException;
-
-  /**
-   * Unwrap a key with the master key in the remote KMS server. 
-   * 
-   * If your KMS client code throws runtime exceptions related to access/permission problems
-   * (such as Hadoop AccessControlException), catch them and throw the KeyAccessDeniedException.
-   * 
-   * @param wrappedKey String produced by wrapKey operation
-   * @param masterKeyIdentifier: a string that uniquely identifies the master key in a KMS instance
-   * @return key bytes
-   * @throws KeyAccessDeniedException unauthorized to unwrap with the given master key
-   * @throws UnsupportedOperationException KMS does not support in-server unwrapping 
-   */
-  protected abstract byte[] unwrapKeyInServer(String wrappedKey, String masterKeyIdentifier) 
-      throws KeyAccessDeniedException, UnsupportedOperationException;
-
-  /**
    * Get master key from the remote KMS server.
-   * Required only for local wrapping. No need to implement if KMS supports in-server wrapping/unwrapping.
    * 
    * If your KMS client code throws runtime exceptions related to access/permission problems
    * (such as Hadoop AccessControlException), catch them and throw the KeyAccessDeniedException.
@@ -216,10 +165,9 @@ public abstract class RemoteKmsClient implements KmsClient {
    * @param masterKeyIdentifier: a string that uniquely identifies the master key in a KMS instance
    * @return master key bytes
    * @throws KeyAccessDeniedException unauthorized to get the master key
-   * @throws UnsupportedOperationException If not implemented, or KMS does not support key fetching 
    */
   protected abstract byte[] getMasterKeyFromServer(String masterKeyIdentifier) 
-      throws KeyAccessDeniedException, UnsupportedOperationException;
+      throws KeyAccessDeniedException;
 
   /**
    * Pass configuration with KMS-specific parameters.

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/LocalWrapKmsClient.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/LocalWrapKmsClient.java
@@ -33,8 +33,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static org.apache.parquet.crypto.keytools.KeyToolkit.stringIsEmpty;
-
 public abstract class LocalWrapKmsClient implements KmsClient {
 
   public static final String LOCAL_WRAP_NO_KEY_VERSION = "NO_VERSION";
@@ -144,15 +142,9 @@ public abstract class LocalWrapKmsClient implements KmsClient {
     return KeyToolkit.decryptKeyLocally(encryptedEncodedKey, masterKey, AAD);
   }
 
-  private void refreshToken() {
-    kmsToken = hadoopConfiguration.getTrimmed(KeyToolkit.KEY_ACCESS_TOKEN_PROPERTY_NAME);
-    if (stringIsEmpty(kmsToken)) {
-      throw new ParquetCryptoRuntimeException("Empty token");
-    }
-  }
-
   private byte[] getKeyFromServer(String keyIdentifier) {
-    refreshToken();
+    // refresh token
+    kmsToken = hadoopConfiguration.getTrimmed(KeyToolkit.KEY_ACCESS_TOKEN_PROPERTY_NAME);
     byte[] key = getMasterKeyFromServer(keyIdentifier);
     int keyLength = key.length;
     if (!(16 == keyLength || 24 == keyLength || 32 == keyLength)) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/LocalWrapKmsClient.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/LocalWrapKmsClient.java
@@ -153,7 +153,13 @@ public abstract class LocalWrapKmsClient implements KmsClient {
 
   private byte[] getKeyFromServer(String keyIdentifier) {
     refreshToken();
-    return getMasterKeyFromServer(keyIdentifier);
+    byte[] key = getMasterKeyFromServer(keyIdentifier);
+    int keyLength = key.length;
+    if (!(16 == keyLength || 24 == keyLength || 32 == keyLength)) {
+      throw new ParquetCryptoRuntimeException( "Wrong length: "+ keyLength +
+          " of AES key: "  + keyIdentifier);
+    }
+    return key;
   }
 
   /**

--- a/parquet-hadoop/src/test/java/org/apache/parquet/crypto/TestPropertiesDrivenEncryption.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/crypto/TestPropertiesDrivenEncryption.java
@@ -406,6 +406,10 @@ public class TestPropertiesDrivenEncryption {
   private void testReadEncryptedParquetFiles(Path root, List<SingleRow> data, ExecutorService threadPool) throws IOException {
     readFilesMultithreaded(root, data, threadPool, false/*keysRotated*/);
 
+    if (isWrapLocally) {
+      return; // key rotation is not supported with local key wrapping
+    }
+
     LOG.info("--> Start master key rotation");
     Configuration hadoopConfigForRotation =
       EncryptionConfiguration.ENCRYPT_COLUMNS_AND_FOOTER.getHadoopConfiguration(this);

--- a/parquet-hadoop/src/test/java/org/apache/parquet/crypto/TestPropertiesDrivenEncryption.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/crypto/TestPropertiesDrivenEncryption.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.crypto.keytools.KeyToolkit;
 import org.apache.parquet.crypto.keytools.PropertiesDrivenCryptoFactory;
 import org.apache.parquet.crypto.keytools.mocks.InMemoryKMS;
+import org.apache.parquet.crypto.keytools.mocks.LocalWrapInMemoryKMS;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.hadoop.ParquetReader;
@@ -277,13 +278,16 @@ public class TestPropertiesDrivenEncryption {
     conf.set(EncryptionPropertiesFactory.CRYPTO_FACTORY_CLASS_PROPERTY_NAME,
       PropertiesDrivenCryptoFactory.class.getName());
 
-    conf.set(KeyToolkit.KMS_CLIENT_CLASS_PROPERTY_NAME, InMemoryKMS.class.getName());
+    if (test.isWrapLocally) {
+      conf.set(KeyToolkit.KMS_CLIENT_CLASS_PROPERTY_NAME, LocalWrapInMemoryKMS.class.getName());
+    } else {
+      conf.set(KeyToolkit.KMS_CLIENT_CLASS_PROPERTY_NAME, InMemoryKMS.class.getName());
+    }
     conf.set(InMemoryKMS.KEY_LIST_PROPERTY_NAME, KEY_LIST);
     conf.set(InMemoryKMS.NEW_KEY_LIST_PROPERTY_NAME, NEW_KEY_LIST);
 
     conf.setBoolean(KeyToolkit.KEY_MATERIAL_INTERNAL_PROPERTY_NAME, test.isKeyMaterialInternalStorage);
     conf.setBoolean(KeyToolkit.DOUBLE_WRAPPING_PROPERTY_NAME, test.isDoubleWrapping);
-    conf.setBoolean(KeyToolkit.WRAP_LOCALLY_PROPERTY_NAME, test.isWrapLocally);
     return conf;
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/crypto/keytools/mocks/LocalWrapInMemoryKMS.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/crypto/keytools/mocks/LocalWrapInMemoryKMS.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.crypto.keytools.mocks;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.parquet.crypto.KeyAccessDeniedException;
+import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
+import org.apache.parquet.crypto.keytools.LocalWrapKmsClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a mock class, built for testing only. Don't use it as an example of KmsClient implementation.
+ * (VaultClient is the sample implementation).
+ */
+public class LocalWrapInMemoryKMS extends LocalWrapKmsClient {
+  private static final Logger LOG = LoggerFactory.getLogger(LocalWrapInMemoryKMS.class);
+
+  public static final String KEY_LIST_PROPERTY_NAME = "parquet.encryption.key.list";
+
+  private static Map<String,byte[]> masterKeyMap;
+
+  @Override
+  protected synchronized void initializeInternal() throws KeyAccessDeniedException {
+    // Parse master  keys
+    String[] masterKeys = hadoopConfiguration.getTrimmedStrings(KEY_LIST_PROPERTY_NAME);
+    if (null == masterKeys || masterKeys.length == 0) {
+      throw new ParquetCryptoRuntimeException("No encryption key list");
+    }
+    masterKeyMap = parseKeyList(masterKeys);
+  }
+
+  private static Map<String, byte[]> parseKeyList(String[] masterKeys) {
+    Map<String,byte[]> keyMap = new HashMap<>();
+
+    int nKeys = masterKeys.length;
+    for (int i=0; i < nKeys; i++) {
+      String[] parts = masterKeys[i].split(":");
+      String keyName = parts[0].trim();
+      if (parts.length != 2) {
+        throw new IllegalArgumentException("Key '" + keyName + "' is not formatted correctly");
+      }
+      String key = parts[1].trim();
+      try {
+        byte[] keyBytes = Base64.getDecoder().decode(key);
+        keyMap.put(keyName, keyBytes);
+      } catch (IllegalArgumentException e) {
+        LOG.warn("Could not decode key '" + keyName + "'!");
+        throw e;
+      }
+    }
+    return keyMap;
+  }
+
+  @Override
+  protected synchronized byte[] getMasterKeyFromServer(String masterKeyIdentifier)
+      throws KeyAccessDeniedException, UnsupportedOperationException {
+    return masterKeyMap.get(masterKeyIdentifier);
+  }
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/crypto/keytools/samples/VaultClient.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/crypto/keytools/samples/VaultClient.java
@@ -64,10 +64,6 @@ public class VaultClient implements KmsClient {
   @Override
   public void initialize(Configuration configuration, String kmsInstanceID, String kmsInstanceURL, String accessToken) 
       throws KeyAccessDeniedException {
-    if(configuration.getBoolean(KeyToolkit.WRAP_LOCALLY_PROPERTY_NAME, KeyToolkit.WRAP_LOCALLY_DEFAULT)) {
-      throw new ParquetCryptoRuntimeException("This Vault client doesn't support local wrapping");
-    }
-
     hadoopConfiguration = configuration;
     checkToken(accessToken);
     kmsToken = accessToken;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/crypto/keytools/samples/VaultClient.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/crypto/keytools/samples/VaultClient.java
@@ -25,10 +25,11 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.crypto.KeyAccessDeniedException;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
+import org.apache.parquet.crypto.keytools.KeyToolkit;
 import org.apache.parquet.crypto.keytools.KmsClient;
-import org.apache.parquet.crypto.keytools.RemoteKmsClient;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,8 +43,9 @@ import java.util.Map;
 /**
  * An example of KmsClient implementation. Not for production use!
  */
-public class VaultClient extends RemoteKmsClient {
+public class VaultClient implements KmsClient {
   private static final Logger LOG = LoggerFactory.getLogger(VaultClient.class);
+
   private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
   private static final String DEFAULT_TRANSIT_ENGINE = "/v1/transit/";
   private static final String transitWrapEndpoint = "encrypt/";
@@ -51,16 +53,24 @@ public class VaultClient extends RemoteKmsClient {
   private static final String tokenHeader="X-Vault-Token";
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
+  private String kmsToken;
+  private Configuration hadoopConfiguration;
+
   private String endPointPrefix;
   private OkHttpClient httpClient = new OkHttpClient.Builder()
     .connectionSpecs(Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS))
     .build();
 
   @Override
-  protected void initializeInternal() {
-    if (isDefaultToken) {
-      throw new ParquetCryptoRuntimeException("Vault token not provided");
+  public void initialize(Configuration configuration, String kmsInstanceID, String kmsInstanceURL, String accessToken) 
+      throws KeyAccessDeniedException {
+    if(configuration.getBoolean(KeyToolkit.WRAP_LOCALLY_PROPERTY_NAME, KeyToolkit.WRAP_LOCALLY_DEFAULT)) {
+      throw new ParquetCryptoRuntimeException("This Vault client doesn't support local wrapping");
     }
+
+    hadoopConfiguration = configuration;
+    checkToken(accessToken);
+    kmsToken = accessToken;
 
     if (kmsInstanceURL.equals(KmsClient.KMS_INSTANCE_URL_DEFAULT)) {
       throw new ParquetCryptoRuntimeException("Vault URL not provided");
@@ -82,29 +92,29 @@ public class VaultClient extends RemoteKmsClient {
   }
 
   @Override
-  public String wrapKeyInServer(byte[] dataKey, String masterKeyIdentifier) {
+  public String wrapKey(byte[] keyBytes, String masterKeyIdentifier)
+      throws KeyAccessDeniedException {
+    refreshToken();
     Map<String, String> writeKeyMap = new HashMap<String, String>(1);
-    final String dataKeyStr = Base64.getEncoder().encodeToString(dataKey);
+    final String dataKeyStr = Base64.getEncoder().encodeToString(keyBytes);
     writeKeyMap.put("plaintext", dataKeyStr);
-    String response = getContentFromTransitEngine(endPointPrefix + transitWrapEndpoint, buildPayload(writeKeyMap), masterKeyIdentifier);
+    String response = getContentFromTransitEngine(endPointPrefix + transitWrapEndpoint, 
+        buildPayload(writeKeyMap), masterKeyIdentifier);
     String ciphertext = parseReturn(response, "ciphertext");
     return ciphertext;
   }
 
   @Override
-  public byte[] unwrapKeyInServer(String wrappedKey, String masterKeyIdentifier) {
+  public byte[] unwrapKey(String wrappedKey, String masterKeyIdentifier)
+      throws KeyAccessDeniedException {
+    refreshToken();
     Map<String, String> writeKeyMap = new HashMap<String, String>(1);
     writeKeyMap.put("ciphertext", wrappedKey);
-    String response = getContentFromTransitEngine(endPointPrefix + transitUnwrapEndpoint, buildPayload(writeKeyMap), masterKeyIdentifier);
+    String response = getContentFromTransitEngine(endPointPrefix + transitUnwrapEndpoint, 
+        buildPayload(writeKeyMap), masterKeyIdentifier);
     String plaintext = parseReturn(response, "plaintext");
     final byte[] key = Base64.getDecoder().decode(plaintext);
     return key;
-  }
-
-  @Override
-  protected byte[] getMasterKeyFromServer(String masterKeyIdentifier) {
-    // Vault supports in-server wrapping and unwrapping. No need to fetch master keys.
-    throw new UnsupportedOperationException("Use server wrap/unwrap, instead of fetching master keys (local wrap)");
   }
 
   private String buildPayload(Map<String, String> paramMap) {
@@ -115,6 +125,17 @@ public class VaultClient extends RemoteKmsClient {
       throw new ParquetCryptoRuntimeException("Failed to build payload", e);
     }
     return jsonValue;
+  }
+
+  private void checkToken(String token) {
+    if (null == token || token.isEmpty() || token.equals(KmsClient.KEY_ACCESS_TOKEN_DEFAULT)) {
+      throw new ParquetCryptoRuntimeException("Wrong Vault token : " + token);
+    }
+  }
+
+  private void refreshToken() {
+    kmsToken = hadoopConfiguration.getTrimmed(KeyToolkit.KEY_ACCESS_TOKEN_PROPERTY_NAME);
+    checkToken(kmsToken);
   }
 
   private String getContentFromTransitEngine(String endPoint, String jPayload, String masterKeyIdentifier) {
@@ -150,7 +171,6 @@ public class VaultClient extends RemoteKmsClient {
       }
     }
   }
-
 
   private static String parseReturn(String response, String searchKey) {
     String matchingValue;


### PR DESCRIPTION
1. rename RemoteKmsClient class to LocalWrapKmsClient; it will be used only in rare situations where in-server wrapping in not supported. 

2. this also means the "wrap.locally" property is not needed anymore, making the API slightly simpler.