### PR TITLE
PARQUET-2173. Fix parquet build against hadoop 3.3.3+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,11 @@
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -188,7 +192,11 @@
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -199,7 +207,11 @@
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -285,6 +297,7 @@
                 <bannedDependencies>
                   <excludes>
                     <exclude>org.slf4j:slf4j-log4j12:*:*:compile</exclude>
+                    <exclude>org.slf4j:slf4j-reload4j:*:*:compile</exclude>
                   </excludes>
                 </bannedDependencies>
               </rules>


### PR DESCRIPTION

Hadoop 3.3.3 moved to reload4j for logging to stop
shipping a version of log4j with known (albeit unused)
CVEs.

This bypasses the existing exclusion code used to
keep hadoop's SLF4J dependency off the classpaths,
and by adding a new jar, breaks parquet-cli build.


Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

The testing is regression testing "does the build work?", "does a test run complete without SLF4J warnings of duplicates?". done manually with `-Dhadoop.version=3.3.4`

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
