### PR TITLE
[PARQUET-1951] Allow different strategies to combine key values when …

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -70,7 +70,7 @@ import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.apache.parquet.hadoop.metadata.DefaultKeyValueMetadataMergeStrategy;
+import org.apache.parquet.hadoop.metadata.StrictKeyValueMetadataMergeStrategy;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.hadoop.metadata.GlobalMetaData;
 import org.apache.parquet.hadoop.metadata.KeyValueMetadataMergeStrategy;
@@ -1292,7 +1292,7 @@ public class ParquetFileWriter {
    */
   @Deprecated
   public static ParquetMetadata mergeMetadataFiles(List<Path> files,  Configuration conf) throws IOException {
-    return mergeMetadataFiles(files, conf, new DefaultKeyValueMetadataMergeStrategy());
+    return mergeMetadataFiles(files, conf, new StrictKeyValueMetadataMergeStrategy());
   }
 
   /**
@@ -1409,7 +1409,7 @@ public class ParquetFileWriter {
    * @return the global meta data for all the footers
    */
   static ParquetMetadata mergeFooters(Path root, List<Footer> footers) {
-    return mergeFooters(root, footers, new DefaultKeyValueMetadataMergeStrategy());
+    return mergeFooters(root, footers, new StrictKeyValueMetadataMergeStrategy());
   }
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ConcatenatingKeyValueMetadataMergeStrategy.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ConcatenatingKeyValueMetadataMergeStrategy.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop.metadata;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ *  Strategy to concatenate if there are multiple values for a given key in metadata.
+ *  Note: use this with caution. This is expected to work only for certain use cases.
+ */
+public class ConcatenatingKeyValueMetadataMergeStrategy implements KeyValueMetadataMergeStrategy {
+  private static final String DEFAULT_DELIMITER = ",";
+  
+  private final String delimiter;
+
+  /**
+   * Default constructor.
+   */
+  public ConcatenatingKeyValueMetadataMergeStrategy() {
+    this.delimiter = DEFAULT_DELIMITER;
+  }
+
+  /**
+   * Constructor to use different delimiter for concatenation.
+   * 
+   * @param delim delimiter char sequence.
+   */
+  public ConcatenatingKeyValueMetadataMergeStrategy(String delim) {
+    this.delimiter = delim;
+  }
+  
+  /**
+   * @param keyValueMetaData the merged app specific metadata
+   */
+  public Map<String, String> merge(Map<String, Set<String>> keyValueMetaData) {
+    Map<String, String> mergedKeyValues = new HashMap<String, String>();
+    for (Map.Entry<String, Set<String>> entry : keyValueMetaData.entrySet()) {
+      mergedKeyValues.put(entry.getKey(), entry.getValue().stream().collect(Collectors.joining(this.delimiter)));
+    }
+    return mergedKeyValues;
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/DefaultKeyValueMetadataMergeStrategy.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/DefaultKeyValueMetadataMergeStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop.metadata;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ *  Default strategy to throw errors in metadata if there are multiple values for a given key in metadata.
+ */
+public class DefaultKeyValueMetadataMergeStrategy implements KeyValueMetadataMergeStrategy {
+  /**
+   * @param keyValueMetaData the merged app specific metadata
+   *
+   * @throws NullPointerException if keyValueMetaData is {@code null}
+   */
+  public Map<String, String> merge(Map<String, Set<String>> keyValueMetaData) {
+    Map<String, String> mergedKeyValues = new HashMap<String, String>();
+    for (Map.Entry<String, Set<String>> entry : keyValueMetaData.entrySet()) {
+      if (entry.getValue().size() > 1) {
+        throw new RuntimeException("could not merge metadata: key " + entry.getKey() + " has conflicting values: " + entry.getValue());
+      }
+      mergedKeyValues.put(entry.getKey(), entry.getValue().iterator().next());
+    }
+    return mergedKeyValues;
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/GlobalMetaData.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/GlobalMetaData.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -87,19 +87,25 @@ public class GlobalMetaData implements Serializable {
    * Will merge the metadata as if it was coming from a single file.
    * (for all part files written together this will always work)
    * If there are conflicting values an exception will be thrown
+   * 
+   * Provided for backward compatibility
    * @return the merged version of this
    */
-  public FileMetaData merge() {
+   public FileMetaData merge() {
+     return merge(new DefaultKeyValueMetadataMergeStrategy());
+   }
+
+  /**
+   * Will merge the metadata as if it was coming from a single file.
+   * (for all part files written together this will always work)
+   * If there are conflicting values an exception will be thrown
+   * @return the merged version of this
+   */
+  public FileMetaData merge(KeyValueMetadataMergeStrategy keyValueMetadataMergeStrategy) {
     String createdByString = createdBy.size() == 1 ?
       createdBy.iterator().next() :
       createdBy.toString();
-    Map<String, String> mergedKeyValues = new HashMap<String, String>();
-    for (Entry<String, Set<String>> entry : keyValueMetaData.entrySet()) {
-      if (entry.getValue().size() > 1) {
-        throw new RuntimeException("could not merge metadata: key " + entry.getKey() + " has conflicting values: " + entry.getValue());
-      }
-      mergedKeyValues.put(entry.getKey(), entry.getValue().iterator().next());
-    }
+    Map<String, String> mergedKeyValues = keyValueMetadataMergeStrategy.merge(keyValueMetaData);
     return new FileMetaData(schema, mergedKeyValues, createdByString);
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/GlobalMetaData.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/GlobalMetaData.java
@@ -21,10 +21,8 @@ package org.apache.parquet.hadoop.metadata;
 import static java.util.Collections.unmodifiableMap;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.parquet.schema.MessageType;
@@ -91,8 +89,8 @@ public class GlobalMetaData implements Serializable {
    * Provided for backward compatibility
    * @return the merged version of this
    */
-   public FileMetaData merge() {
-     return merge(new DefaultKeyValueMetadataMergeStrategy());
+  public FileMetaData merge() {
+     return merge(new StrictKeyValueMetadataMergeStrategy());
    }
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/KeyValueMetadataMergeStrategy.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/KeyValueMetadataMergeStrategy.java
@@ -37,8 +37,6 @@ import static java.util.Collections.unmodifiableMap;
 public interface KeyValueMetadataMergeStrategy extends Serializable {
   /**
    * @param keyValueMetaData the merged app specific metadata
-   *
-   * @throws NullPointerException if keyValueMetaData is {@code null}
    */
   Map<String, String> merge(Map<String, Set<String>> keyValueMetaData);
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/KeyValueMetadataMergeStrategy.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/KeyValueMetadataMergeStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop.metadata;
+
+import org.apache.parquet.schema.MessageType;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+
+import static java.util.Collections.unmodifiableMap;
+
+/**
+ * Strategy to merge metadata. Possible implementations:
+ * 1) Expect metadata to be exactly identical. Otherwise throw error (this is the default strategy implementation)
+ * 2) Custom strategy to merge metadata if the values are not identical. Example: concatenate values.
+ */
+public interface KeyValueMetadataMergeStrategy extends Serializable {
+  /**
+   * @param keyValueMetaData the merged app specific metadata
+   *
+   * @throws NullPointerException if keyValueMetaData is {@code null}
+   */
+  Map<String, String> merge(Map<String, Set<String>> keyValueMetaData);
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/StrictKeyValueMetadataMergeStrategy.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/StrictKeyValueMetadataMergeStrategy.java
@@ -23,13 +23,11 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- *  Default strategy to throw errors in metadata if there are multiple values for a given key in metadata.
+ *  Strategy to throw errors if there are multiple values for a given key in metadata.
  */
-public class DefaultKeyValueMetadataMergeStrategy implements KeyValueMetadataMergeStrategy {
+public class StrictKeyValueMetadataMergeStrategy implements KeyValueMetadataMergeStrategy {
   /**
    * @param keyValueMetaData the merged app specific metadata
-   *
-   * @throws NullPointerException if keyValueMetaData is {@code null}
    */
   public Map<String, String> merge(Map<String, Set<String>> keyValueMetaData) {
     Map<String, String> mergedKeyValues = new HashMap<String, String>();

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -1028,12 +1028,17 @@ public class TestParquetFileWriter {
       keyValues2, "test");
     GlobalMetaData merged = ParquetFileWriter.mergeInto(md2, ParquetFileWriter.mergeInto(md1, null));
     try {
-      merged.merge(new DefaultKeyValueMetadataMergeStrategy());
+      merged.merge(new StrictKeyValueMetadataMergeStrategy());
       fail("Merge metadata is expected to fail because of conflicting key values");
     } catch (RuntimeException e) {
       // expected because of conflicting values
       assertTrue(e.getMessage().contains("could not merge metadata"));
     }
+
+    Map<String, String> mergedKeyValues = merged.merge(new ConcatenatingKeyValueMetadataMergeStrategy()).getKeyValueMetaData();
+    assertEquals(1, mergedKeyValues.size());
+    String mergedValue = mergedKeyValues.get("a");
+    assertTrue(mergedValue.equals("b,c") || mergedValue.equals("c,b"));
   }
 
   @Test
@@ -1055,7 +1060,7 @@ public class TestParquetFileWriter {
         new PrimitiveType(OPTIONAL, BINARY, "b")),
       keyValues2, "test");
     GlobalMetaData merged = ParquetFileWriter.mergeInto(md2, ParquetFileWriter.mergeInto(md1, null));
-    Map<String, String> mergedValues = merged.merge(new DefaultKeyValueMetadataMergeStrategy()).getKeyValueMetaData();
+    Map<String, String> mergedValues = merged.merge(new StrictKeyValueMetadataMergeStrategy()).getKeyValueMetaData();
     assertEquals("b", mergedValues.get("a"));
     assertEquals("d", mergedValues.get("c"));
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -1008,6 +1008,58 @@ public class TestParquetFileWriter {
     }
   }
 
+  @Test
+  public void testMergeMetadataWithConflictingKeyValues() {
+    Map<String, String> keyValues1 = new HashMap<String, String>() {{
+      put("a", "b");
+    }};
+    Map<String, String> keyValues2 = new HashMap<String, String>() {{
+      put("a", "c");
+    }};
+    FileMetaData md1 = new FileMetaData(
+      new MessageType("root1",
+        new PrimitiveType(REPEATED, BINARY, "a"),
+        new PrimitiveType(OPTIONAL, BINARY, "b")),
+     keyValues1, "test");
+    FileMetaData md2 = new FileMetaData(
+      new MessageType("root1",
+        new PrimitiveType(REPEATED, BINARY, "a"),
+        new PrimitiveType(OPTIONAL, BINARY, "b")),
+      keyValues2, "test");
+    GlobalMetaData merged = ParquetFileWriter.mergeInto(md2, ParquetFileWriter.mergeInto(md1, null));
+    try {
+      merged.merge(new DefaultKeyValueMetadataMergeStrategy());
+      fail("Merge metadata is expected to fail because of conflicting key values");
+    } catch (RuntimeException e) {
+      // expected because of conflicting values
+      assertTrue(e.getMessage().contains("could not merge metadata"));
+    }
+  }
+
+  @Test
+  public void testMergeMetadataWithNoConflictingKeyValues() {
+    Map<String, String> keyValues1 = new HashMap<String, String>() {{
+      put("a", "b");
+    }};
+    Map<String, String> keyValues2 = new HashMap<String, String>() {{
+      put("c", "d");
+    }};
+    FileMetaData md1 = new FileMetaData(
+      new MessageType("root1",
+        new PrimitiveType(REPEATED, BINARY, "a"),
+        new PrimitiveType(OPTIONAL, BINARY, "b")),
+      keyValues1, "test");
+    FileMetaData md2 = new FileMetaData(
+      new MessageType("root1",
+        new PrimitiveType(REPEATED, BINARY, "a"),
+        new PrimitiveType(OPTIONAL, BINARY, "b")),
+      keyValues2, "test");
+    GlobalMetaData merged = ParquetFileWriter.mergeInto(md2, ParquetFileWriter.mergeInto(md1, null));
+    Map<String, String> mergedValues = merged.merge(new DefaultKeyValueMetadataMergeStrategy()).getKeyValueMetaData();
+    assertEquals("b", mergedValues.get("a"));
+    assertEquals("d", mergedValues.get("c"));
+  }
+
   private org.apache.parquet.column.statistics.Statistics<?> statsC1(Binary... values) {
     org.apache.parquet.column.statistics.Statistics<?> stats = org.apache.parquet.column.statistics.Statistics
         .createStats(C1.getPrimitiveType());

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/MergeCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/MergeCommand.java
@@ -26,12 +26,12 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.apache.parquet.hadoop.metadata.DefaultKeyValueMetadataMergeStrategy;
-import org.apache.parquet.hadoop.metadata.KeyValueMetadataMergeStrategy;
-import org.apache.parquet.hadoop.util.HadoopInputFile;
-import org.apache.parquet.hadoop.util.HiddenFileFilter;
 import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.hadoop.metadata.KeyValueMetadataMergeStrategy;
+import org.apache.parquet.hadoop.metadata.StrictKeyValueMetadataMergeStrategy;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.apache.parquet.hadoop.util.HiddenFileFilter;
 import org.apache.parquet.tools.Main;
 
 import java.io.IOException;
@@ -46,7 +46,7 @@ public class MergeCommand extends ArgsOnlyCommand {
           "   <output> is the destination parquet file"
   };
 
-  private static final String DEFAULT_KEY_VALUE_MERGE_STRATEGY = new DefaultKeyValueMetadataMergeStrategy().getClass().getName();
+  private static final String DEFAULT_KEY_VALUE_MERGE_STRATEGY = StrictKeyValueMetadataMergeStrategy.class.getName();
   public static final Options OPTIONS;
 
   static {

--- a/parquet-tools/src/main/java/org/apache/parquet/tools/command/MergeCommand.java
+++ b/parquet-tools/src/main/java/org/apache/parquet/tools/command/MergeCommand.java
@@ -38,7 +38,9 @@ import org.apache.parquet.tools.Main;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class MergeCommand extends ArgsOnlyCommand {
   public static final String[] USAGE = new String[] {
@@ -57,11 +59,12 @@ public class MergeCommand extends ArgsOnlyCommand {
 
   static {
     OPTIONS = new Options();
+    String availableStrategies = Arrays.stream(MergeStrategy.values()).map(Enum::name).collect(Collectors.joining(", "));
     Option mergeStrategy = Option.builder("s")
       .longOpt("mergeStrategy")
-      .desc("Strategy to merge (key, value) pairs in metadata if there are multiple values for same key " +
-        "(default: " + MergeStrategy.STRICT + "). You can provide your custom implementation by specifying " +
-        MergeStrategy.CUSTOM)
+      .desc("Strategy to merge (key, value) pairs in metadata if there are multiple values for same key. " +
+        "Available strategies: " + availableStrategies.toLowerCase() + ". (default: '" + MergeStrategy.STRICT.name().toLowerCase() + "')." +
+        " You can provide your custom implementation by specifying '" + MergeStrategy.CUSTOM.name().toLowerCase() + "' strategy.")
       .optionalArg(true)
       .build();
     


### PR DESCRIPTION
…merging parquet files

### Jira

- [ X] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET-1951) issues and references them in the PR title.

### Tests

- [X ] My PR adds the following unit tests: TestParquetFileWriter#testMergeMetadataWithNoConflictingKeyValues, and testMergeMetadataWithConflictingKeyValues

### Commits

- [ X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
