### PR TITLE
Prevent IntelliJ from making unsolicited whitespace changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,7 +22,6 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
-trim_trailing_whitespace = true
 indent_style = space
 
 [*.scala]


### PR DESCRIPTION
Every time I make a PR on this project, I get a whole bunch of complaints about superfluous whitespace changes that I have to manually revert. Those changes are caused by a flag in .editorconfig called trim_trailing_whitespace. By removing this flag, we should stop seeing those complaints.