### PR TITLE
PARQUET-2148: Enable uniform decryption with plaintext footer

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/InternalFileDecryptor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/InternalFileDecryptor.java
@@ -102,14 +102,11 @@ public class InternalFileDecryptor {
     if (!fileCryptoMetaDataProcessed) {
       throw new ParquetCryptoRuntimeException("Haven't parsed the file crypto metadata yet");
     }
-    if (!encryptedFooter) {
-      return null;
-    }
 
     return getThriftModuleDecryptor(null);
   }
 
-  public void setFileCryptoMetaData(EncryptionAlgorithm algorithm, 
+  public void setFileCryptoMetaData(EncryptionAlgorithm algorithm,
       boolean encryptedFooter, byte[] footerKeyMetaData) {
 
     // first use of the decryptor
@@ -198,7 +195,7 @@ public class InternalFileDecryptor {
         }
       }
     } else {
-      // re-use of the decryptor 
+      // re-use of the decryptor
       // check the crypto metadata.
       if (!this.algorithm.equals(algorithm)) {
         throw new ParquetCryptoRuntimeException("Decryptor re-use: Different algorithm");
@@ -216,7 +213,7 @@ public class InternalFileDecryptor {
     }
   }
 
-  public InternalColumnDecryptionSetup setColumnCryptoMetadata(ColumnPath path, boolean encrypted, 
+  public InternalColumnDecryptionSetup setColumnCryptoMetadata(ColumnPath path, boolean encrypted,
       boolean encryptedWithFooterKey, byte[] keyMetadata, int columnOrdinal) {
 
     if (!fileCryptoMetaDataProcessed) {
@@ -246,7 +243,7 @@ public class InternalFileDecryptor {
         if (null == footerKey) {
           throw new ParquetCryptoRuntimeException("Column " + path + " is encrypted with NULL footer key");
         }
-        columnDecryptionSetup = new InternalColumnDecryptionSetup(path, true, true, 
+        columnDecryptionSetup = new InternalColumnDecryptionSetup(path, true, true,
             getDataModuleDecryptor(null), getThriftModuleDecryptor(null), columnOrdinal, null);
 
         if (LOG.isDebugEnabled()) {
@@ -265,7 +262,7 @@ public class InternalFileDecryptor {
         if (null == columnKeyBytes) {
           throw new ParquetCryptoRuntimeException("Column " + path + "is encrypted with NULL column key");
         }
-        columnDecryptionSetup = new InternalColumnDecryptionSetup(path, true, false, 
+        columnDecryptionSetup = new InternalColumnDecryptionSetup(path, true, false,
               getDataModuleDecryptor(columnKeyBytes), getThriftModuleDecryptor(columnKeyBytes), columnOrdinal, keyMetadata);
 
         if (LOG.isDebugEnabled()) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestEncryptionOptions.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestEncryptionOptions.java
@@ -93,6 +93,8 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
  *
  *  UNIFORM_ENCRYPTION:             Encrypt all columns and the footer with the same key.
  *                                  (uniform encryption)
+ *  UNIFORM_ENCRYPTION_PLAINTEXT_FOOTER: Encrypt all columns with the same key.
+ *                                  Do not encrypt footer.
  *  ENCRYPT_COLUMNS_AND_FOOTER:     Encrypt six columns and the footer, with different
  *                                  keys.
  *  ENCRYPT_COLUMNS_PLAINTEXT_FOOTER: Encrypt six columns, with different keys.
@@ -240,6 +242,17 @@ public class TestEncryptionOptions {
           .withEncryptedColumns(columnPropertiesMap)
           .withAlgorithm(ParquetCipher.AES_GCM_CTR_V1)
           .build();
+      }
+    },
+    UNIFORM_ENCRYPTION_PLAINTEXT_FOOTER {
+      /**
+       * Encryption configuration 7: Encrypt all columns with the same key.
+       * Don't encrypt footer.
+       */
+      public FileEncryptionProperties getEncryptionProperties() {
+        return FileEncryptionProperties.builder(FOOTER_ENCRYPTION_KEY)
+          .withPlaintextFooter()
+          .withFooterKeyMetadata(footerKeyMetadata).build();
       }
     },
     NO_ENCRYPTION {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestEncryptionOptions.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestEncryptionOptions.java
@@ -468,6 +468,9 @@ public class TestEncryptionOptions {
       if (readOnlyEncrypted && (EncryptionConfiguration.NO_ENCRYPTION == encryptionConfiguration)) {
         continue;
       }
+      if (EncryptionConfiguration.UNIFORM_ENCRYPTION_PLAINTEXT_FOOTER == encryptionConfiguration) {
+        continue;
+      }
       String fileName = getFileName(encryptionConfiguration);
       Path file = new Path(rootPath, fileName);
       if (!fs.exists(file)) {
@@ -492,6 +495,9 @@ public class TestEncryptionOptions {
       EncryptionConfiguration[] encryptionConfigurations = EncryptionConfiguration.values();
       for (EncryptionConfiguration encryptionConfiguration : encryptionConfigurations) {
         if (readOnlyEncrypted && (EncryptionConfiguration.NO_ENCRYPTION == encryptionConfiguration)) {
+          continue;
+        }
+        if (EncryptionConfiguration.UNIFORM_ENCRYPTION_PLAINTEXT_FOOTER == encryptionConfiguration) {
           continue;
         }
         Path file = new Path(root, getFileName(encryptionConfiguration));


### PR DESCRIPTION
Currently, uniform decryption is not enabled in the plaintext footer mode - for no good reason. Column metadata is available, we just need to decrypt and use it.