### PR TITLE
Performance optimizations:  Merged all LittleEndianDataInputStream functionality into ByteBufferInputStream

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/rle/RunLengthBitPackingHybridDecoder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/rle/RunLengthBitPackingHybridDecoder.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.parquet.Preconditions;
+import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.column.values.bitpacking.BytePacker;
 import org.apache.parquet.column.values.bitpacking.Packer;
@@ -37,13 +38,16 @@ import org.slf4j.LoggerFactory;
 public class RunLengthBitPackingHybridDecoder {
   private static final Logger LOG = LoggerFactory.getLogger(RunLengthBitPackingHybridDecoder.class);
 
-  private static enum MODE { RLE, PACKED }
-
   private final int bitWidth;
   private final BytePacker packer;
-  private final InputStream in;
+  private final ByteBufferInputStream in;
 
-  private MODE mode;
+  /*
+  Note: In an older version, this class used to use an enum to keep track of the mode. Switching to a boolean
+  resulted in a measurable performance improvement.
+   */
+  boolean packed_mode;
+
   private int currentCount;
   private int currentValue;
   private int[] currentBuffer;
@@ -54,39 +58,41 @@ public class RunLengthBitPackingHybridDecoder {
     Preconditions.checkArgument(bitWidth >= 0 && bitWidth <= 32, "bitWidth must be >= 0 and <= 32");
     this.bitWidth = bitWidth;
     this.packer = Packer.LITTLE_ENDIAN.newBytePacker(bitWidth);
-    this.in = in;
+    // Every place in ParquetMR that calls this constructor does so with a ByteBufferInputStream. If some other
+    // user calls this with some other type, we can rely on the ClassCastException to be thrown.
+    this.in = (ByteBufferInputStream)in;
   }
 
   public int readInt() throws IOException {
     if (currentCount == 0) {
       readNext();
     }
-    -- currentCount;
+    --currentCount;
     int result;
-    switch (mode) {
-    case RLE:
-      result = currentValue;
-      break;
-    case PACKED:
-      result = currentBuffer[currentBuffer.length - 1 - currentCount];
-      break;
-    default:
-      throw new ParquetDecodingException("not a valid mode " + mode);
+    if (packed_mode) {
+      return currentBuffer[currentBuffer.length - 1 - currentCount];
+    } else {
+      return currentValue;
     }
-    return result;
   }
+
+  /*
+  Note: An older version used to create a DataInputStream just to be able to call readFully. This object creation
+  in the critical path was bad for performance. Since we're using the new ByteBufferInputStream, we can call
+  its built-in readFully, along with other optimized methods like readUnsignedVarInt and
+  readIntLittleEndianPaddedOnBitWidth, which replace the use of BytesUtils, which we can't count on being
+  inlined.
+   */
 
   private void readNext() throws IOException {
     Preconditions.checkArgument(in.available() > 0, "Reading past RLE/BitPacking stream.");
-    final int header = BytesUtils.readUnsignedVarInt(in);
-    mode = (header & 1) == 0 ? MODE.RLE : MODE.PACKED;
-    switch (mode) {
-    case RLE:
+    final int header = in.readUnsignedVarInt();
+    packed_mode = (header & 1) != 0;
+    if (!packed_mode) {
       currentCount = header >>> 1;
       LOG.debug("reading {} values RLE", currentCount);
-      currentValue = BytesUtils.readIntLittleEndianPaddedOnBitWidth(in, bitWidth);
-      break;
-    case PACKED:
+      currentValue = in.readIntLittleEndianPaddedOnBitWidth(bitWidth);
+    } else {
       int numGroups = header >>> 1;
       currentCount = numGroups * 8;
       LOG.debug("reading {} values BIT PACKED", currentCount);
@@ -95,13 +101,11 @@ public class RunLengthBitPackingHybridDecoder {
       // At the end of the file RLE data though, there might not be that many bytes left.
       int bytesToRead = (int)Math.ceil(currentCount * bitWidth / 8.0);
       bytesToRead = Math.min(bytesToRead, in.available());
-      new DataInputStream(in).readFully(bytes, 0, bytesToRead);
+      in.readFully(bytes, 0, bytesToRead);
       for (int valueIndex = 0, byteIndex = 0; valueIndex < currentCount; valueIndex += 8, byteIndex += bitWidth) {
+        // It's faster to use an array with unpack8Values than to use a ByteBuffer.
         packer.unpack8Values(bytes, byteIndex, currentBuffer, valueIndex);
       }
-      break;
-    default:
-      throw new ParquetDecodingException("not a valid mode " + mode);
     }
   }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/rle/TestRunLengthBitPackingHybridEncoder.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/rle/TestRunLengthBitPackingHybridEncoder.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.junit.Test;
 
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
@@ -294,7 +295,7 @@ public class TestRunLengthBitPackingHybridEncoder {
 	// bit width 2.
 	bytes[0] = (1 << 1 )| 1;
 	bytes[1] = (1 << 0) | (2 << 2) | (3 << 4);
-    ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
+    ByteBufferInputStream stream = new ByteBufferInputStream(bytes);
     RunLengthBitPackingHybridDecoder decoder = new RunLengthBitPackingHybridDecoder(2, stream);
     assertEquals(decoder.readInt(), 1);
     assertEquals(decoder.readInt(), 2);

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/ByteBufferInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/ByteBufferInputStream.java
@@ -97,7 +97,14 @@ public class ByteBufferInputStream extends InputStream {
    */
   @Deprecated
   public ByteBufferInputStream(ByteBuffer buffer, int offset, int count) {
-    delegate = wrap(buffer, offset, count);
+    // This is necessary to pass "TestDeprecatedBufferInputStream"...
+    ByteBuffer temp = buffer.duplicate();
+    temp.position(offset);
+    ByteBuffer byteBuf = temp.slice();
+    byteBuf.limit(count);
+    delegate = wrap(byteBuf);
+    // ... but it would probably be faster to do this:
+//    delegate = wrap(buffer, offset, count);
   }
 
   public ByteBufferInputStream(byte[] inBuf) {

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/LittleEndianDataInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/LittleEndianDataInputStream.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,6 +25,7 @@ import java.io.InputStream;
 /**
  * Based on DataInputStream but little endian and without the String/char methods
  */
+@Deprecated
 public final class LittleEndianDataInputStream extends InputStream {
 
   private final InputStream in;

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/SingleBufferInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/SingleBufferInputStream.java
@@ -59,6 +59,8 @@ class SingleBufferInputStream extends ByteBufferInputStream {
   SingleBufferInputStream(byte[] inBuf, int start, int length) {
     this.buffer = ByteBuffer.wrap(inBuf, start, length);
     this.buffer.order(java.nio.ByteOrder.LITTLE_ENDIAN);
+    // This seems to be consistent with HeapByteBuffer.wrap(), which leaves
+    // the internal "offset" at zero and sets the starting position at start.
     this.startPosition = 0;
   }
 
@@ -298,7 +300,7 @@ class SingleBufferInputStream extends ByteBufferInputStream {
   }
 
   @Override
-  public final long readLong() throws IOException {
+  public long readLong() throws IOException {
     try {
       return buffer.getLong();
     } catch (Exception e) {


### PR DESCRIPTION
This PR is all performance optimization. In benchmarking with Trino, we find query performance to improve from 5% to 15%, depending on the query, and that includes all the I/O time from S3.

The main modification is to merge all of LittleEndianDataInputStream functionality into ByteBufferInputStream, which yields the following benefits:
- Elimination of extra layers of abstraction and method call overhead
- Enable the use of intrinsics for readInt, readLong, etc.
- Availability of faster access methods like readFully and skipFully, without the need for helper functions
- Reduces some object creation in the performance critical path

This also includes and enables performance optimizations to:
- ByteBitPackingValuesReader
- PlainValuesReader
- RunLengthBitPackingHybridDecoder

Context:
I've been working on improving Parquet reading performance in Trino, mostly by profiling while running performance benchmarks and TPCDS queries. This PR is a subset of the changes I made that have more than doubled the performance of a lot of TPCDS queries (wall clock time, including the S3 access time). If you are kind enough to accept these changes, I have more I would like to contribute.