### PR TITLE
PARQUET-2022: ZstdDecompressorStream should close `zstdInputStream` (…

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/ZstdDecompressorStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/ZstdDecompressorStream.java
@@ -50,4 +50,13 @@ public class ZstdDecompressorStream extends CompressionInputStream {
   public void resetState() throws IOException {
     // no-opt, doesn't apply to ZSTD
   }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      zstdInputStream.close();
+    } finally {
+      super.close();
+    }
+  }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestZstandardCodec.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestZstandardCodec.java
@@ -79,8 +79,8 @@ public class TestZstandardCodec {
     byte[] data = new byte[dataSize];
     (new Random()).nextBytes(data);
     BytesInput compressedData = compress(codec,  BytesInput.from(data));
-    BytesInput decompressedData = decompress(codec, compressedData, data.length);
-    Assert.assertArrayEquals(data, decompressedData.toByteArray());
+    byte[] decompressedData = decompress(codec, compressedData, data.length);
+    Assert.assertArrayEquals(data, decompressedData);
   }
 
   private BytesInput compress(ZstandardCodec codec, BytesInput bytes) throws IOException {
@@ -91,10 +91,9 @@ public class TestZstandardCodec {
     return BytesInput.from(compressedOutBuffer);
   }
 
-  private BytesInput decompress(ZstandardCodec codec, BytesInput bytes, int uncompressedSize) throws IOException {
-    BytesInput decompressed;
+  private byte[] decompress(ZstandardCodec codec, BytesInput bytes, int uncompressedSize) throws IOException {
     InputStream is = codec.createInputStream(bytes.toInputStream(), null);
-    decompressed = BytesInput.from(is, uncompressedSize);
+    byte[] decompressed = BytesInput.from(is, uncompressedSize).toByteArray();
     is.close();
     return decompressed;
   }


### PR DESCRIPTION
…#889)

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
