### PR TITLE
PARQUET-2112: Fix typo in MessageColumnIO

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -186,32 +186,32 @@ public class MessageColumnIO extends GroupColumnIO {
     private int currentLevel = 0;
 
     private class FieldsMarker {
-      private BitSet vistedIndexes = new BitSet();
+      private BitSet visitedIndexes = new BitSet();
 
       @Override
       public String toString() {
         return "VistedIndex{" +
-            "vistedIndexes=" + vistedIndexes +
+            "visitedIndexes=" + visitedIndexes +
             '}';
       }
 
       public void reset(int fieldsCount) {
-        this.vistedIndexes.clear(0, fieldsCount);
+        this.visitedIndexes.clear(0, fieldsCount);
       }
 
       public void markWritten(int i) {
-        vistedIndexes.set(i);
+        visitedIndexes.set(i);
       }
 
       public boolean isWritten(int i) {
-        return vistedIndexes.get(i);
+        return visitedIndexes.get(i);
       }
     }
 
     //track at each level of depth, which fields are written, so nulls can be inserted for the unwritten fields
     private final FieldsMarker[] fieldsWritten;
     private final int[] r;
-    private final ColumnWriter[] columnWriter;
+    private final ColumnWriter[] columnWriters;
 
     /**
      * Maintain a map of groups and all the leaf nodes underneath it. It's used to optimize writing null for a group node.
@@ -248,12 +248,12 @@ public class MessageColumnIO extends GroupColumnIO {
     public MessageColumnIORecordConsumer(ColumnWriteStore columns) {
       this.columns = columns;
       int maxDepth = 0;
-      this.columnWriter = new ColumnWriter[MessageColumnIO.this.getLeaves().size()];
+      this.columnWriters = new ColumnWriter[MessageColumnIO.this.getLeaves().size()];
 
       for (PrimitiveColumnIO primitiveColumnIO : MessageColumnIO.this.getLeaves()) {
         ColumnWriter w = columns.getColumnWriter(primitiveColumnIO.getColumnDescriptor());
         maxDepth = Math.max(maxDepth, primitiveColumnIO.getFieldPath().length);
-        columnWriter[primitiveColumnIO.getId()] = w;
+        columnWriters[primitiveColumnIO.getId()] = w;
         buildGroupToLeafWriterMap(primitiveColumnIO, w);
       }
 
@@ -351,7 +351,7 @@ public class MessageColumnIO extends GroupColumnIO {
 
     private void writeNull(ColumnIO undefinedField, int r, int d) {
       if (undefinedField.getType().isPrimitive()) {
-        columnWriter[((PrimitiveColumnIO) undefinedField).getId()].writeNull(r, d);
+        columnWriters[((PrimitiveColumnIO) undefinedField).getId()].writeNull(r, d);
       } else {
         GroupColumnIO groupColumnIO = (GroupColumnIO) undefinedField;
         // only cache the repetition level, the definition level should always be the definition level of the parent node
@@ -436,7 +436,7 @@ public class MessageColumnIO extends GroupColumnIO {
     }
 
     private ColumnWriter getColumnWriter() {
-      return columnWriter[((PrimitiveColumnIO) currentColumnIO).getId()];
+      return columnWriters[((PrimitiveColumnIO) currentColumnIO).getId()];
     }
 
     @Override

--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -190,7 +190,7 @@ public class MessageColumnIO extends GroupColumnIO {
 
       @Override
       public String toString() {
-        return "VistedIndex{" +
+        return "VisitedIndex{" +
             "visitedIndexes=" + visitedIndexes +
             '}';
       }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
