### PR TITLE
PARQUET-2167: Fix CLI serializing footer with date fields

### DIFF
--- a/parquet-cli/pom.xml
+++ b/parquet-cli/pom.xml
@@ -106,6 +106,11 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>${jackson.datatype.groupId}</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
       <version>${jcommander.version}</version>

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowFooterCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowFooterCommand.java
@@ -23,6 +23,7 @@ import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndian;
 import static org.apache.parquet.hadoop.ParquetFileWriter.EFMAGIC;
 import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -86,6 +87,7 @@ public class ShowFooterCommand extends BaseCommand {
     ObjectMapper mapper = new ObjectMapper();
     mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+    mapper.registerModule(new JavaTimeModule());
     return mapper;
   }
 

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/FileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/FileTest.java
@@ -35,6 +35,7 @@ public abstract class FileTest {
   static final String DOUBLE_FIELD = "double_field";
   static final String BINARY_FIELD = "binary_field";
   static final String FIXED_LEN_BYTE_ARRAY_FIELD = "flba_field";
+  static final String DATE_FIELD = "date_field";
 
   static final String[] COLORS = {"RED", "BLUE", "YELLOW", "GREEN", "WHITE"};
 

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetFileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetFileTest.java
@@ -23,12 +23,17 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.format.DateType;
+import org.apache.parquet.format.LogicalType;
+import org.apache.parquet.format.LogicalTypes;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.GroupWriteSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Types;
 import org.junit.Before;
 
 import java.io.File;
@@ -59,15 +64,17 @@ public abstract class ParquetFileTest extends FileTest {
   }
 
   private static MessageType createSchema() {
-    return new MessageType("schema",
-      new PrimitiveType(REQUIRED, PrimitiveTypeName.INT32, INT32_FIELD),
-      new PrimitiveType(REQUIRED, PrimitiveTypeName.INT64, INT64_FIELD),
-      new PrimitiveType(REQUIRED, PrimitiveTypeName.FLOAT, FLOAT_FIELD),
-      new PrimitiveType(REQUIRED, PrimitiveTypeName.DOUBLE, DOUBLE_FIELD),
-      new PrimitiveType(REQUIRED, PrimitiveTypeName.BINARY, BINARY_FIELD),
-      new PrimitiveType(REQUIRED, PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
-        12, FIXED_LEN_BYTE_ARRAY_FIELD)
-    );
+    return Types.buildMessage()
+      .required(PrimitiveTypeName.INT32).named(INT32_FIELD)
+      .required(PrimitiveTypeName.INT64).named(INT64_FIELD)
+      .required(PrimitiveTypeName.FLOAT).named(FLOAT_FIELD)
+      .required(PrimitiveTypeName.DOUBLE).named(DOUBLE_FIELD)
+      .required(PrimitiveTypeName.BINARY).named(BINARY_FIELD)
+      .required(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY).length(12)
+        .named(FIXED_LEN_BYTE_ARRAY_FIELD)
+      .required(PrimitiveTypeName.INT32).as(LogicalTypeAnnotation.dateType())
+        .named(DATE_FIELD)
+      .named("schema");
   }
 
   private void createTestParquetFile() throws IOException {
@@ -102,7 +109,8 @@ public abstract class ParquetFileTest extends FileTest {
          .append(DOUBLE_FIELD, 2.0d + i)
          .append(BINARY_FIELD, Binary.fromString(COLORS[i % COLORS.length]))
          .append(FIXED_LEN_BYTE_ARRAY_FIELD,
-           Binary.fromConstantByteArray(bytes)));
+           Binary.fromConstantByteArray(bytes))
+         .append(DATE_FIELD, i));
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <github.global.server>github</github.global.server>
     <jackson.groupId>com.fasterxml.jackson.core</jackson.groupId>
+    <jackson.datatype.groupId>com.fasterxml.jackson.datatype</jackson.datatype.groupId>
     <jackson.package>com.fasterxml.jackson</jackson.package>
     <jackson.version>2.13.2</jackson.version>
     <jackson-databind.version>2.13.2.2</jackson-databind.version>


### PR DESCRIPTION
This PR fixes an issue when attempting to use the CLI to view the footer of a file with date fields. The error thrown is ```com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.ZoneOffset` not supported by default```.

The fix is to register the JavaTimeModue() with the Jackson object mapper.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2167
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
I updated the existing test to include a date field to cover this case.

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
