### PR TITLE
PARQUET-1994: Upgrade ZSTD JNI to 1.4.9-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <!-- parquet-cli dependencies -->
     <opencsv.version>2.3</opencsv.version>
     <jcommander.version>1.72</jcommander.version>
-    <zstd-jni.version>1.4.8-6</zstd-jni.version>
+    <zstd-jni.version>1.4.9-1</zstd-jni.version>
     <commons-text.version>1.8</commons-text.version>
 
     <!-- properties for the profiles -->


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

ZStandard 1.4.9 and its corresponding JNI brings the following bug fixes and improvements.

- https://github.com/facebook/zstd/releases/tag/v1.4.9

One of notable improvement of ZStandard 1.4.9 is 2x faster Long Distance Mode, but we are not using it yet.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1994
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Since this is a dependency update, this should pass the existing CIs.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
