### PR TITLE
PARQUET-1988: Upgrade to ZSTD 1.4.8-6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <!-- parquet-cli dependencies -->
     <opencsv.version>2.3</opencsv.version>
     <jcommander.version>1.72</jcommander.version>
-    <zstd-jni.version>1.4.8-3</zstd-jni.version>
+    <zstd-jni.version>1.4.8-5</zstd-jni.version>
     <commons-text.version>1.8</commons-text.version>
 
     <!-- properties for the profiles -->

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <!-- parquet-cli dependencies -->
     <opencsv.version>2.3</opencsv.version>
     <jcommander.version>1.72</jcommander.version>
-    <zstd-jni.version>1.4.8-5</zstd-jni.version>
+    <zstd-jni.version>1.4.8-6</zstd-jni.version>
     <commons-text.version>1.8</commons-text.version>
 
     <!-- properties for the profiles -->


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

This PR aims to update ZSTD JNI library from 1.4.8-3 to 1.4.8-6 to bring the following improvements.
- https://github.com/luben/zstd-jni/commit/be51ebade15cbd4939a46581070836cc56e23ae6 (Simpler and more optimized `RecyclingBufferPool`)
- https://github.com/luben/zstd-jni/commit/44ff8b6f958bfcd75e187c6a51acf324a481cbe1 (Use pooled buffers also for `InputStream.skip(n)`)

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1988

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
   This is a dependency update and should pass all the existing UTs.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
