### PR TITLE
PARQUET-1020 Add DynamicMessage writing support

### DIFF
--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoSchemaConverter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoSchemaConverter.java
@@ -64,14 +64,18 @@ public class ProtoSchemaConverter {
     this.parquetSpecsCompliant = parquetSpecsCompliant;
   }
 
-  public MessageType convert(Class<? extends Message> protobufClass) {
-    LOG.debug("Converting protocol buffer class \"" + protobufClass + "\" to parquet schema.");
-    Descriptors.Descriptor descriptor = Protobufs.getMessageDescriptor(protobufClass);
+  public MessageType convert(Descriptors.Descriptor descriptor) {
     MessageType messageType =
         convertFields(Types.buildMessage(), descriptor.getFields())
         .named(descriptor.getFullName());
     LOG.debug("Converter info:\n " + descriptor.toProto() + " was converted to \n" + messageType);
     return messageType;
+  }
+
+  public MessageType convert(Class<? extends Message> protobufClass) {
+    LOG.debug("Converting protocol buffer class \"" + protobufClass + "\" to parquet schema.");
+    Descriptors.Descriptor descriptor = Protobufs.getMessageDescriptor(protobufClass);
+    return convert(descriptor);
   }
 
   /* Iterates over list of fields. **/

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -119,6 +119,8 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
   @Override
   public WriteContext init(Configuration configuration) {
 
+    Map<String, String> extraMetaData = new HashMap<>();
+
     // if no protobuf descriptor was given in constructor, load descriptor from configuration (set with setProtobufClass)
     if (descriptor == null) {
       if (protoMessage == null) {
@@ -132,9 +134,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
         }
       }
       descriptor = Protobufs.getMessageDescriptor(protoMessage);
-    } else {
-      //Assume no specific Message extending class, so use DynamicMessage
-      protoMessage = DynamicMessage.class;
+      extraMetaData.put(ProtoReadSupport.PB_CLASS, protoMessage.getName());
     }
 
     writeSpecsCompliant = configuration.getBoolean(PB_SPECS_COMPLIANT_WRITE, writeSpecsCompliant);
@@ -143,8 +143,6 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
 
     this.messageWriter = new MessageWriter(descriptor, rootSchema);
 
-    Map<String, String> extraMetaData = new HashMap<>();
-    extraMetaData.put(ProtoReadSupport.PB_CLASS, protoMessage.getName());
     extraMetaData.put(ProtoReadSupport.PB_DESCRIPTOR, descriptor.toProto().toString());
     extraMetaData.put(PB_SPECS_COMPLIANT_WRITE, String.valueOf(writeSpecsCompliant));
     return new WriteContext(rootSchema, extraMetaData);


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title:
  - https://issues.apache.org/jira/browse/PARQUET-1020


### Tests

- [X] My PR adds the following unit test:
  - testProto3SimplestDynamicMessage in parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does


This is sort of a resubmission of https://github.com/apache/parquet-mr/pull/414 as the PR has been left open for quite some time, and the branch has diverged a bit.
Please tell me if this is okay.