### PR TITLE
PARQUET-1963: DeprecatedParquetInputFormat in CombineFileInputFormat …

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/mapred/DeprecatedParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/mapred/DeprecatedParquetInputFormat.java
@@ -100,9 +100,9 @@ public class DeprecatedParquetInputFormat<V> extends org.apache.hadoop.mapred.Fi
         }
 
         // read once to gain access to key and value objects
+        valueContainer = new Container<V>();
         if (realReader.nextKeyValue()) {
           firstRecord = true;
-          valueContainer = new Container<V>();
           valueContainer.set(realReader.getCurrentValue());
 
         } else {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/DeprecatedInputFormatTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/DeprecatedInputFormatTest.java
@@ -213,7 +213,9 @@ public class DeprecatedInputFormatTest {
     File outputFile = File.createTempFile("temp", null);
     outputFile.delete();
     PrintWriter pw = new PrintWriter(new FileWriter(inputFile));
-    pw.println(content);
+    if (content != null) {
+      pw.println(content);
+    }
     pw.close();
     writeJob = new Job(conf, "write");
 
@@ -239,10 +241,12 @@ public class DeprecatedInputFormatTest {
     File inputDir = File.createTempFile("temp", null);
     inputDir.delete();
     inputDir.mkdirs();
-    File parquetFile1 = createParquetFile("hello");
-    File parquetFile2 = createParquetFile("world");
+    File parquetFile1 = createParquetFile(null);
+    File parquetFile2 = createParquetFile("hello");
+    File parquetFile3 = createParquetFile("world");
     Files.move(parquetFile1.toPath(), new File(inputDir, "1").toPath());
     Files.move(parquetFile2.toPath(), new File(inputDir, "2").toPath());
+    Files.move(parquetFile3.toPath(), new File(inputDir, "3").toPath());
 
     File outputDir = File.createTempFile("temp", null);
     outputDir.delete();


### PR DESCRIPTION
…throw NPE when the first sub-split is empty

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1963
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
