### PR TITLE
PARQUET-2054: fix TCP leaking when calling ParquetFileWriter.appendFile

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/CheckParquet251Command.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/CheckParquet251Command.java
@@ -108,10 +108,8 @@ public class CheckParquet251Command extends BaseCommand {
           }));
 
       // now check to see if the data is actually corrupt
-      ParquetFileReader reader = new ParquetFileReader(getConf(),
-          fakeMeta, path, footer.getBlocks(), columns);
-
-      try {
+      try (ParquetFileReader reader = new ParquetFileReader(getConf(),
+        fakeMeta, path, footer.getBlocks(), columns)) {
         PageStatsValidator validator = new PageStatsValidator();
         for (PageReadStore pages = reader.readNextRowGroup(); pages != null;
              pages = reader.readNextRowGroup()) {

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/SchemaCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/SchemaCommand.java
@@ -119,9 +119,10 @@ public class SchemaCommand extends BaseCommand {
 
       switch (format) {
         case PARQUET:
-          return new ParquetFileReader(
-              getConf(), qualifiedPath(source), ParquetMetadataConverter.NO_FILTER)
-              .getFileMetaData().getSchema().toString();
+          try (ParquetFileReader reader = new ParquetFileReader(
+            getConf(), qualifiedPath(source), ParquetMetadataConverter.NO_FILTER)) {
+            return reader.getFileMetaData().getSchema().toString();
+          }
         default:
           throw new IllegalArgumentException(String.format(
               "Could not get a Parquet schema for format %s: %s", format, source));

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -887,7 +887,9 @@ public class ParquetFileWriter {
    */
   @Deprecated
   public void appendFile(Configuration conf, Path file) throws IOException {
-    ParquetFileReader.open(conf, file).appendTo(this);
+    try (ParquetFileReader reader = ParquetFileReader.open(conf, file)) {
+      reader.appendTo(this);
+    }
   }
 
   public void appendFile(InputFile file) throws IOException {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
@@ -270,14 +270,15 @@ public class TestParquetWriter {
       }
     }
 
-    ParquetFileReader reader = ParquetFileReader.open(HadoopInputFile.fromPath(path, new Configuration()));
-    BlockMetaData blockMetaData = reader.getFooter().getBlocks().get(0);
-    BloomFilter bloomFilter = reader.getBloomFilterDataReader(blockMetaData)
-      .readBloomFilter(blockMetaData.getColumns().get(0));
+    try (ParquetFileReader reader = ParquetFileReader.open(HadoopInputFile.fromPath(path, new Configuration()))) {
+      BlockMetaData blockMetaData = reader.getFooter().getBlocks().get(0);
+      BloomFilter bloomFilter = reader.getBloomFilterDataReader(blockMetaData)
+        .readBloomFilter(blockMetaData.getColumns().get(0));
 
-    for (String name: testNames) {
-      assertTrue(bloomFilter.findHash(
-        LongHashFunction.xx(0).hashBytes(Binary.fromString(name).toByteBuffer())));
+      for (String name : testNames) {
+        assertTrue(bloomFilter.findHash(
+          LongHashFunction.xx(0).hashBytes(Binary.fromString(name).toByteBuffer())));
+      }
     }
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestReadWriteEncodingStats.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestReadWriteEncodingStats.java
@@ -93,29 +93,30 @@ public class TestReadWriteEncodingStats {
     writeData(writer);
     writer.close();
 
-    ParquetFileReader reader = ParquetFileReader.open(CONF, path);
-    assertEquals("Should have one row group", 1, reader.getRowGroups().size());
-    BlockMetaData rowGroup = reader.getRowGroups().get(0);
+    try (ParquetFileReader reader = ParquetFileReader.open(CONF, path)) {
+      assertEquals("Should have one row group", 1, reader.getRowGroups().size());
+      BlockMetaData rowGroup = reader.getRowGroups().get(0);
 
-    ColumnChunkMetaData dictColumn = rowGroup.getColumns().get(0);
-    EncodingStats dictStats = dictColumn.getEncodingStats();
-    assertNotNull("Dict column should have non-null encoding stats", dictStats);
-    assertTrue("Dict column should have a dict page", dictStats.hasDictionaryPages());
-    assertTrue("Dict column should have dict-encoded pages", dictStats.hasDictionaryEncodedPages());
-    assertFalse("Dict column should not have non-dict pages", dictStats.hasNonDictionaryEncodedPages());
+      ColumnChunkMetaData dictColumn = rowGroup.getColumns().get(0);
+      EncodingStats dictStats = dictColumn.getEncodingStats();
+      assertNotNull("Dict column should have non-null encoding stats", dictStats);
+      assertTrue("Dict column should have a dict page", dictStats.hasDictionaryPages());
+      assertTrue("Dict column should have dict-encoded pages", dictStats.hasDictionaryEncodedPages());
+      assertFalse("Dict column should not have non-dict pages", dictStats.hasNonDictionaryEncodedPages());
 
-    ColumnChunkMetaData plainColumn = rowGroup.getColumns().get(1);
-    EncodingStats plainStats = plainColumn.getEncodingStats();
-    assertNotNull("Plain column should have non-null encoding stats", plainStats);
-    assertFalse("Plain column should not have a dict page", plainStats.hasDictionaryPages());
-    assertFalse("Plain column should not have dict-encoded pages", plainStats.hasDictionaryEncodedPages());
-    assertTrue("Plain column should have non-dict pages", plainStats.hasNonDictionaryEncodedPages());
+      ColumnChunkMetaData plainColumn = rowGroup.getColumns().get(1);
+      EncodingStats plainStats = plainColumn.getEncodingStats();
+      assertNotNull("Plain column should have non-null encoding stats", plainStats);
+      assertFalse("Plain column should not have a dict page", plainStats.hasDictionaryPages());
+      assertFalse("Plain column should not have dict-encoded pages", plainStats.hasDictionaryEncodedPages());
+      assertTrue("Plain column should have non-dict pages", plainStats.hasNonDictionaryEncodedPages());
 
-    ColumnChunkMetaData fallbackColumn = rowGroup.getColumns().get(2);
-    EncodingStats fallbackStats = fallbackColumn.getEncodingStats();
-    assertNotNull("Fallback column should have non-null encoding stats", fallbackStats);
-    assertTrue("Fallback column should have a dict page", fallbackStats.hasDictionaryPages());
-    assertTrue("Fallback column should have dict-encoded pages", fallbackStats.hasDictionaryEncodedPages());
-    assertTrue("Fallback column should have non-dict pages", fallbackStats.hasNonDictionaryEncodedPages());
+      ColumnChunkMetaData fallbackColumn = rowGroup.getColumns().get(2);
+      EncodingStats fallbackStats = fallbackColumn.getEncodingStats();
+      assertNotNull("Fallback column should have non-null encoding stats", fallbackStats);
+      assertTrue("Fallback column should have a dict page", fallbackStats.hasDictionaryPages());
+      assertTrue("Fallback column should have dict-encoded pages", fallbackStats.hasDictionaryEncodedPages());
+      assertTrue("Fallback column should have non-dict pages", fallbackStats.hasNonDictionaryEncodedPages());
+    }
   }
 }


### PR DESCRIPTION
use try-with-resource clause to close ParquetFileReader explicitly to prevent TCP leaking issue

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
