### PR TITLE
PARQUET-1992: Move submodules update to ci-test profile and encryption interop test to maven integration-test phase

### DIFF
--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/ITTestEncryptionOptions.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/ITTestEncryptionOptions.java
@@ -19,6 +19,8 @@
 package org.apache.parquet.hadoop;
 
 import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.ErrorCollector;
 
 import java.io.IOException;
 
@@ -30,12 +32,14 @@ import java.io.IOException;
  * For a full description and the actual implementation see TestEncryptionOptions.
  */
 public class ITTestEncryptionOptions {
+  @Rule
+  public ErrorCollector errorCollector = new ErrorCollector();
 
   TestEncryptionOptions test = new TestEncryptionOptions();
 
   @Test
   public void testInteropReadEncryptedParquetFiles() throws IOException {
-    test.testInteropReadEncryptedParquetFiles();
+    test.testInteropReadEncryptedParquetFiles(errorCollector);
   }
 
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/ITTestEncryptionOptions.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/ITTestEncryptionOptions.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/*
+ * This file continues the testing in TestEncryptionOptions. This test goals:
+ * 4) Perform interoperability tests with other (eg parquet-cpp) writers, by reading
+ *    encrypted files produced by these writers.
+ *
+ * For a full description and the actual implementation see TestEncryptionOptions.
+ */
+public class ITTestEncryptionOptions {
+
+  TestEncryptionOptions test = new TestEncryptionOptions();
+
+  @Test
+  public void testInteropReadEncryptedParquetFiles() throws IOException {
+    test.testInteropReadEncryptedParquetFiles();
+  }
+
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestEncryptionOptions.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestEncryptionOptions.java
@@ -121,7 +121,8 @@ public class TestEncryptionOptions {
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Rule
-  public ErrorCollector errorCollector = new ErrorCollector();
+  public ErrorCollector localErrorCollector = new ErrorCollector();
+  private ErrorCollector errorCollector;
 
   private static String PARQUET_TESTING_PATH = "../submodules/parquet-testing/data";
 
@@ -288,6 +289,7 @@ public class TestEncryptionOptions {
 
   @Test
   public void testWriteReadEncryptedParquetFiles() throws IOException {
+    this.errorCollector = localErrorCollector;
     Path rootPath = new Path(temporaryFolder.getRoot().getPath());
     LOG.info("======== testWriteReadEncryptedParquetFiles {} ========", rootPath.toString());
     byte[] AADPrefix = AAD_PREFIX_STRING.getBytes(StandardCharsets.UTF_8);
@@ -297,7 +299,8 @@ public class TestEncryptionOptions {
     testReadEncryptedParquetFiles(rootPath, DATA);
   }
 
-  public void testInteropReadEncryptedParquetFiles() throws IOException {
+  public void testInteropReadEncryptedParquetFiles(ErrorCollector errorCollector) throws IOException {
+    this.errorCollector = errorCollector;
     Path rootPath = new Path(PARQUET_TESTING_PATH);
     LOG.info("======== testInteropReadEncryptedParquetFiles {} ========", rootPath.toString());
     byte[] AADPrefix = AAD_PREFIX_STRING.getBytes(StandardCharsets.UTF_8);

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestEncryptionOptions.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestEncryptionOptions.java
@@ -64,8 +64,6 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
  *    readers that support encryption.
  * 3) Produce encrypted files with plaintext footer, for testing the ability of legacy
  *    readers to parse the footer and read unencrypted columns.
- * 4) Perform interoperability tests with other (eg parquet-cpp) writers, by reading
- *    encrypted files produced by these writers.
  *
  * The write sample produces number of parquet files, each encrypted with a different
  * encryption configuration as described below.
@@ -299,7 +297,6 @@ public class TestEncryptionOptions {
     testReadEncryptedParquetFiles(rootPath, DATA);
   }
 
-  @Test
   public void testInteropReadEncryptedParquetFiles() throws IOException {
     Path rootPath = new Path(PARQUET_TESTING_PATH);
     LOG.info("======== testInteropReadEncryptedParquetFiles {} ========", rootPath.toString());

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
     <!-- scala.binary.version is used for projects that fetch dependencies that are in scala -->
     <scala.binary.version>2.12</scala.binary.version>
     <skip.integration.tests>true</skip.integration.tests>
-    <skip.unit.tests>false</skip.unit.tests>
     <scala.maven.test.skip>false</scala.maven.test.skip>
     <scrooge.verion>19.10.0</scrooge.verion>
     <pig.version>0.16.0</pig.version>
@@ -412,8 +411,6 @@
             <!-- Configure log level for Hadoop -->
             <hadoop.logLevel>${surefire.logLevel}</hadoop.logLevel>
           </systemPropertyVariables>
-          <!-- Skips unit tests if the value of skip.unit.tests property is true -->
-          <skipTests>${skip.unit.tests}</skipTests>
           <excludes>
             <exclude>**/benchmark/*.java</exclude>
             <exclude>**/IT*.java</exclude>
@@ -598,45 +595,15 @@
       </properties>
     </profile>
 
-    <!-- Profile for CI tests to have less output -->
+    <!-- Profile for CI tests to have less output and initialize
+    or update submodules needed for integration tests -->
     <profile>
       <id>ci-test</id>
       <properties>
         <surefire.logLevel>WARN</surefire.logLevel>
         <surefire.argLine>-Xmx512m -XX:MaxJavaStackTraceDepth=10</surefire.argLine>
-      </properties>
-    </profile>
-
-    <profile>
-      <id>jdk9+</id>
-      <activation>
-        <jdk>[1.9,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <release>8</release>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>integration-test</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <properties>
-        <!--
-            Only integration tests are run when the integration-test profile is active
-        -->
         <skip.integration.tests>false</skip.integration.tests>
-        <skip.unit.tests>true</skip.unit.tests>
       </properties>
-
       <build>
         <pluginManagement>
           <plugins>
@@ -665,6 +632,24 @@
             </plugin>
           </plugins>
         </pluginManagement>
+      </build>
+    </profile>
+
+    <profile>
+      <id>jdk9+</id>
+      <activation>
+        <jdk>[1.9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <release>8</release>
+            </configuration>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,6 @@
           </systemPropertyVariables>
           <excludes>
             <exclude>**/benchmark/*.java</exclude>
-            <exclude>**/IT*.java</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,8 @@
     <scala.version>2.12.8</scala.version>
     <!-- scala.binary.version is used for projects that fetch dependencies that are in scala -->
     <scala.binary.version>2.12</scala.binary.version>
+    <skip.integration.tests>true</skip.integration.tests>
+    <skip.unit.tests>false</skip.unit.tests>
     <scala.maven.test.skip>false</scala.maven.test.skip>
     <scrooge.verion>19.10.0</scrooge.verion>
     <pig.version>0.16.0</pig.version>
@@ -213,30 +215,6 @@
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>exec-maven-plugin</artifactId>
-          <version>${exec-maven-plugin.version}</version>
-          <executions>
-            <execution>
-              <id>git submodule update</id>
-              <phase>initialize</phase>
-              <configuration>
-                <executable>git</executable>
-                <arguments>
-                  <argument>submodule</argument>
-                  <argument>update</argument>
-                  <argument>--init</argument>
-                  <argument>--recursive</argument>
-                </arguments>
-              </configuration>
-              <goals>
-                <goal>exec</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-
         <plugin>
           <!-- Disable the source artifact from ASF parent -->
           <artifactId>maven-assembly-plugin</artifactId>
@@ -434,8 +412,11 @@
             <!-- Configure log level for Hadoop -->
             <hadoop.logLevel>${surefire.logLevel}</hadoop.logLevel>
           </systemPropertyVariables>
+          <!-- Skips unit tests if the value of skip.unit.tests property is true -->
+          <skipTests>${skip.unit.tests}</skipTests>
           <excludes>
             <exclude>**/benchmark/*.java</exclude>
+            <exclude>**/IT*.java</exclude>
           </excludes>
         </configuration>
       </plugin>
@@ -643,6 +624,48 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>integration-test</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <!--
+            Only integration tests are run when the integration-test profile is active
+        -->
+        <skip.integration.tests>false</skip.integration.tests>
+        <skip.unit.tests>true</skip.unit.tests>
+      </properties>
 
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>exec-maven-plugin</artifactId>
+              <version>${exec-maven-plugin.version}</version>
+              <executions>
+                <execution>
+                  <id>git submodule update</id>
+                  <phase>initialize</phase>
+                  <configuration>
+                    <executable>git</executable>
+                    <arguments>
+                      <argument>submodule</argument>
+                      <argument>update</argument>
+                      <argument>--init</argument>
+                      <argument>--recursive</argument>
+                    </arguments>
+                  </configuration>
+                  <goals>
+                    <goal>exec</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,6 @@
     <scala.version>2.12.8</scala.version>
     <!-- scala.binary.version is used for projects that fetch dependencies that are in scala -->
     <scala.binary.version>2.12</scala.binary.version>
-    <skip.integration.tests>true</skip.integration.tests>
     <scala.maven.test.skip>false</scala.maven.test.skip>
     <scrooge.verion>19.10.0</scrooge.verion>
     <pig.version>0.16.0</pig.version>
@@ -601,7 +600,6 @@
       <properties>
         <surefire.logLevel>WARN</surefire.logLevel>
         <surefire.argLine>-Xmx512m -XX:MaxJavaStackTraceDepth=10</surefire.argLine>
-        <skip.integration.tests>false</skip.integration.tests>
       </properties>
       <build>
         <pluginManagement>


### PR DESCRIPTION
This PR is one of the options to solve the problem "Cannot build from tarball because of git submodules".
1. encryption interop tests run separately from unit tests - in integration-test phase
2. Files for interop tests are downloaded using git submodules in ci-test maven profile only

- `mvn package` - doesn't run interop tests
- `mvn verify/install` - runs interop tests, fails if submodule files are not there
- `mvn verify/install -P ci-test` - update git submodules and then run interop test, fail if not inside git repo, e.g. if it's a tarball