### PR TITLE
PARQUET-2101: Fix wrong descriptions about the default block size

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
@@ -87,8 +87,8 @@ public class AvroParquetWriter<T> extends ParquetWriter<T> {
         DEFAULT_IS_VALIDATING_ENABLED);
   }
 
-  /** Create a new {@link AvroParquetWriter}. The default block size is 50 MB.The default
-   *  page size is 1 MB.  Default compression is no compression. (Inherited from {@link ParquetWriter})
+  /** Create a new {@link AvroParquetWriter}. The default block size is 128 MB. The default
+   *  page size is 1 MB. Default compression is no compression. (Inherited from {@link ParquetWriter})
    *
    * @param file The file name to write to.
    * @param avroSchema The schema to write with.

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -237,8 +237,8 @@ public class ParquetWriter<T> implements Closeable {
   }
 
   /**
-   * Create a new ParquetWriter.  The default block size is 50 MB.The default
-   * page size is 1 MB.  Default compression is no compression. Dictionary encoding is disabled.
+   * Create a new ParquetWriter. The default block size is 128 MB. The default
+   * page size is 1 MB. Default compression is no compression. Dictionary encoding is disabled.
    *
    * @param file the file to create
    * @param writeSupport the implementation to write a record to a RecordConsumer

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
@@ -77,8 +77,8 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
   }
 
   /**
-   * Create a new {@link ProtoParquetWriter}. The default block size is 50 MB.The default
-   * page size is 1 MB.  Default compression is no compression. (Inherited from {@link ParquetWriter})
+   * Create a new {@link ProtoParquetWriter}. The default block size is 128 MB. The default
+   * page size is 1 MB. Default compression is no compression. (Inherited from {@link ParquetWriter})
    *
    * @param file The file name to write to.
    * @param protoMessage         Protobuf message class


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2101
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

It doesn't add any test since it's just a documentation fix.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
