### PR TITLE
PARQUET-1947: DeprecatedParquetInputFormat in CombineFileInputFormat …

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/mapred/DeprecatedParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/mapred/DeprecatedParquetInputFormat.java
@@ -151,6 +151,7 @@ public class DeprecatedParquetInputFormat<V> extends org.apache.hadoop.mapred.Fi
       }
 
       if (firstRecord) { // key & value are already read.
+        value.set(valueContainer.get());
         firstRecord = false;
         return true;
       }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/DeprecatedInputFormatTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/DeprecatedInputFormatTest.java
@@ -125,7 +125,9 @@ public class DeprecatedInputFormatTest {
     }
   }
 
-  // This is the implementation from cascading 2
+  // This is the RecordReader implementation simulate cascading 2 behavior:
+  // https://github.com/Cascading/cascading/blob/2.6/cascading-hadoop/
+  // src/main/shared/cascading/tap/hadoop/io/CombineFileRecordReaderWrapper.java
   static class CombineFileRecordReaderWrapper<K, V> implements RecordReader<K, V>
   {
     private final RecordReader<K, V> delegate;
@@ -173,7 +175,9 @@ public class DeprecatedInputFormatTest {
     }
   }
 
-  // This is the implementation from cascading 2
+  // This is the InputFormat implementation simulates cascading 2:
+  // https://github.com/Cascading/cascading/blob/2.6/cascading-hadoop/
+  // src/main/shared/cascading/tap/hadoop/Hfs.java#L773
   static class CombinedInputFormat extends CombineFileInputFormat implements Configurable
   {
     private Configuration conf;


### PR DESCRIPTION
…would produce wrong data

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title:
  - https://issues.apache.org/jira/browse/PARQUET-1947

### Tests

- [ ] My PR adds the following unit tests: DeprecatedInputFormatTest.testCombineParquetInputFormat
