### PR TITLE
PARQUET-2120: Dictionary command should handle missing dictionary pages

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowDictionaryCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowDictionaryCommand.java
@@ -75,40 +75,12 @@ public class ShowDictionaryCommand extends BaseCommand {
       while ((dictionaryReader = reader.getNextDictionaryReader()) != null) {
         DictionaryPage page = dictionaryReader.readDictionaryPage(descriptor);
 
-        Dictionary dict = page.getEncoding().initDictionary(descriptor, page);
-
-        console.info("\nRow group {} dictionary for \"{}\":", rowGroup, column, page.getCompressedSize());
-        for (int i = 0; i <= dict.getMaxId(); i += 1) {
-          switch(type.getPrimitiveTypeName()) {
-            case BINARY:
-              if (type.getLogicalTypeAnnotation() instanceof LogicalTypeAnnotation.StringLogicalTypeAnnotation) {
-                console.info("{}: {}", String.format("%6d", i),
-                    Util.humanReadable(dict.decodeToBinary(i).toStringUsingUTF8(), 70));
-              } else {
-                console.info("{}: {}", String.format("%6d", i),
-                    Util.humanReadable(dict.decodeToBinary(i).getBytesUnsafe(), 70));
-              }
-              break;
-            case INT32:
-              console.info("{}: {}", String.format("%6d", i),
-                dict.decodeToInt(i));
-              break;
-            case INT64:
-              console.info("{}: {}", String.format("%6d", i),
-                  dict.decodeToLong(i));
-              break;
-            case FLOAT:
-              console.info("{}: {}", String.format("%6d", i),
-                  dict.decodeToFloat(i));
-              break;
-            case DOUBLE:
-              console.info("{}: {}", String.format("%6d", i),
-                  dict.decodeToDouble(i));
-              break;
-            default:
-              throw new IllegalArgumentException(
-                  "Unknown dictionary type: " + type.getPrimitiveTypeName());
-          }
+        if (page != null) {
+          console.info("\nRow group {} dictionary for \"{}\":", rowGroup, column);
+          Dictionary dict = page.getEncoding().initDictionary(descriptor, page);
+          printDictionary(dict, type);
+        } else {
+          console.info("\nRow group {} has no dictionary for \"{}\"", rowGroup, column);
         }
 
         reader.skipNextRowGroup();
@@ -120,6 +92,41 @@ public class ShowDictionaryCommand extends BaseCommand {
     console.info("");
 
     return 0;
+  }
+
+  private void printDictionary(Dictionary dict, PrimitiveType type) {
+    for (int i = 0; i <= dict.getMaxId(); i += 1) {
+      switch(type.getPrimitiveTypeName()) {
+        case BINARY:
+          if (type.getLogicalTypeAnnotation() instanceof LogicalTypeAnnotation.StringLogicalTypeAnnotation) {
+            console.info("{}: {}", String.format("%6d", i),
+                    Util.humanReadable(dict.decodeToBinary(i).toStringUsingUTF8(), 70));
+          } else {
+            console.info("{}: {}", String.format("%6d", i),
+                    Util.humanReadable(dict.decodeToBinary(i).getBytesUnsafe(), 70));
+          }
+          break;
+        case INT32:
+          console.info("{}: {}", String.format("%6d", i),
+                  dict.decodeToInt(i));
+          break;
+        case INT64:
+          console.info("{}: {}", String.format("%6d", i),
+                  dict.decodeToLong(i));
+          break;
+        case FLOAT:
+          console.info("{}: {}", String.format("%6d", i),
+                  dict.decodeToFloat(i));
+          break;
+        case DOUBLE:
+          console.info("{}: {}", String.format("%6d", i),
+                  dict.decodeToDouble(i));
+          break;
+        default:
+          throw new IllegalArgumentException(
+                  "Unknown dictionary type: " + type.getPrimitiveTypeName());
+      }
+    }
   }
 
   @Override

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowDictionaryCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowDictionaryCommandTest.java
@@ -36,4 +36,15 @@ public class ShowDictionaryCommandTest extends ParquetFileTest {
     command.setConf(new Configuration());
     Assert.assertEquals(0, command.run());
   }
+
+  @Test
+  public void testShowDirectoryCommandWithoutDictionaryEncoding() throws IOException {
+    File file = parquetFile();
+    ShowDictionaryCommand command = new ShowDictionaryCommand(createLogger());
+    command.targets = Arrays.asList(file.getAbsolutePath());
+    // the 'double_field' column does not have dictionary encoding
+    command.column = DOUBLE_FIELD;
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2120
  - ~In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).~

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
