### PR TITLE
[PARQUET-2113]BUILD] Fix build failure with specified thrift and mvn command

### DIFF
--- a/parquet-format-structures/pom.xml
+++ b/parquet-format-structures/pom.xml
@@ -75,7 +75,7 @@
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus</artifactId>
-            <version>${odehaus-plexus.version}</version>
+            <version>${codehaus-plexus.version}</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/parquet-format-structures/pom.xml
+++ b/parquet-format-structures/pom.xml
@@ -71,6 +71,13 @@
         <groupId>org.apache.thrift</groupId>
         <artifactId>thrift-maven-plugin</artifactId>
         <version>${thrift-maven-plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus</artifactId>
+            <version>${odehaus-plexus.version}</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <thriftSourceRoot>${parquet.thrift.path}</thriftSourceRoot>
           <thriftExecutable>${format.thrift.executable}</thriftExecutable>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -205,7 +205,7 @@
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus</artifactId>
-            <version>${odehaus-plexus.version}</version>
+            <version>${codehaus-plexus.version}</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -201,6 +201,13 @@
         <groupId>org.apache.thrift</groupId>
         <artifactId>thrift-maven-plugin</artifactId>
         <version>${thrift-maven-plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus</artifactId>
+            <version>${odehaus-plexus.version}</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <thriftExecutable>${thrift.executable}</thriftExecutable>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
     <pig.classifier>h2</pig.classifier>
     <thrift-maven-plugin.version>0.10.0</thrift-maven-plugin.version>
     <thrift.version>0.15.0</thrift.version>
+    <odehaus-plexus.version>3.3.1</odehaus-plexus.version>
     <format.thrift.version>${thrift.version}</format.thrift.version>
     <fastutil.version>8.4.2</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <pig.classifier>h2</pig.classifier>
     <thrift-maven-plugin.version>0.10.0</thrift-maven-plugin.version>
     <thrift.version>0.15.0</thrift.version>
-    <odehaus-plexus.version>3.3.1</odehaus-plexus.version>
+    <codehaus-plexus.version>3.3.1</codehaus-plexus.version>
     <format.thrift.version>${thrift.version}</format.thrift.version>
     <fastutil.version>8.4.2</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>


### PR DESCRIPTION
I git clone parquet-mr project with latest version and i build on branch master, i met the build failure with thrift version and mvn command specified as describe in README.md, env as follows:

yikaifei@***** parquet-mr % mvn -v
Apache Maven 3.8.3 (ff8e977a158738155dc465c6a97ffaf31982d739)
Maven home: /Users/yikaifei/maven/apache-maven-3.8.3
Java version: 1.8.0_192, vendor: Oracle Corporation, runtime: /Library/Java/JavaVirtualMachines/jdk1.8.0_192.jdk/Contents/Home/jre
Default locale: zh_CN, platform encoding: UTF-8
OS name: "mac os x", version: "10.16", arch: "x86_64", family: "mac"
yikaifei@***** parquet-mr % thrift -version
Thrift version 0.15.0

Before the PR:
![image](https://user-images.githubusercontent.com/51110188/151150173-79feada2-8699-4270-ad80-af39b1e56333.png)

After the PR:
successfully to compile


### Jira
[PARQUET-2113](https://issues.apache.org/jira/browse/PARQUET-2113)

### Tests

manually test

### Commits


### Documentation


