### PR TITLE
PARQUET-1975 Disable BrotliCodec for non-x86_64

### DIFF
--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -98,12 +98,6 @@
       <version>${fastutil.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.rdblue</groupId>
-      <artifactId>brotli-codec</artifactId>
-      <version>${brotli-codec.version}</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>
       <version>${zstd-jni.version}</version>
@@ -151,5 +145,24 @@
     </plugins>
   </build>
 
+  <profiles>
+    <!-- PARQUET-1975 Do not add brotli-codec for non-x86_64 architectures -->
+    <profile>
+      <id>x86_64</id>
+      <activation>
+        <os>
+          <arch>amd64</arch>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.github.rdblue</groupId>
+          <artifactId>brotli-codec</artifactId>
+          <version>${brotli-codec.version}</version>
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
 </project>

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -146,12 +146,12 @@
   </build>
 
   <profiles>
-    <!-- PARQUET-1975 Do not add brotli-codec for non-x86_64 architectures -->
+    <!-- PARQUET-1975 Do not add brotli-codec for ARM64 architectures -->
     <profile>
-      <id>x86_64</id>
+      <id>non-aarch64</id>
       <activation>
         <os>
-          <arch>amd64</arch>
+          <arch>!aarch64</arch>
         </os>
       </activation>
       <dependencies>

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDirectCodecFactory.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDirectCodecFactory.java
@@ -39,7 +39,7 @@ import static org.apache.parquet.hadoop.metadata.CompressionCodecName.ZSTD;
 
 public class TestDirectCodecFactory {
 
-  private static enum Decompression {
+  private enum Decompression {
     ON_HEAP, OFF_HEAP, OFF_HEAP_BYTES_INPUT
   }
 
@@ -150,13 +150,18 @@ public class TestDirectCodecFactory {
   }
 
   @Test
-  public void compressionCodecs() throws Exception {
+  public void compressionCodecs() {
     final int[] sizes = { 4 * 1024, 1 * 1024 * 1024 };
     final boolean[] comp = { true, false };
     Set<CompressionCodecName> codecsToSkip = new HashSet<>();
     codecsToSkip.add(LZO); // not distributed because it is GPL
     codecsToSkip.add(LZ4); // not distributed in the default version of Hadoop
     codecsToSkip.add(ZSTD); // not distributed in the default version of Hadoop
+    final String arch = System.getProperty("os.arch");
+    if (!"amd64".equals(arch)) {
+      // PARQUET-1975 brotli-codec does not have natives for non-x86_64 architectures
+      codecsToSkip.add(BROTLI);
+    }
 
     for (final int size : sizes) {
       for (final boolean useOnHeapComp : comp) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDirectCodecFactory.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDirectCodecFactory.java
@@ -158,8 +158,8 @@ public class TestDirectCodecFactory {
     codecsToSkip.add(LZ4); // not distributed in the default version of Hadoop
     codecsToSkip.add(ZSTD); // not distributed in the default version of Hadoop
     final String arch = System.getProperty("os.arch");
-    if (!"amd64".equals(arch)) {
-      // PARQUET-1975 brotli-codec does not have natives for non-x86_64 architectures
+    if ("aarch64".equals(arch)) {
+      // PARQUET-1975 brotli-codec does not have natives for ARM64 architectures
       codecsToSkip.add(BROTLI);
     }
 


### PR DESCRIPTION
BrotliCodec fails to load on non-x86_64 CPU architectures because MeteoGroup/jbrotli does not provide native binaries
With this change brotli-codec is added as a dependency to parquet-hadoop only for amd64, i.e. x86_64