### PR TITLE
Upgrade protobuf version to 3.20.1

### DIFF
--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <elephant-bird.version>4.4</elephant-bird.version>
-    <protobuf.version>3.16.1</protobuf.version>
+    <protobuf.version>3.20.1</protobuf.version>
     <truth-proto-extension.version>1.0</truth-proto-extension.version>
   </properties>
 


### PR DESCRIPTION
Currently the repo can't be compiled with M1 Mac:
```
com.google.protobuf:protoc:exe:osx-aarch_64:3.16.1 was not found in https://jitpack.io/ during a previous attempt.
```

since the artifact for M1 arch was not published: https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.16.1/

This upgrade the protobuf version to 3.20.1 to support compiling on M1 Mac.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2155
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
