### PR TITLE
[PARQUET-2106] Refactoring lexicographic `BinaryComparator` to avoid `ByteBuffer.wrap` in the hot-path

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -76,6 +76,12 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
   @Override
   @Deprecated
   abstract public int compareTo(Binary other);
+
+  public abstract int compareToLexicographic(Binary other);
+
+  public abstract int compareToLexicographic(byte[] other, int otherOffset, int otherLength);
+
+  public abstract int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength);
 
   abstract public ByteBuffer toByteBuffer();
 
@@ -189,6 +195,22 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     @Override
     public int compareTo(Binary other) {
       return PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR.compare(this, other);
+    }
+
+    @Override
+    public int compareToLexicographic(Binary other) {
+      // NOTE: We have to flip the sign, since we swap operands sides
+      return -other.compareToLexicographic(value, offset, length);
+    }
+
+    @Override
+    public int compareToLexicographic(byte[] other, int otherOffset, int otherLength) {
+      return Binary.compareToLexicographic(value, offset, length, other, otherOffset, otherLength);
+    }
+
+    @Override
+    public int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength) {
+      return Binary.compareToLexicographic(value, offset, length, other, otherOffset, otherLength);
     }
 
     @Override
@@ -328,7 +350,23 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
       return PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR.compare(this, other);
     }
 
-   @Override
+    @Override
+    public int compareToLexicographic(Binary other) {
+      // NOTE: We have to flip the sign, since we swap operands sides
+      return -other.compareToLexicographic(value, 0, value.length);
+    }
+
+    @Override
+    public int compareToLexicographic(byte[] other, int otherOffset, int otherLength) {
+      return Binary.compareToLexicographic(this.value, 0, value.length, other, otherOffset, otherLength);
+    }
+
+    @Override
+    public int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength) {
+      return Binary.compareToLexicographic(this.value, 0, value.length, other, otherOffset, otherLength);
+    }
+
+    @Override
     public ByteBuffer toByteBuffer() {
       return ByteBuffer.wrap(value);
     }
@@ -476,6 +514,32 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     }
 
     @Override
+    public int compareToLexicographic(Binary other) {
+      if (value.hasArray()) {
+        // NOTE: We have to flip the sign, since we swap operands sides
+        return -other.compareToLexicographic(value.array(), value.arrayOffset() + offset, length);
+      } else {
+        // NOTE: We have to flip the sign, since we swap operands sides
+        return -other.compareToLexicographic(value, offset, length);
+      }
+    }
+
+    @Override
+    public int compareToLexicographic(byte[] other, int otherOffset, int otherLength) {
+      if (value.hasArray()) {
+        return Binary.compareToLexicographic(value.array(), value.arrayOffset() + offset, length, other, otherOffset, otherLength);
+      } else {
+        // NOTE: We have to flip the sign, since we swap operands sides
+        return -Binary.compareToLexicographic(other, otherOffset, otherLength, value, offset, length);
+      }
+    }
+
+    @Override
+    public int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength) {
+      return Binary.compareToLexicographic(value, offset, length, other, otherOffset, otherLength);
+    }
+
+    @Override
     public ByteBuffer toByteBuffer() {
       ByteBuffer ret = value.duplicate();
       ret.position(offset);
@@ -612,5 +676,61 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
       }
     }
     return true;
+  }
+
+  // TODO java-doc
+  private static final int compareToLexicographic(byte[] array1, int offset1, int length1, byte[] array2, int offset2, int length2) {
+    if (array1 == null && array2 == null) return 0;
+    if (array1 == null || array2 == null) return array1 != null ? 1 : -1;
+
+    int minLen = Math.min(length1, length2);
+    for (int i = 0; i < minLen; i++) {
+      int res = unsignedCompare(array1[i + offset1], array2[i + offset2]);
+      if (res != 0) {
+        return res;
+      }
+    }
+
+    return length1 - length2;
+  }
+
+  // TODO java-doc
+  private static final int compareToLexicographic(byte[] array1, int offset1, int length1, ByteBuffer array2, int offset2, int length2) {
+    if (array1 == null && array2 == null) return 0;
+    if (array1 == null || array2 == null) return array1 != null ? 1 : -1;
+
+    int minLen = Math.min(length1, length2);
+    for (int i = 0; i < minLen; i++) {
+      int res = unsignedCompare(array1[i + offset1], array2.get(i + offset2));
+      if (res != 0) {
+        return res;
+      }
+    }
+
+    return length1 - length2;
+  }
+
+  // TODO java-doc
+  private static final int compareToLexicographic(ByteBuffer array1, int offset1, int length1, ByteBuffer array2, int offset2, int length2) {
+    if (array1 == null && array2 == null) return 0;
+    if (array1 == null || array2 == null) return array1 != null ? 1 : -1;
+
+    int minLen = Math.min(length1, length2);
+    for (int i = 0; i < minLen; i++) {
+      int res = unsignedCompare(array1.get(i + offset1), array2.get(i + offset2));
+      if (res != 0) {
+        return res;
+      }
+    }
+
+    return length1 - length2;
+  }
+
+  private static int unsignedCompare(byte b1, byte b2) {
+    return toUnsigned(b1) - toUnsigned(b2);
+  }
+
+  private static final int toUnsigned(byte b) {
+    return b & 0xFF;
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
@@ -77,11 +77,11 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
   @Deprecated
   abstract public int compareTo(Binary other);
 
-  public abstract int compareToLexicographic(Binary other);
+  abstract int compareToLexicographic(Binary other);
 
-  public abstract int compareToLexicographic(byte[] other, int otherOffset, int otherLength);
+  abstract int compareToLexicographic(byte[] other, int otherOffset, int otherLength);
 
-  public abstract int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength);
+  abstract int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength);
 
   abstract public ByteBuffer toByteBuffer();
 
@@ -604,6 +604,10 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
 
   public static Binary fromCharSequence(CharSequence value) {
     return new FromCharSequenceBinary(value);
+  }
+
+  public static int compareToLexicographic(Binary one, Binary other) {
+    return one.compareToLexicographic(other);
   }
 
   /**

--- a/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
@@ -682,7 +682,6 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     return true;
   }
 
-  // TODO java-doc
   private static final int compareToLexicographic(byte[] array1, int offset1, int length1, byte[] array2, int offset2, int length2) {
     if (array1 == null && array2 == null) return 0;
     if (array1 == null || array2 == null) return array1 != null ? 1 : -1;
@@ -698,7 +697,6 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     return length1 - length2;
   }
 
-  // TODO java-doc
   private static final int compareToLexicographic(byte[] array1, int offset1, int length1, ByteBuffer array2, int offset2, int length2) {
     if (array1 == null && array2 == null) return 0;
     if (array1 == null || array2 == null) return array1 != null ? 1 : -1;
@@ -714,7 +712,6 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     return length1 - length2;
   }
 
-  // TODO java-doc
   private static final int compareToLexicographic(ByteBuffer array1, int offset1, int length1, ByteBuffer array2, int offset2, int length2) {
     if (array1 == null && array2 == null) return 0;
     if (array1 == null || array2 == null) return array1 != null ? 1 : -1;

--- a/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
@@ -198,18 +198,18 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     }
 
     @Override
-    public int compareToLexicographic(Binary other) {
+    int compareToLexicographic(Binary other) {
       // NOTE: We have to flip the sign, since we swap operands sides
       return -other.compareToLexicographic(value, offset, length);
     }
 
     @Override
-    public int compareToLexicographic(byte[] other, int otherOffset, int otherLength) {
+    int compareToLexicographic(byte[] other, int otherOffset, int otherLength) {
       return Binary.compareToLexicographic(value, offset, length, other, otherOffset, otherLength);
     }
 
     @Override
-    public int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength) {
+    int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength) {
       return Binary.compareToLexicographic(value, offset, length, other, otherOffset, otherLength);
     }
 
@@ -351,18 +351,18 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     }
 
     @Override
-    public int compareToLexicographic(Binary other) {
+    int compareToLexicographic(Binary other) {
       // NOTE: We have to flip the sign, since we swap operands sides
       return -other.compareToLexicographic(value, 0, value.length);
     }
 
     @Override
-    public int compareToLexicographic(byte[] other, int otherOffset, int otherLength) {
+    int compareToLexicographic(byte[] other, int otherOffset, int otherLength) {
       return Binary.compareToLexicographic(this.value, 0, value.length, other, otherOffset, otherLength);
     }
 
     @Override
-    public int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength) {
+    int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength) {
       return Binary.compareToLexicographic(this.value, 0, value.length, other, otherOffset, otherLength);
     }
 
@@ -514,7 +514,7 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     }
 
     @Override
-    public int compareToLexicographic(Binary other) {
+    int compareToLexicographic(Binary other) {
       if (value.hasArray()) {
         // NOTE: We have to flip the sign, since we swap operands sides
         return -other.compareToLexicographic(value.array(), value.arrayOffset() + offset, length);
@@ -525,7 +525,7 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     }
 
     @Override
-    public int compareToLexicographic(byte[] other, int otherOffset, int otherLength) {
+    int compareToLexicographic(byte[] other, int otherOffset, int otherLength) {
       if (value.hasArray()) {
         return Binary.compareToLexicographic(value.array(), value.arrayOffset() + offset, length, other, otherOffset, otherLength);
       } else {
@@ -535,7 +535,7 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     }
 
     @Override
-    public int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength) {
+    int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength) {
       return Binary.compareToLexicographic(value, offset, length, other, otherOffset, otherLength);
     }
 

--- a/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
@@ -77,11 +77,11 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
   @Deprecated
   abstract public int compareTo(Binary other);
 
-  abstract int compareToLexicographic(Binary other);
+  abstract int lexicographicCompare(Binary other);
 
-  abstract int compareToLexicographic(byte[] other, int otherOffset, int otherLength);
+  abstract int lexicographicCompare(byte[] other, int otherOffset, int otherLength);
 
-  abstract int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength);
+  abstract int lexicographicCompare(ByteBuffer other, int otherOffset, int otherLength);
 
   abstract public ByteBuffer toByteBuffer();
 
@@ -198,19 +198,19 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     }
 
     @Override
-    int compareToLexicographic(Binary other) {
+    int lexicographicCompare(Binary other) {
       // NOTE: We have to flip the sign, since we swap operands sides
-      return -other.compareToLexicographic(value, offset, length);
+      return -other.lexicographicCompare(value, offset, length);
     }
 
     @Override
-    int compareToLexicographic(byte[] other, int otherOffset, int otherLength) {
-      return Binary.compareToLexicographic(value, offset, length, other, otherOffset, otherLength);
+    int lexicographicCompare(byte[] other, int otherOffset, int otherLength) {
+      return Binary.lexicographicCompare(value, offset, length, other, otherOffset, otherLength);
     }
 
     @Override
-    int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength) {
-      return Binary.compareToLexicographic(value, offset, length, other, otherOffset, otherLength);
+    int lexicographicCompare(ByteBuffer other, int otherOffset, int otherLength) {
+      return Binary.lexicographicCompare(value, offset, length, other, otherOffset, otherLength);
     }
 
     @Override
@@ -351,19 +351,19 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     }
 
     @Override
-    int compareToLexicographic(Binary other) {
+    int lexicographicCompare(Binary other) {
       // NOTE: We have to flip the sign, since we swap operands sides
-      return -other.compareToLexicographic(value, 0, value.length);
+      return -other.lexicographicCompare(value, 0, value.length);
     }
 
     @Override
-    int compareToLexicographic(byte[] other, int otherOffset, int otherLength) {
-      return Binary.compareToLexicographic(this.value, 0, value.length, other, otherOffset, otherLength);
+    int lexicographicCompare(byte[] other, int otherOffset, int otherLength) {
+      return Binary.lexicographicCompare(this.value, 0, value.length, other, otherOffset, otherLength);
     }
 
     @Override
-    int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength) {
-      return Binary.compareToLexicographic(this.value, 0, value.length, other, otherOffset, otherLength);
+    int lexicographicCompare(ByteBuffer other, int otherOffset, int otherLength) {
+      return Binary.lexicographicCompare(this.value, 0, value.length, other, otherOffset, otherLength);
     }
 
     @Override
@@ -514,29 +514,29 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     }
 
     @Override
-    int compareToLexicographic(Binary other) {
+    int lexicographicCompare(Binary other) {
       if (value.hasArray()) {
         // NOTE: We have to flip the sign, since we swap operands sides
-        return -other.compareToLexicographic(value.array(), value.arrayOffset() + offset, length);
+        return -other.lexicographicCompare(value.array(), value.arrayOffset() + offset, length);
       } else {
         // NOTE: We have to flip the sign, since we swap operands sides
-        return -other.compareToLexicographic(value, offset, length);
+        return -other.lexicographicCompare(value, offset, length);
       }
     }
 
     @Override
-    int compareToLexicographic(byte[] other, int otherOffset, int otherLength) {
+    int lexicographicCompare(byte[] other, int otherOffset, int otherLength) {
       if (value.hasArray()) {
-        return Binary.compareToLexicographic(value.array(), value.arrayOffset() + offset, length, other, otherOffset, otherLength);
+        return Binary.lexicographicCompare(value.array(), value.arrayOffset() + offset, length, other, otherOffset, otherLength);
       } else {
         // NOTE: We have to flip the sign, since we swap operands sides
-        return -Binary.compareToLexicographic(other, otherOffset, otherLength, value, offset, length);
+        return -Binary.lexicographicCompare(other, otherOffset, otherLength, value, offset, length);
       }
     }
 
     @Override
-    int compareToLexicographic(ByteBuffer other, int otherOffset, int otherLength) {
-      return Binary.compareToLexicographic(value, offset, length, other, otherOffset, otherLength);
+    int lexicographicCompare(ByteBuffer other, int otherOffset, int otherLength) {
+      return Binary.lexicographicCompare(value, offset, length, other, otherOffset, otherLength);
     }
 
     @Override
@@ -606,8 +606,8 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     return new FromCharSequenceBinary(value);
   }
 
-  public static int compareToLexicographic(Binary one, Binary other) {
-    return one.compareToLexicographic(other);
+  public static int lexicographicCompare(Binary one, Binary other) {
+    return one.lexicographicCompare(other);
   }
 
   /**
@@ -682,7 +682,7 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     return true;
   }
 
-  private static final int compareToLexicographic(byte[] array1, int offset1, int length1, byte[] array2, int offset2, int length2) {
+  private static final int lexicographicCompare(byte[] array1, int offset1, int length1, byte[] array2, int offset2, int length2) {
     if (array1 == null && array2 == null) return 0;
     if (array1 == null || array2 == null) return array1 != null ? 1 : -1;
 
@@ -697,13 +697,13 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     return length1 - length2;
   }
 
-  private static final int compareToLexicographic(byte[] array1, int offset1, int length1, ByteBuffer array2, int offset2, int length2) {
-    if (array1 == null && array2 == null) return 0;
-    if (array1 == null || array2 == null) return array1 != null ? 1 : -1;
+  private static final int lexicographicCompare(byte[] array, int offset1, int length1, ByteBuffer buffer, int offset2, int length2) {
+    if (array == null && buffer == null) return 0;
+    if (array == null || buffer == null) return array != null ? 1 : -1;
 
     int minLen = Math.min(length1, length2);
     for (int i = 0; i < minLen; i++) {
-      int res = unsignedCompare(array1[i + offset1], array2.get(i + offset2));
+      int res = unsignedCompare(array[i + offset1], buffer.get(i + offset2));
       if (res != 0) {
         return res;
       }
@@ -712,13 +712,13 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
     return length1 - length2;
   }
 
-  private static final int compareToLexicographic(ByteBuffer array1, int offset1, int length1, ByteBuffer array2, int offset2, int length2) {
-    if (array1 == null && array2 == null) return 0;
-    if (array1 == null || array2 == null) return array1 != null ? 1 : -1;
+  private static final int lexicographicCompare(ByteBuffer buffer1, int offset1, int length1, ByteBuffer buffer2, int offset2, int length2) {
+    if (buffer1 == null && buffer2 == null) return 0;
+    if (buffer1 == null || buffer2 == null) return buffer1 != null ? 1 : -1;
 
     int minLen = Math.min(length1, length2);
     for (int i = 0; i < minLen; i++) {
-      int res = unsignedCompare(array1.get(i + offset1), array2.get(i + offset2));
+      int res = unsignedCompare(buffer1.get(i + offset1), buffer2.get(i + offset2));
       if (res != 0) {
         return res;
       }

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
@@ -183,10 +183,10 @@ public abstract class PrimitiveComparator<T> implements Comparator<T>, Serializa
   private static abstract class BinaryComparator extends PrimitiveComparator<Binary> {
     @Override
     int compareNotNulls(Binary o1, Binary o2) {
-      return compare(o1.toByteBuffer(), o2.toByteBuffer());
+      return compare(o1, o2);
     }
 
-    abstract int compare(ByteBuffer b1, ByteBuffer b2);
+    abstract int compareInternal(Binary b1, Binary b2);
 
     final int toUnsigned(byte b) {
       return b & 0xFF;
@@ -195,21 +195,8 @@ public abstract class PrimitiveComparator<T> implements Comparator<T>, Serializa
 
   public static final PrimitiveComparator<Binary> UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR = new BinaryComparator() {
     @Override
-    int compare(ByteBuffer b1, ByteBuffer b2) {
-      int l1 = b1.remaining();
-      int l2 = b2.remaining();
-      int p1 = b1.position();
-      int p2 = b2.position();
-      int minL = Math.min(l1, l2);
-
-      for (int i = 0; i < minL; ++i) {
-        int result = unsignedCompare(b1.get(p1 + i), b2.get(p2 + i));
-        if (result != 0) {
-          return result;
-        }
-      }
-
-      return l1 - l2;
+    int compareInternal(Binary b1, Binary b2) {
+      return b1.compareToLexicographic(b2);
     }
 
     private int unsignedCompare(byte b1, byte b2) {
@@ -232,7 +219,11 @@ public abstract class PrimitiveComparator<T> implements Comparator<T>, Serializa
     private static final int POSITIVE_PADDING = 0;
 
     @Override
-    int compare(ByteBuffer b1, ByteBuffer b2) {
+    int compareInternal(Binary b1, Binary b2) {
+      return compare(b1.toByteBuffer(), b2.toByteBuffer());
+    }
+
+    private int compare(ByteBuffer b1, ByteBuffer b2) {
       int l1 = b1.remaining();
       int l2 = b2.remaining();
       int p1 = b1.position();

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
@@ -199,10 +199,6 @@ public abstract class PrimitiveComparator<T> implements Comparator<T>, Serializa
       return Binary.compareToLexicographic(b1, b2);
     }
 
-    private int unsignedCompare(byte b1, byte b2) {
-      return toUnsigned(b1) - toUnsigned(b2);
-    }
-
     @Override
     public String toString() {
       return "UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR";

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
@@ -183,10 +183,10 @@ public abstract class PrimitiveComparator<T> implements Comparator<T>, Serializa
   private static abstract class BinaryComparator extends PrimitiveComparator<Binary> {
     @Override
     int compareNotNulls(Binary o1, Binary o2) {
-      return compare(o1, o2);
+      return compareBinary(o1, o2);
     }
 
-    abstract int compareInternal(Binary b1, Binary b2);
+    abstract int compareBinary(Binary b1, Binary b2);
 
     final int toUnsigned(byte b) {
       return b & 0xFF;
@@ -195,7 +195,7 @@ public abstract class PrimitiveComparator<T> implements Comparator<T>, Serializa
 
   public static final PrimitiveComparator<Binary> UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR = new BinaryComparator() {
     @Override
-    int compareInternal(Binary b1, Binary b2) {
+    int compareBinary(Binary b1, Binary b2) {
       return Binary.compareToLexicographic(b1, b2);
     }
 
@@ -215,7 +215,7 @@ public abstract class PrimitiveComparator<T> implements Comparator<T>, Serializa
     private static final int POSITIVE_PADDING = 0;
 
     @Override
-    int compareInternal(Binary b1, Binary b2) {
+    int compareBinary(Binary b1, Binary b2) {
       return compare(b1.toByteBuffer(), b2.toByteBuffer());
     }
 

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
@@ -196,7 +196,7 @@ public abstract class PrimitiveComparator<T> implements Comparator<T>, Serializa
   public static final PrimitiveComparator<Binary> UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR = new BinaryComparator() {
     @Override
     int compareBinary(Binary b1, Binary b2) {
-      return Binary.compareToLexicographic(b1, b2);
+      return Binary.lexicographicCompare(b1, b2);
     }
 
     @Override

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
@@ -196,7 +196,7 @@ public abstract class PrimitiveComparator<T> implements Comparator<T>, Serializa
   public static final PrimitiveComparator<Binary> UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR = new BinaryComparator() {
     @Override
     int compareInternal(Binary b1, Binary b2) {
-      return b1.compareToLexicographic(b2);
+      return Binary.compareToLexicographic(b1, b2);
     }
 
     private int unsignedCompare(byte b1, byte b2) {


### PR DESCRIPTION
This refactors `BinaryComparator` to essentially avoid any allocations in the routine of comparing 2 `Binary` objects. 

More details could be found in [PARQUET-2106](https://issues.apache.org/jira/browse/PARQUET-2106)

### Jira

- [ ] My PR addresses [PARQUET-2106](https://issues.apache.org/jira/browse/PARQUET-2106) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"

### Tests

- Does not need testing, since it's a simple refactoring that changes flows that are already covered

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
