### PR TITLE
PARQUET-1973: Support ZSTD JNI BufferPool

### DIFF
--- a/parquet-hadoop/README.md
+++ b/parquet-hadoop/README.md
@@ -338,8 +338,8 @@ ParquetInputFormat to materialize records. It should be a the descendant class o
 
 ## Class: ZstandardCodec
 
-**Property:** `parquet.compression.codec.zstd.bufferPool.enabled`
-**Description:** If it is true, [RecyclingBufferPool](https://github.com/luben/zstd-jni/blob/master/src/main/java/com/github/luben/zstd/RecyclingBufferPool.java) is used.
+**Property:** `parquet.compression.codec.zstd.bufferPool.enabled`  
+**Description:** If it is true, [RecyclingBufferPool](https://github.com/luben/zstd-jni/blob/master/src/main/java/com/github/luben/zstd/RecyclingBufferPool.java) is used.  
 **Default value:** `false`
 
 ---

--- a/parquet-hadoop/README.md
+++ b/parquet-hadoop/README.md
@@ -338,6 +338,12 @@ ParquetInputFormat to materialize records. It should be a the descendant class o
 
 ## Class: ZstandardCodec
 
+**Property:** `parquet.compression.codec.zstd.bufferPool.enabled`
+**Description:** If it is true, [RecyclingBufferPool](https://github.com/luben/zstd-jni/blob/master/src/main/java/com/github/luben/zstd/RecyclingBufferPool.java) is used.
+**Default value:** `false`
+
+---
+
 **Property:** `parquet.compression.codec.zstd.level`  
 **Description:** The compression level of ZSTD. The valid range is 1~22. Generally the higher compression level, the higher compression ratio can be achieved, but the writing time will be longer.  
 **Default value:** `3`

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/ZstdCompressorStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/ZstdCompressorStream.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.hadoop.codec;
 
+import com.github.luben.zstd.BufferPool;
 import com.github.luben.zstd.ZstdOutputStream;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 
@@ -32,6 +33,13 @@ public class ZstdCompressorStream extends CompressionOutputStream {
 	    super(stream);
 	    zstdOutputStream = new ZstdOutputStream(stream, level);
 	    zstdOutputStream.setWorkers(workers);
+  }
+
+  public ZstdCompressorStream(OutputStream stream, BufferPool pool, int level, int workers) throws IOException {
+    super(stream);
+    zstdOutputStream = new ZstdOutputStream(stream, pool);
+    zstdOutputStream.setLevel(level);
+    zstdOutputStream.setWorkers(workers);
   }
 
   public void write(byte[] b, int off, int len) throws IOException {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/ZstdDecompressorStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/ZstdDecompressorStream.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.hadoop.codec;
 
+import com.github.luben.zstd.BufferPool;
 import com.github.luben.zstd.ZstdInputStream;
 import org.apache.hadoop.io.compress.CompressionInputStream;
 
@@ -31,6 +32,11 @@ public class ZstdDecompressorStream extends CompressionInputStream {
   public ZstdDecompressorStream(InputStream stream) throws IOException {
 	  super(stream);
     zstdInputStream = new ZstdInputStream(stream);
+  }
+
+  public ZstdDecompressorStream(InputStream stream, BufferPool pool) throws IOException {
+    super(stream);
+    zstdInputStream = new ZstdInputStream(stream, pool);
   }
 
   public int read(byte[] b, int off, int len) throws IOException {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestZstandardCodec.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestZstandardCodec.java
@@ -18,6 +18,9 @@
  */
 package org.apache.parquet.hadoop;
 
+import com.github.luben.zstd.BufferPool;
+import com.github.luben.zstd.NoPool;
+import com.github.luben.zstd.RecyclingBufferPool;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -56,14 +59,18 @@ public class TestZstandardCodec {
   public void testZstdCodec() throws IOException {
     ZstandardCodec codec = new ZstandardCodec();
     Configuration conf = new Configuration();
+    boolean[] pools = {false, true};
     int[] levels = {1, 4, 7, 10, 13, 16, 19, 22};
     int[] dataSizes = {0, 1, 10, 1024, 1024 * 1024};
 
-    for (int i = 0; i < levels.length; i++) {
-      conf.setInt(ZstandardCodec.PARQUET_COMPRESS_ZSTD_LEVEL, levels[i]);
-      codec.setConf(conf);
-      for (int j = 0; j < dataSizes.length; j++) {
-        testZstd(codec, dataSizes[j]);
+    for (boolean pool: pools) {
+      for (int i = 0; i < levels.length; i++) {
+        conf.setBoolean(ZstandardCodec.PARQUET_COMPRESS_ZSTD_BUFFERPOOL_ENABLED, pool);
+        conf.setInt(ZstandardCodec.PARQUET_COMPRESS_ZSTD_LEVEL, levels[i]);
+        codec.setConf(conf);
+        for (int j = 0; j < dataSizes.length; j++) {
+          testZstd(codec, dataSizes[j]);
+        }
       }
     }
   }


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1973
  - This PR aims to add `parquet.compression.codec.zstd.bufferPool.enabled` to support ZSTD JNI's BufferPool feature.

| Version | Description | Commit |
| ---------- | --------------- | ----------- |
| v1.4.5-7 | `BufferPool` was added and used it by default | https://github.com/luben/zstd-jni/commit/4f55c8917216518d7390eb0624bee3bf0e2c491a |
| v1.4.5-8 | `RecyclingBufferPool` was added and `BufferPool` became an interface to allow custom BufferPool implementation | https://github.com/luben/zstd-jni/commit/dd2588edd302823fa534de1516e4ae6d6dc6417e |
| v1.4.7+ | `NoPool` is used by default and user should specify buffer pool explicitly | https://github.com/luben/zstd-jni/commit/f7c8279bc162c8c8b1964948d0f3b309ad715311 |

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
