### PR TITLE
PARQUET-2023 Do not pipe the mvn output to pv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ install:
   - sudo apt-get install -qq maven
   - java -version
   - mvn -version
-  - mvn install --quiet --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true
+  - travis_wait 60 mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true -Dorg.slf4j.simpleLogger.logFile=mvn-install.log
   
-script: mvn verify --quiet --batch-mode javadoc:javadoc -P ci-test,$HADOOP_PROFILE
+script: travis_wait 60 mvn verify --batch-mode javadoc:javadoc -P ci-test,$HADOOP_PROFILE -Dorg.slf4j.simpleLogger.logFile=mvn-verify.log
+
+after_failure:
+  - cat mvn-install.log
+  - cat mvn-verify.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,6 @@ install:
   - sudo apt-get install -qq maven
   - java -version
   - mvn -version
-  - mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true | pv -fbi 60 > mvn_install.log || (cat mvn_install.log && false)
+  - mvn install --quiet --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true
   
-script: mvn verify --batch-mode javadoc:javadoc -P ci-test,$HADOOP_PROFILE | pv -fbi 60 > mvn_verify.log || (cat mvn_verify.log && false)
+script: mvn verify --quiet --batch-mode javadoc:javadoc -P ci-test,$HADOOP_PROFILE


### PR DESCRIPTION
Piping to pv looses the exit status of mvn and the builds never fail

Run mvn in quiet mode to prevent Travis error because of too much output

Make sure you have checked _all_ steps below.

### Jira

https://issues.apache.org/jira/browse/PARQUET-2023

### Tests

No modifications to the source code. Only to the CI config.

### Commits

- [ X ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

No new functionality!