### PR TITLE
PARQUET-2072: Do Not Determine Both Min/Max for Binary Stats

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/BinaryStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/BinaryStatistics.java
@@ -54,9 +54,13 @@ public class BinaryStatistics extends Statistics<Binary> {
   @Override
   public void updateStats(Binary value) {
     if (!this.hasNonNullValue()) {
-      initializeStats(value, value);
-    } else {
-      updateStats(value, value);
+      min = value.copy();
+      max = value.copy();
+      this.markAsNotEmpty();
+    } else if (comparator().compare(min, value) > 0) {
+      min = value.copy();
+    } else if (comparator().compare(max, value) < 0) {
+      max = value.copy();
     }
   }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [PARQUET-2072](https://issues.apache.org/jira/browse/PARQUET-2072) issues

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No change in functionality. Use existing unit tests.

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
