### PR TITLE
PARQUET-2051: AvroWriteSupport Doesn't Pass Configuration to AvroSchemaConverter During Init

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
@@ -127,7 +127,7 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
   public WriteContext init(Configuration configuration) {
     if (rootAvroSchema == null) {
       this.rootAvroSchema = new Schema.Parser().parse(configuration.get(AVRO_SCHEMA));
-      this.rootSchema = new AvroSchemaConverter().convert(rootAvroSchema);
+      this.rootSchema = new AvroSchemaConverter(configuration).convert(rootAvroSchema);
     }
 
     if (model == null) {

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroWriteSupport.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroWriteSupport.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.avro;
+
+import com.google.common.io.Resources;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.hadoop.api.WriteSupport;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class TestAvroWriteSupport {
+
+  @Test
+  public void testInitConfiguration() throws IOException {
+    final String listField = "NullableList";
+    Schema schema = new Schema.Parser().parse(Resources.getResource("list_with_nulls.avsc").openStream());
+    AvroWriteSupport<GenericRecord> awsWithConfigSpecificBehavior = new AvroWriteSupport<>();
+    Configuration configuration = new Configuration();
+    AvroWriteSupport.setSchema(configuration, schema);
+    configuration.set(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE, "false");
+    WriteSupport.WriteContext writeContext = awsWithConfigSpecificBehavior.init(configuration);
+    MessageType actual = writeContext.getSchema();
+    int idx = actual.getFieldIndex(listField);
+    ColumnDescriptor columnDescriptor = actual.getColumns().get(idx);
+    PrimitiveType primitiveType = columnDescriptor.getPrimitiveType();
+    Assert.assertEquals("Confirm that old list type was not used", AvroWriteSupport.LIST_ELEMENT_NAME, primitiveType.getName());
+    // Default configuration
+    configuration = new Configuration();
+    AvroWriteSupport.setSchema(configuration, schema);
+    AvroWriteSupport<GenericRecord> awsWithoutConfigBehavior = new AvroWriteSupport<>();
+    WriteSupport.WriteContext writeContextDefault = awsWithoutConfigBehavior.init(configuration);
+    actual = writeContextDefault.getSchema();
+    idx = actual.getFieldIndex(listField);
+    columnDescriptor = actual.getColumns().get(idx);
+    primitiveType = columnDescriptor.getPrimitiveType();
+    Assert.assertEquals("Confirm that old list type was used if not specified", "array", primitiveType.getName());
+  }
+}

--- a/parquet-avro/src/test/resources/list_with_nulls.avsc
+++ b/parquet-avro/src/test/resources/list_with_nulls.avsc
@@ -1,0 +1,25 @@
+{
+  "type": "record",
+  "name": "NullLists",
+  "namespace": "com.test",
+  "fields": [
+    {
+      "name": "KeyID",
+      "type": "string"
+    },
+    {
+      "name": "NullableList",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": [
+            "null",
+            "string"
+          ]
+        }
+      ],
+      "default": null
+    }
+  ]
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/projects/PARQUET/issues/PARQUET-2051) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
     - TestAvroWriteSupport.java

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
