### PR TITLE
PARQUET-2142: Update the parquet-cli document to avoid NoSuchMethodError

### DIFF
--- a/parquet-cli/README.md
+++ b/parquet-cli/README.md
@@ -31,13 +31,13 @@ mvn clean install -DskipTests
 The build produces a shaded Jar that can be run using the `hadoop` command:
 
 ```
-hadoop jar parquet-cli-1.9.1-runtime.jar org.apache.parquet.cli.Main
+hadoop jar parquet-cli-1.12.3-runtime.jar org.apache.parquet.cli.Main
 ```
 
 For a shorter command-line invocation, add an alias to your shell like this:
 
 ```
-alias parquet="hadoop jar /path/to/parquet-cli-1.9.1-runtime.jar org.apache.parquet.cli.Main --dollar-zero parquet"
+alias parquet="hadoop jar /path/to/parquet-cli-1.12.3-runtime.jar org.apache.parquet.cli.Main --dollar-zero parquet"
 ```
 
 ### Running without Hadoop
@@ -51,8 +51,13 @@ mvn dependency:copy-dependencies
 Then, run the command-line and add `target/dependencies/*` to the classpath:
 
 ```
-java -cp 'target/*:target/dependency/*' org.apache.parquet.cli.Main
+java -cp 'target/parquet-cli-1.12.3.jar:target/dependency/*' org.apache.parquet.cli.Main
 ```
+
+Note that you shouldn't include the runtime jar used above into the classpath in this case.
+In that jar, the `org.apache.avro package` is relocated for avoiding conflict with Hadoop's one.
+That relocation changes method signatures, so it can cause `NoSuchMethodError` depending on the class loading order.
+See PARQUET-2142 for details.
 
 
 ### Help
@@ -100,7 +105,7 @@ Usage: parquet [options] [command] [command options]
   Examples:
 
     # print information for create
-    parquet help create
+    parquet help meta
 
   See 'parquet help <command>' for more information on a specific command.
 ```


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2142
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR doesn't need testing since it's just a documentation fix.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
