### PR TITLE
PARQUET-2160: Close ZstdInputStream to free off-heap memory in time.

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.compression.CompressionCodecFactory;
+import org.apache.parquet.hadoop.codec.ZstandardCodec;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 public class CodecFactory implements CompressionCodecFactory {
@@ -109,7 +110,12 @@ public class CodecFactory implements CompressionCodecFactory {
           decompressor.reset();
         }
         InputStream is = codec.createInputStream(bytes.toInputStream(), decompressor);
-        decompressed = BytesInput.from(is, uncompressedSize);
+        if (codec instanceof ZstandardCodec) {
+          decompressed = BytesInput.copy(BytesInput.from(is, uncompressedSize));
+          is.close();
+        } else {
+          decompressed = BytesInput.from(is, uncompressedSize);
+        }
       } else {
         decompressed = bytes;
       }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
@@ -110,6 +110,11 @@ public class CodecFactory implements CompressionCodecFactory {
           decompressor.reset();
         }
         InputStream is = codec.createInputStream(bytes.toInputStream(), decompressor);
+
+        // We need to explicitly close the ZstdDecompressorStream here to release the resources it holds to avoid
+        // off-heap memory fragmentation issue, see https://issues.apache.org/jira/browse/PARQUET-2160.
+        // This change will load the decompressor stream into heap a little earlier, since the problem it solves
+        // only happens in the ZSTD codec, so this modification is only made for ZSTD streams.
         if (codec instanceof ZstandardCodec) {
           decompressed = BytesInput.copy(BytesInput.from(is, uncompressedSize));
           is.close();


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET-2160) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2160
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does

### Benchmark

**Benchmark:** 
The benchmark data consists of 500 string columns * 1_000_000  rows(10.85GB under ZSTD compression), and the benchmark is simply reading all the data out and pass them to the black hole.

**JMH Configuration:**
3 rounds of warmup iterations
5 rounds of  measurenemt iterations

**Notes:** 
> - Closing the input stream means reading the decompressed data into the heap early and closing the input stream, which is the method proposed in this pr. Not closing the stream means leaving the stream to the GC. 
>- The JMH Score in the table below is the average of multiple rounds of measurement, while GC Events and GC Time are the statistical values of the total measurement process (3 rounds of Warmup + 5 rounds of Measurement)

According to the benchmark results below, _closing stream_ does not bring additional heap overload, but improves GC instead. From the comparison of the first two results of below table, we can see that _closing stream_ improves the read performance and reduces the GC load.

I also measured the impact of heap size (GC) on read performance. After reducing heap memory to 3GB, GC Events increased, but the read performance is not decreased; However, after increasing heap memory to 5GB, GC Events decreased by about 30% , but the GC time has increased by about 2 times, and the read performance has also been significantly reduced, which may verify the previous guess in Jira: Untimely GC may exacerbate the off-heap memory fragmentation issue. (Of course, this may require more in-depth testing to corroborate)

<div class="okr-block-clipboard" data-okr="%7B%22okrDelta%22%3A%5B%7B%22lineType%22%3A%22unsupport%22%2C%22lineOptions%22%3A%7B%7D%2C%22lineContent%22%3A%5B%5D%7D%5D%2C%22businessKey%22%3A%22lark-doc%22%7D"></div><div data-zone-id="0" data-line-index="0" style="white-space: pre;">

Compression | Close Inputstream | Heap Size(GB) | JMH Score ± Error (s/op) | GC Events | GC Time(s)
-- | -- | -- | -- | -- | --
ZSTD | No | 4 | 53.374 ± 3.303 | 1591 | 40.069
ZSTD | Yes | 4 | 49.613 ± 2.564 | 928 | 17.194
ZSTD | No | 3 | 53.303 ± 1.431 | 2174 | 46.121
ZSTD | No | 5 | 75.993 ± 10.919 | 950 | 116.184

</div>

Out of curiosity, I also tested the effect of _closing stream_ on Snappy and Gzip, the benchmark results show that in such simple read scenario _closing stream_ also has some positive effect on both Snappy and Gzip.

<div class="okr-block-clipboard" data-okr="%7B%22okrDelta%22%3A%5B%7B%22lineType%22%3A%22unsupport%22%2C%22lineOptions%22%3A%7B%7D%2C%22lineContent%22%3A%5B%5D%7D%5D%2C%22businessKey%22%3A%22lark-doc%22%7D"></div><div data-zone-id="0" data-line-index="0" style="white-space: pre;">

Compression | Close Inputstream | Heap Size(GB) | JMH Score ± Error (s/op) | GC Events | GC Time(s)
-- | -- | -- | -- | -- | --
Snappy | No | 4 | 38.835 ± 7.505 | 1618 | 40.193
Snappy | Yes | 4 | 33.796 ± 2.871 | 872 | 12.449
Gzip | No | 4 | 94.902 ± 5.833 | 1539 | 39.630
Gzip | Yes | 4 | 86.160 ± 2.329 | 843 | 12.153

</div>

For more details, please refer to the following pictures:

**ZSTD + Not close + 4GB**
![image](https://user-images.githubusercontent.com/42907416/188415100-76554e82-57ee-45b4-b085-76d1660d295c.png)
![image](https://user-images.githubusercontent.com/42907416/188415170-5faea357-7b81-41ac-a25e-3e2ba873019d.png)

**ZSTD + Close + 4GB**
![image](https://user-images.githubusercontent.com/42907416/188415290-26bd5a1f-f3be-430f-b85e-17b930169501.png)
![image](https://user-images.githubusercontent.com/42907416/188415338-82a0ec76-bc32-4bc5-aed7-152d25b9fb0d.png)

**ZSTD + Not close + 3GB**
![image](https://user-images.githubusercontent.com/42907416/188415503-f285ff1d-f321-4524-8e64-1880eb099c4f.png)
![image](https://user-images.githubusercontent.com/42907416/188415531-2127c2c1-b5dc-45b0-b378-1a826261b735.png)

**ZSTD + Not close + 5GB**
![image](https://user-images.githubusercontent.com/42907416/188415590-53d5c34e-ba16-4098-9881-3122775f5526.png)
![image](https://user-images.githubusercontent.com/42907416/188415628-43423129-b71a-46a7-b9b5-ff890d3d3eee.png)

**Snappy + Not close + 4GB**
![image](https://user-images.githubusercontent.com/42907416/188420408-cdaa1377-a87b-4d70-93ae-df58a46d541f.png)
![image](https://user-images.githubusercontent.com/42907416/188420473-7a595459-50fc-4f21-bdd2-dcb4d016914e.png)

**Snappy + Close + 4GB**
![image](https://user-images.githubusercontent.com/42907416/188415810-baaa8cc1-bd68-45cd-b849-a6b119ef95a9.png)
![image](https://user-images.githubusercontent.com/42907416/188415829-69fdb1b5-7cd5-4d5a-8f36-97fdc96e1480.png)

**Gzip + Not Close + 4GB**
![image](https://user-images.githubusercontent.com/42907416/188415918-dab5fc49-549f-4d4c-81f8-2627172fa5de.png)
![image](https://user-images.githubusercontent.com/42907416/188415942-5393d945-b8a4-40ac-8110-6357a00ecd1a.png)

**Gzip + Close + 4GB**
![image](https://user-images.githubusercontent.com/42907416/188415975-ec1b178e-e4a1-40a9-8309-6154abbd4653.png)
![image](https://user-images.githubusercontent.com/42907416/188415994-e69574d2-2e18-4988-9361-3de66f9d9e2a.png)

