### PR TITLE
PARQUET-1711: Break circular dependencies in proto definitions

### DIFF
--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaConverterTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaConverterTest.java
@@ -342,4 +342,34 @@ public class ProtoSchemaConverterTest {
 
     testConversion(TestProto3.MapIntMessage.class, expectedSchema, false);
   }
+
+  @Test
+  public void testCircularDependencyCutoff() throws Exception {
+    String expectedSchema =
+      "message TestProtobuf.CircularDependency1 {\n" +
+        "  optional int32 identifier = 1;\n" +
+        "  optional group dependency2 = 2 {\n" +
+        "    optional binary name (STRING) = 1;\n" +
+        "    optional group dependency1 = 2 {\n" +
+        "      optional int32 identifier = 1;\n" +
+        "    }\n" +
+        "  }\n" +
+        "}";
+    testConversion(TestProtobuf.CircularDependency1.class, expectedSchema, false);
+  }
+
+  @Test
+  public void testProto3CircularDependencyCutoff() throws Exception {
+    String expectedSchema =
+      "message TestProto3.CircularDependency1 {\n" +
+        "  optional int32 identifier = 1;\n" +
+        "  optional group dependency2 = 2 {\n" +
+        "    optional binary name (STRING) = 1;\n" +
+        "    optional group dependency1 = 2 {\n" +
+        "      optional int32 identifier = 1;\n" +
+        "    }\n" +
+        "  }\n" +
+        "}";
+    testConversion(TestProto3.CircularDependency1.class, expectedSchema, false);
+  }
 }

--- a/parquet-protobuf/src/test/resources/TestProto3.proto
+++ b/parquet-protobuf/src/test/resources/TestProto3.proto
@@ -156,3 +156,13 @@ message FirstCustomClassMessage {
 message SecondCustomClassMessage {
     string string = 11;
 }
+
+message CircularDependency1 {
+  int32 identifier = 1;
+  CircularDependency2 dependency2 = 2;
+}
+
+message CircularDependency2 {
+  string name = 1;
+  CircularDependency1 dependency1 = 2;
+}

--- a/parquet-protobuf/src/test/resources/TestProtobuf.proto
+++ b/parquet-protobuf/src/test/resources/TestProtobuf.proto
@@ -158,3 +158,13 @@ message Airplane {
         optional int32 wingSpan = 101;
     }
 }
+
+message CircularDependency1 {
+  optional int32 identifier = 1;
+  optional CircularDependency2 dependency2 = 2;
+}
+
+message CircularDependency2 {
+  optional string name = 1;
+  optional CircularDependency1 dependency1 = 2;
+}


### PR DESCRIPTION
In case some proto definitions have circular dependencies, the proto schema converter breaks those and logs a warning, instead of a `StackOverflowException`.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1711

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Proto definitions with circular dependencies tested in `ProtoSchemaConverterTest`

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
