### PR TITLE
PARQUET-2094: Handle negative values in page headers

### DIFF
--- a/parquet-format-structures/src/main/java/org/apache/parquet/format/InvalidParquetMetadataException.java
+++ b/parquet-format-structures/src/main/java/org/apache/parquet/format/InvalidParquetMetadataException.java
@@ -20,25 +20,11 @@
 package org.apache.parquet.format;
 
 /**
- * Utility class to validate different types of Parquet metadata (e.g. footer, page headers etc.).
+ * A specific RuntimeException thrown when invalid values are found in the Parquet file metadata (including the footer,
+ * page header etc.).
  */
-public class MetadataValidator {
-
-  static PageHeader validate(PageHeader pageHeader) {
-    int compressed_page_size = pageHeader.getCompressed_page_size();
-    validateValue(compressed_page_size >= 0,
-        String.format("Compressed page size must not be negative but was: %s", compressed_page_size));
-    return pageHeader;
+public class InvalidParquetMetadataException extends RuntimeException {
+  <T> InvalidParquetMetadataException(String message) {
+    super(message);
   }
-
-  private static <T> void validateValue(boolean valid, String message) {
-    if (!valid) {
-      throw new InvalidParquetMetadataException(message);
-    }
-  }
-
-  private MetadataValidator() {
-    // Private constructor to prevent instantiation
-  }
-
 }

--- a/parquet-format-structures/src/main/java/org/apache/parquet/format/InvalidParquetMetadataException.java
+++ b/parquet-format-structures/src/main/java/org/apache/parquet/format/InvalidParquetMetadataException.java
@@ -24,7 +24,7 @@ package org.apache.parquet.format;
  * page header etc.).
  */
 public class InvalidParquetMetadataException extends RuntimeException {
-  <T> InvalidParquetMetadataException(String message) {
+  InvalidParquetMetadataException(String message) {
     super(message);
   }
 }

--- a/parquet-format-structures/src/main/java/org/apache/parquet/format/MetadataValidator.java
+++ b/parquet-format-structures/src/main/java/org/apache/parquet/format/MetadataValidator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.format;
+
+import java.io.IOException;
+import java.util.function.Predicate;
+
+/**
+ * Utility class to validate different types of Parquet metadata (e.g. footer, page headers etc.).
+ */
+public class MetadataValidator {
+
+  /**
+   * A specific IOException thrown when invalid values are found in the Parquet file metadata (including the footer,
+   * page header etc.).
+   */
+  public static class InvalidParquetMetadataException extends IOException {
+    private <T> InvalidParquetMetadataException(String metaName, T value) {
+      super("Metadata " + metaName + " is invalid: " + value);
+    }
+  }
+
+  static PageHeader validate(PageHeader pageHeader) throws InvalidParquetMetadataException {
+    validateValue(size -> size >= 0, pageHeader.getCompressed_page_size(), "pageHeader.compressed_page_size");
+    return pageHeader;
+  }
+
+  private static <T> void validateValue(Predicate<? super T> validator, T value, String metaName)
+      throws InvalidParquetMetadataException {
+    if (!validator.test(value)) {
+      throw new InvalidParquetMetadataException(metaName, value);
+    }
+  }
+
+  private MetadataValidator() {
+    // Private constructor to prevent instantiation
+  }
+
+}

--- a/parquet-format-structures/src/main/java/org/apache/parquet/format/MetadataValidator.java
+++ b/parquet-format-structures/src/main/java/org/apache/parquet/format/MetadataValidator.java
@@ -19,33 +19,31 @@
 
 package org.apache.parquet.format;
 
-import java.io.IOException;
-import java.util.function.Predicate;
-
 /**
  * Utility class to validate different types of Parquet metadata (e.g. footer, page headers etc.).
  */
 public class MetadataValidator {
 
   /**
-   * A specific IOException thrown when invalid values are found in the Parquet file metadata (including the footer,
-   * page header etc.).
+   * A specific RuntimeException thrown when invalid values are found in the Parquet file metadata (including the
+   * footer, page header etc.).
    */
-  public static class InvalidParquetMetadataException extends IOException {
-    private <T> InvalidParquetMetadataException(String metaName, T value) {
-      super("Metadata " + metaName + " is invalid: " + value);
+  public static class InvalidParquetMetadataException extends RuntimeException {
+    private <T> InvalidParquetMetadataException(String message) {
+      super(message);
     }
   }
 
-  static PageHeader validate(PageHeader pageHeader) throws InvalidParquetMetadataException {
-    validateValue(size -> size >= 0, pageHeader.getCompressed_page_size(), "pageHeader.compressed_page_size");
+  static PageHeader validate(PageHeader pageHeader) {
+    int compressed_page_size = pageHeader.getCompressed_page_size();
+    validateValue(compressed_page_size >= 0,
+        String.format("Compressed page size must not be negative but was: %s", compressed_page_size));
     return pageHeader;
   }
 
-  private static <T> void validateValue(Predicate<? super T> validator, T value, String metaName)
-      throws InvalidParquetMetadataException {
-    if (!validator.test(value)) {
-      throw new InvalidParquetMetadataException(metaName, value);
+  private static <T> void validateValue(boolean valid, String message) {
+    if (!valid) {
+      throw new InvalidParquetMetadataException(message);
     }
   }
 

--- a/parquet-format-structures/src/main/java/org/apache/parquet/format/Util.java
+++ b/parquet-format-structures/src/main/java/org/apache/parquet/format/Util.java
@@ -27,6 +27,7 @@ import static org.apache.parquet.format.FileMetaData._Fields.NUM_ROWS;
 import static org.apache.parquet.format.FileMetaData._Fields.ROW_GROUPS;
 import static org.apache.parquet.format.FileMetaData._Fields.SCHEMA;
 import static org.apache.parquet.format.FileMetaData._Fields.VERSION;
+import static org.apache.parquet.format.MetadataValidator.validate;
 import static org.apache.parquet.format.event.Consumers.fieldConsumer;
 import static org.apache.parquet.format.event.Consumers.listElementsOf;
 import static org.apache.parquet.format.event.Consumers.listOf;
@@ -130,7 +131,7 @@ public class Util {
 
   public static PageHeader readPageHeader(InputStream from, 
       BlockCipher.Decryptor decryptor, byte[] AAD) throws IOException {
-    return read(from, new PageHeader(), decryptor, AAD);
+    return validate(read(from, new PageHeader(), decryptor, AAD));
   }
 
   public static void writeFileMetaData(org.apache.parquet.format.FileMetaData fileMetadata, 

--- a/parquet-format-structures/src/main/java/org/apache/parquet/format/Util.java
+++ b/parquet-format-structures/src/main/java/org/apache/parquet/format/Util.java
@@ -27,7 +27,6 @@ import static org.apache.parquet.format.FileMetaData._Fields.NUM_ROWS;
 import static org.apache.parquet.format.FileMetaData._Fields.ROW_GROUPS;
 import static org.apache.parquet.format.FileMetaData._Fields.SCHEMA;
 import static org.apache.parquet.format.FileMetaData._Fields.VERSION;
-import static org.apache.parquet.format.MetadataValidator.validate;
 import static org.apache.parquet.format.event.Consumers.fieldConsumer;
 import static org.apache.parquet.format.event.Consumers.listElementsOf;
 import static org.apache.parquet.format.event.Consumers.listOf;
@@ -131,7 +130,7 @@ public class Util {
 
   public static PageHeader readPageHeader(InputStream from, 
       BlockCipher.Decryptor decryptor, byte[] AAD) throws IOException {
-    return validate(read(from, new PageHeader(), decryptor, AAD));
+    return MetadataValidator.validate(read(from, new PageHeader(), decryptor, AAD));
   }
 
   public static void writeFileMetaData(org.apache.parquet.format.FileMetaData fileMetadata, 

--- a/parquet-format-structures/src/test/java/org/apache/parquet/format/TestUtil.java
+++ b/parquet-format-structures/src/test/java/org/apache/parquet/format/TestUtil.java
@@ -92,7 +92,7 @@ public class TestUtil {
       fail("Expected exception but did not thrown");
     } catch (InvalidParquetMetadataException e) {
       assertTrue("Exception message does not contain the expected parts",
-          e.getMessage().contains("pageHeader.compressed_page_size"));
+          e.getMessage().contains("Compressed page size"));
     }
   }
 

--- a/parquet-format-structures/src/test/java/org/apache/parquet/format/TestUtil.java
+++ b/parquet-format-structures/src/test/java/org/apache/parquet/format/TestUtil.java
@@ -30,8 +30,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import org.apache.parquet.format.Util.DefaultFileMetaDataConsumer;
 import org.junit.Test;
+import org.apache.parquet.format.Util.DefaultFileMetaDataConsumer;
 
 public class TestUtil {
 

--- a/parquet-format-structures/src/test/java/org/apache/parquet/format/TestUtil.java
+++ b/parquet-format-structures/src/test/java/org/apache/parquet/format/TestUtil.java
@@ -30,9 +30,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import org.junit.Test;
-import org.apache.parquet.format.MetadataValidator.InvalidParquetMetadataException;
 import org.apache.parquet.format.Util.DefaultFileMetaDataConsumer;
+import org.junit.Test;
 
 public class TestUtil {
 

--- a/parquet-format-structures/src/test/java/org/apache/parquet/format/TestUtil.java
+++ b/parquet-format-structures/src/test/java/org/apache/parquet/format/TestUtil.java
@@ -23,13 +23,17 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
 import static org.apache.parquet.format.Util.readFileMetaData;
 import static org.apache.parquet.format.Util.writeFileMetaData;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 import org.junit.Test;
-
+import org.apache.parquet.format.MetadataValidator.InvalidParquetMetadataException;
 import org.apache.parquet.format.Util.DefaultFileMetaDataConsumer;
+
 public class TestUtil {
 
   @Test
@@ -75,6 +79,21 @@ public class TestUtil {
     assertEquals(md, md5);
     assertEquals(md4, md5);
     assertEquals(md, md6);
+  }
+
+  @Test
+  public void testInvalidPageHeader() throws IOException {
+    PageHeader ph = new PageHeader(PageType.DATA_PAGE, 100, -50);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Util.writePageHeader(ph, out);
+
+    try {
+      Util.readPageHeader(in(out));
+      fail("Expected exception but did not thrown");
+    } catch (InvalidParquetMetadataException e) {
+      assertTrue("Exception message does not contain the expected parts",
+          e.getMessage().contains("pageHeader.compressed_page_size"));
+    }
   }
 
   private ByteArrayInputStream in(ByteArrayOutputStream baos) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
