### PR TITLE
PARQUET-2012 Mark ProtoParquetWriter constructors deprecated

### DIFF
--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
@@ -44,8 +44,9 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
    * @param pageSize             See parquet write up. Blocks are subdivided into pages for alignment and other purposes.
    * @throws IOException if there is an error while writing
    *
-   * @deprecated will be removed in 2.0.0.; Used ProtoParquetWriter.Builder instead
+   * @deprecated will be removed in 2.0.0.; Use ProtoParquetWriter.Builder instead
    */
+  @Deprecated
   public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage,
                             CompressionCodecName compressionCodecName, int blockSize,
                             int pageSize) throws IOException {
@@ -65,8 +66,9 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
    * @param validating           to turn on validation using the schema
    * @throws IOException if there is an error while writing
    *
-   * @deprecated will be removed in 2.0.0.; Used ProtoParquetWriter.Builder instead
+   * @deprecated will be removed in 2.0.0.; Use ProtoParquetWriter.Builder instead
    */
+  @Deprecated
   public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage,
                             CompressionCodecName compressionCodecName, int blockSize,
                             int pageSize, boolean enableDictionary, boolean validating) throws IOException {
@@ -82,8 +84,9 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
    * @param protoMessage         Protobuf message class
    * @throws IOException if there is an error while writing
    *
-   * @deprecated will be removed in 2.0.0.; Used ProtoParquetWriter.Builder instead
+   * @deprecated will be removed in 2.0.0.; Use ProtoParquetWriter.Builder instead
    */
+  @Deprecated
   public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage) throws IOException {
     this(file, protoMessage, CompressionCodecName.UNCOMPRESSED,
             DEFAULT_BLOCK_SIZE, DEFAULT_PAGE_SIZE);

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
@@ -43,6 +43,8 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
    * @param blockSize            HDFS block size
    * @param pageSize             See parquet write up. Blocks are subdivided into pages for alignment and other purposes.
    * @throws IOException if there is an error while writing
+   *
+   * @deprecated will be removed in 2.0.0.; Used ProtoParquetWriter.Builder instead
    */
   public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage,
                             CompressionCodecName compressionCodecName, int blockSize,
@@ -62,6 +64,8 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
    * @param enableDictionary     Whether to use a dictionary to compress columns.
    * @param validating           to turn on validation using the schema
    * @throws IOException if there is an error while writing
+   *
+   * @deprecated will be removed in 2.0.0.; Used ProtoParquetWriter.Builder instead
    */
   public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage,
                             CompressionCodecName compressionCodecName, int blockSize,
@@ -77,12 +81,13 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
    * @param file The file name to write to.
    * @param protoMessage         Protobuf message class
    * @throws IOException if there is an error while writing
+   *
+   * @deprecated will be removed in 2.0.0.; Used ProtoParquetWriter.Builder instead
    */
   public ProtoParquetWriter(Path file, Class<? extends Message> protoMessage) throws IOException {
     this(file, protoMessage, CompressionCodecName.UNCOMPRESSED,
             DEFAULT_BLOCK_SIZE, DEFAULT_PAGE_SIZE);
   }
-  
   public static <T> Builder<T> builder(Path file) {
 	    return new Builder<T>(file);
 	}
@@ -90,13 +95,10 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
 	public static <T> Builder<T> builder(OutputFile file) {
 	    return new Builder<T>(file);
 	}
-	
 	private static <T extends MessageOrBuilder> WriteSupport<T> writeSupport(Class<? extends Message> protoMessage) {
-		return new ProtoWriteSupport<T>(protoMessage);
+		return new ProtoWriteSupport<>(protoMessage);
 	}
-	  
 	public static class Builder<T> extends ParquetWriter.Builder<T, Builder<T>> {
-		  
 		Class<? extends Message> protoMessage = null;
 
 		private Builder(Path file) {
@@ -110,7 +112,6 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
 		protected Builder<T> self() {
 		    return this;
 		}
-		
 		public Builder<T> withMessage(Class<? extends Message> protoMessage){
 			this.protoMessage = protoMessage;
 			return this;
@@ -118,6 +119,6 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
 
 		protected WriteSupport<T> getWriteSupport(Configuration conf) {
 		    return (WriteSupport<T>) ProtoParquetWriter.writeSupport(protoMessage);
-		}    
+		}
 	}
 }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/TestUtils.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/TestUtils.java
@@ -26,6 +26,7 @@ import com.twitter.elephantbird.util.Protobufs;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.InputFile;
 
@@ -46,9 +47,7 @@ public class TestUtils {
   }
 
   public static <T extends MessageOrBuilder> List<T> writeAndRead(T... records) throws IOException {
-    Class<? extends Message> cls = inferRecordsClass(records);
-
-    Path file = writeMessages(cls, records);
+    Path file = writeMessages(records);
 
     return readMessages(file);
   }
@@ -198,14 +197,11 @@ public class TestUtils {
    * Writes messages to temporary file and returns its path.
    */
   public static Path writeMessages(MessageOrBuilder... records) throws IOException {
-    return writeMessages(inferRecordsClass(records), records);
-  }
-
-  public static Path writeMessages(Class<? extends Message> cls, MessageOrBuilder... records) throws IOException {
     Path file = someTemporaryFilePath();
+    Class<? extends Message> cls = inferRecordsClass(records);
 
-    ProtoParquetWriter<MessageOrBuilder> writer =
-            new ProtoParquetWriter<MessageOrBuilder>(file, cls);
+    ParquetWriter<MessageOrBuilder> writer =
+      ProtoParquetWriter.<MessageOrBuilder>builder(file).withMessage(cls).build();
 
     for (MessageOrBuilder record : records) {
       writer.write(record);


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET-2012) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2012

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
