### PR TITLE
PARQUET-2070 replace deprecated syntax in ProtoWriteSupport.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Thrift integration is provided by the [parquet-thrift](https://github.com/apache
 ### Avro
 Avro conversion is implemented via the [parquet-avro](https://github.com/apache/parquet-mr/tree/master/parquet-avro) sub-project.
 
+### Protobuf
+Protobuf conversion is implemented via the [parquet-protobuf](https://github.com/apache/parquet-mr/tree/master/parquet-protobuf) sub-project.
+
 ### Create your own objects
 * The ParquetOutputFormat can be provided a WriteSupport to write your own objects to an event based RecordConsumer.
 * the ParquetInputFormat can be provided a ReadSupport to materialize your own objects by implementing a RecordMaterializer

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -135,7 +135,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
 
     Map<String, String> extraMetaData = new HashMap<>();
     extraMetaData.put(ProtoReadSupport.PB_CLASS, protoMessage.getName());
-    extraMetaData.put(ProtoReadSupport.PB_DESCRIPTOR, serializeDescriptor(protoMessage));
+    extraMetaData.put(ProtoReadSupport.PB_DESCRIPTOR, messageDescriptor.toProto().toString());
     extraMetaData.put(PB_SPECS_COMPLIANT_WRITE, String.valueOf(writeSpecsCompliant));
     return new WriteContext(rootSchema, extraMetaData);
   }
@@ -563,10 +563,4 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
     throw new InvalidRecordException(exceptionMsg);
   }
 
-  /** Returns message descriptor as JSON String*/
-  private String serializeDescriptor(Class<? extends Message> protoClass) {
-    Descriptor descriptor = Protobufs.getMessageDescriptor(protoClass);
-    DescriptorProtos.DescriptorProto asProto = descriptor.toProto();
-    return TextFormat.printToString(asProto);
-  }
 }


### PR DESCRIPTION

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET-2070)

### Tests

- [ ] My PR does not need testing for this extremely good reason: I'm simply removing a private method, no feature has changed, existing unit are sufficient to validate the change.

### Commits

This minor PR:

* replaces usage of the deprecated syntax `TextFormat.printToString(asProto)` with the now recommended and simpler `.toString()` 
* the private method where this code was present was only invoked from one place, where the protobuf Descriptor was already available => I moved the logic directly there, which removes one reflection invocation and makes the code slightly more concise (and probably trivially faster as well)
* I also added a mention of protobuf in the readme, since Thrif and Avro were mentioned already
