### PR TITLE
PARQUET-2076: Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ install:
   - sudo apt-get install -qq maven
   - java -version
   - mvn -version
-  - travis_wait 60 mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true -Dorg.slf4j.simpleLogger.logFile=mvn-install.log
+  - mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true -Dorg.slf4j.simpleLogger.logFile=mvn-install.log
   
-script: travis_wait 60 mvn verify --batch-mode javadoc:javadoc -P ci-test,$HADOOP_PROFILE -Dorg.slf4j.simpleLogger.logFile=mvn-verify.log
+script: mvn verify --batch-mode javadoc:javadoc -P ci-test,$HADOOP_PROFILE -Dorg.slf4j.simpleLogger.logFile=mvn-verify.log
 
 after_failure:
   - cat mvn-install.log


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
