### PR TITLE
PARQUET-2154: `ParquetFileReader` should close its input stream when `filterRowGroups` throw Exception in constructor

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -715,7 +715,14 @@ public class ParquetFileReader implements Closeable {
                                       .withDecryption(fileDecryptor.getDecryptionProperties())
                                       .build();
     }
-    this.blocks = filterRowGroups(blocks);
+    try {
+      this.blocks = filterRowGroups(blocks);
+    } catch (IOException e) {
+      // In case that filterRowGroups throws an exception in the constructor, the new stream
+      // should be closed. Otherwise, there's no way to close this outside.
+      f.close();
+      throw e;
+    }
     this.blockIndexStores = listWithNulls(this.blocks.size());
     this.blockRowRanges = listWithNulls(this.blocks.size());
     for (ColumnDescriptor col : columns) {
@@ -759,7 +766,14 @@ public class ParquetFileReader implements Closeable {
                                       .build();
     }
     this.footer = footer;
-    this.blocks = filterRowGroups(footer.getBlocks());
+    try {
+      this.blocks = filterRowGroups(footer.getBlocks());
+    } catch (IOException e) {
+      // In case that filterRowGroups throws an exception in the constructor, the new stream
+      // should be closed. Otherwise, there's no way to close this outside.
+      f.close();
+      throw e;
+    }
     this.blockIndexStores = listWithNulls(this.blocks.size());
     this.blockRowRanges = listWithNulls(this.blocks.size());
     for (ColumnDescriptor col : footer.getFileMetaData().getSchema().getColumns()) {
@@ -787,7 +801,14 @@ public class ParquetFileReader implements Closeable {
       this.fileDecryptor = null; // Plaintext file. No need in decryptor
     }
 
-    this.blocks = filterRowGroups(footer.getBlocks());
+    try {
+      this.blocks = filterRowGroups(footer.getBlocks());
+    } catch (IOException e) {
+      // In case that filterRowGroups throws an exception in the constructor, the new stream
+      // should be closed. Otherwise, there's no way to close this outside.
+      f.close();
+      throw e;
+    }
     this.blockIndexStores = listWithNulls(this.blocks.size());
     this.blockRowRanges = listWithNulls(this.blocks.size());
     for (ColumnDescriptor col : footer.getFileMetaData().getSchema().getColumns()) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -717,7 +717,7 @@ public class ParquetFileReader implements Closeable {
     }
     try {
       this.blocks = filterRowGroups(blocks);
-    } catch (IOException e) {
+    } catch (Exception e) {
       // In case that filterRowGroups throws an exception in the constructor, the new stream
       // should be closed. Otherwise, there's no way to close this outside.
       f.close();
@@ -768,7 +768,7 @@ public class ParquetFileReader implements Closeable {
     this.footer = footer;
     try {
       this.blocks = filterRowGroups(footer.getBlocks());
-    } catch (IOException e) {
+    } catch (Exception e) {
       // In case that filterRowGroups throws an exception in the constructor, the new stream
       // should be closed. Otherwise, there's no way to close this outside.
       f.close();
@@ -803,7 +803,7 @@ public class ParquetFileReader implements Closeable {
 
     try {
       this.blocks = filterRowGroups(footer.getBlocks());
-    } catch (IOException e) {
+    } catch (Exception e) {
       // In case that filterRowGroups throws an exception in the constructor, the new stream
       // should be closed. Otherwise, there's no way to close this outside.
       f.close();


### PR DESCRIPTION
Similar to [PARQUET-1368](https://issues.apache.org/jira/browse/PARQUET-1368), during the construction of `ParquetFileReader`, if `filterRowGroups(footer.getBlocks())` throws an exception, it will cause resource leak because when the Exception thrown, the open stream `this.f = file.newStream()` looks unable to be closed.

 