### PR TITLE
PARQUET-2177: Fix parquet-cli not to fail showing descriptions

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/Help.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/Help.java
@@ -59,10 +59,13 @@ public class Help implements Command {
         }
 
         boolean hasRequired = false;
-        console.info("\nUsage: {} [general options] {} {} [command options]",
-            new Object[] {
-                programName, cmd,
-                commander.getMainParameterDescription()});
+        if (commander.getParameters().stream().anyMatch(p -> p.getNames().isEmpty())) {
+          console.info("\nUsage: {} [general options] {} {} [command options]",
+            new Object[] { programName, cmd, commander.getMainParameterDescription() });
+        } else {
+          console.info("\nUsage: {} [general options] {} [command options]",
+            new Object[] { programName, cmd });
+        }
         console.info("\n  Description:");
         console.info("\n    {}", jc.getCommandDescription(cmd));
         if (!commander.getParameters().isEmpty()) {

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnMaskingCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnMaskingCommand.java
@@ -53,22 +53,26 @@ public class ColumnMaskingCommand extends BaseCommand {
 
   @Parameter(
     names = {"-m", "--mode"},
-    description = "<mask mode: nullify>")
+    description = "<mask mode: nullify>",
+    required = true)
   String mode;
 
   @Parameter(
     names = {"-i", "--input"},
-    description = "<input parquet file path>")
+    description = "<input parquet file path>",
+    required = true)
   String input;
 
   @Parameter(
     names = {"-o", "--output"},
-    description = "<output parquet file path>")
+    description = "<output parquet file path>",
+    required = true)
   String output;
 
   @Parameter(
     names = {"-c", "--columns"},
-    description = "<columns to be replaced with masked value>")
+    description = "<columns to be replaced with masked value>",
+    required = true)
   List<String> cols;
 
   @Override
@@ -104,7 +108,7 @@ public class ColumnMaskingCommand extends BaseCommand {
   public List<String> getExamples() {
     return Lists.newArrayList(
         "# Replace columns with masked values and write to a new Parquet file",
-        " -m nullify -i input.parquet -o output.parquet -c col1_name"
+        "-m nullify -i input.parquet -o output.parquet -c col1_name"
     );
   }
 }

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/PruneColumnsCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/PruneColumnsCommand.java
@@ -41,19 +41,19 @@ public class PruneColumnsCommand extends BaseCommand {
   @Parameter(
     names = {"-i", "--input"},
     description = "<input parquet file path>",
-    required = false)
+    required = true)
   String input;
 
   @Parameter(
     names = {"-o", "--output"},
     description = "<output parquet file path>",
-    required = false)
+    required = true)
   String output;
 
   @Parameter(
     names = {"-c", "--columns"},
     description = "<columns to be replaced with masked value>",
-    required = false)
+    required = true)
   List<String> cols;
 
   @Override
@@ -75,7 +75,7 @@ public class PruneColumnsCommand extends BaseCommand {
   public List<String> getExamples() {
     return Lists.newArrayList(
       "# Removes specified columns and write to a new Parquet file",
-      " -i input.parquet -o output.parquet -c col1_name"
+      "-i input.parquet -o output.parquet -c col1_name"
     );
   }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2177
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, instead:

* Ran `mvn clean install` locally and got no build and test failure.
* Ran the `help prune` and `help masking` commands and ensured their descriptions were displayed as expected. Also ran `help meta` and there was no regression problem.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
