### PR TITLE
PARQUET-1711: support recursive proto schemas by limiting recursion depth

### DIFF
--- a/parquet-protobuf/README.md
+++ b/parquet-protobuf/README.md
@@ -20,4 +20,4 @@
 parquet-protobuf
 ================
 
-Protocol Buffer support for Parquet columnar format
+Protocol Buffer support for Parquet columnar format.

--- a/parquet-protobuf/pom.xml
+++ b/parquet-protobuf/pom.xml
@@ -47,10 +47,20 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>${jsr305.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.truth.extensions</groupId>
       <artifactId>truth-proto-extension</artifactId>
       <version>${truth-proto-extension.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -131,6 +141,12 @@
   </developers>
 
   <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+      </testResource>
+    </testResources>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -177,6 +193,7 @@
               <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
               <addSources>test</addSources>
               <addProtoSources>all</addProtoSources>
+              <includeMavenTypes>direct</includeMavenTypes>
               <outputDirectory>${project.build.directory}/generated-test-sources/java</outputDirectory>
               <inputDirectories>
                 <include>src/test/resources</include>
@@ -185,7 +202,6 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
 

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoSchemaConverter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoSchemaConverter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.proto;
 
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
@@ -34,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import javax.annotation.Nullable;
 
 import static org.apache.parquet.schema.LogicalTypeAnnotation.enumType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.listType;
@@ -48,48 +50,108 @@ public class ProtoSchemaConverter {
 
   private static final Logger LOG = LoggerFactory.getLogger(ProtoSchemaConverter.class);
   private final boolean parquetSpecsCompliant;
+  // TODO: use proto custom options to override per field.
+  private final int maxRecursion;
 
+  /**
+   * Instantiate a schema converter to get the parquet schema corresponding to protobuf classes.
+   * Returns instances that are not parquetSpecsCompliant with a maxRecursion of 5.
+   */
   public ProtoSchemaConverter() {
     this(false);
   }
 
   /**
    * Instantiate a schema converter to get the parquet schema corresponding to protobuf classes.
+   * Returns instances limited to 5 levels of recursion depth.
+   *
    * @param parquetSpecsCompliant   If set to false, the parquet schema generated will be using the old
    *                                schema style (prior to PARQUET-968) to provide backward-compatibility
    *                                but which does not use LIST and MAP wrappers around collections as required
    *                                by the parquet specifications. If set to true, specs compliant schemas are used.
    */
   public ProtoSchemaConverter(boolean parquetSpecsCompliant) {
-    this.parquetSpecsCompliant = parquetSpecsCompliant;
+    this(parquetSpecsCompliant, 5);
   }
 
+  /**
+   * Instantiate a schema converter to get the parquet schema corresponding to protobuf classes.
+   * Returns instances that are not specs compliant and limited to 5 levels of recursion depth.
+   *
+   * @param config   Hadoop configuration object to parrse parquetSpecsCompliant and maxRecursion settings.
+   */
+  public ProtoSchemaConverter(Configuration config) {
+    this(
+        config.getBoolean(ProtoWriteSupport.PB_SPECS_COMPLIANT_WRITE, false),
+        config.getInt(PB_MAX_RECURSION, 5));
+  }
+
+  /**
+   * Instantiate a schema converter to get the parquet schema corresponding to protobuf classes.
+   *
+   * @param parquetSpecsCompliant   If set to false, the parquet schema generated will be using the old
+   *                                schema style (prior to PARQUET-968) to provide backward-compatibility
+   *                                but which does not use LIST and MAP wrappers around collections as required
+   *                                by the parquet specifications. If set to true, specs compliant schemas are used.
+   * @param maxRecursion            The maximum recursion depth messages are allowed to go before terminating as
+   *                                bytes instead of their actual schema.
+   */
+  public ProtoSchemaConverter(boolean parquetSpecsCompliant, int maxRecursion) {
+    this.parquetSpecsCompliant = parquetSpecsCompliant;
+    this.maxRecursion = maxRecursion;
+  }
+
+  /**
+   * Sets the maximum recursion depth for recursive schemas.
+   *
+   * @param config        The hadoop configuration to be updated.
+   * @param maxRecursion  The maximum recursion depth messages are allowed to go before terminating as
+   *                      bytes instead of their actual schema.
+   */
+  public static void setMaxRecursion(Configuration config, int maxRecursion) {
+    config.setInt(PB_MAX_RECURSION, maxRecursion);
+  }
+
+  /**
+   * Converts a given protobuf message descriptor to a parquet schema.
+   *
+   * @param descriptor  The protobuf message descriptor to convert.
+   * @return The parquet schema encoded as a MessageType.
+   */
   public MessageType convert(Descriptors.Descriptor descriptor) {
-    MessageType messageType =
-        convertFields(Types.buildMessage(), descriptor.getFields())
+    // Remember classes seen with depths to avoid cycles.
+    int depth = 0;
+    ImmutableSetMultimap<String, Integer> seen = ImmutableSetMultimap.of(descriptor.getFullName(), depth);
+    LOG.trace("convert:\n{}", descriptor.toProto());
+    MessageType messageType = convertFields(Types.buildMessage(), descriptor.getFields(), seen, depth)
         .named(descriptor.getFullName());
-    LOG.debug("Converter info:\n " + descriptor.toProto() + " was converted to \n" + messageType);
+    LOG.debug("Converter info:\n{}\n  was converted to:\n{}", descriptor.toProto(), messageType);
     return messageType;
   }
 
+  /**
+   * Converts a given protobuf message class to a parquet schema.
+   *
+   * @param protobufClass  The protobuf message class (e.g. MyMessage.class) to convert.
+   * @return The parquet schema encoded as a MessageType.
+   */
   public MessageType convert(Class<? extends Message> protobufClass) {
-    LOG.debug("Converting protocol buffer class \"" + protobufClass + "\" to parquet schema.");
+    LOG.debug("Converting protocol buffer class \"{}\" to parquet schema", protobufClass);
     Descriptors.Descriptor descriptor = Protobufs.getMessageDescriptor(protobufClass);
     return convert(descriptor);
   }
 
   /* Iterates over list of fields. **/
-  private <T> GroupBuilder<T> convertFields(GroupBuilder<T> groupBuilder, List<FieldDescriptor> fieldDescriptors) {
+  private <T> GroupBuilder<T> convertFields(GroupBuilder<T> groupBuilder, List<FieldDescriptor> fieldDescriptors, ImmutableSetMultimap<String, Integer> seen, int depth) {
     for (FieldDescriptor fieldDescriptor : fieldDescriptors) {
-      groupBuilder =
-          addField(fieldDescriptor, groupBuilder)
+      groupBuilder = addField(fieldDescriptor, groupBuilder, seen, depth)
           .id(fieldDescriptor.getNumber())
           .named(fieldDescriptor.getName());
     }
     return groupBuilder;
   }
 
-  private Type.Repetition getRepetition(FieldDescriptor descriptor) {
+  private static Type.Repetition getRepetition(FieldDescriptor descriptor) {
     if (descriptor.isRequired()) {
       return Type.Repetition.REQUIRED;
     } else if (descriptor.isRepeated()) {
@@ -99,9 +161,9 @@ public class ProtoSchemaConverter {
     }
   }
 
-  private <T> Builder<? extends Builder<?, GroupBuilder<T>>, GroupBuilder<T>> addField(FieldDescriptor descriptor, final GroupBuilder<T> builder) {
+  private <T> Builder<? extends Builder<?, GroupBuilder<T>>, GroupBuilder<T>> addField(FieldDescriptor descriptor, final GroupBuilder<T> builder, ImmutableSetMultimap<String, Integer> seen, int depth) {
     if (descriptor.getJavaType() == JavaType.MESSAGE) {
-      return addMessageField(descriptor, builder);
+      return addMessageField(descriptor, builder, seen, depth);
     }
 
     ParquetType parquetType = getParquetType(descriptor);
@@ -113,7 +175,7 @@ public class ProtoSchemaConverter {
     return builder.primitive(parquetType.primitiveType, getRepetition(descriptor)).as(parquetType.logicalTypeAnnotation);
   }
 
-  private <T> Builder<? extends Builder<?, GroupBuilder<T>>, GroupBuilder<T>> addRepeatedPrimitive(PrimitiveTypeName primitiveType,
+  private static <T> Builder<? extends Builder<?, GroupBuilder<T>>, GroupBuilder<T>> addRepeatedPrimitive(PrimitiveTypeName primitiveType,
                                                                                                    LogicalTypeAnnotation logicalTypeAnnotation,
                                                                                                    final GroupBuilder<T> builder) {
     return builder
@@ -124,35 +186,61 @@ public class ProtoSchemaConverter {
         .named("list");
   }
 
-  private <T> GroupBuilder<GroupBuilder<T>> addRepeatedMessage(FieldDescriptor descriptor, GroupBuilder<T> builder) {
-    GroupBuilder<GroupBuilder<GroupBuilder<GroupBuilder<T>>>> result =
-      builder
+  private <T> GroupBuilder<GroupBuilder<T>> addRepeatedMessage(FieldDescriptor descriptor, GroupBuilder<T> builder, ImmutableSetMultimap<String, Integer> seen, int depth) {
+    GroupBuilder<GroupBuilder<GroupBuilder<GroupBuilder<T>>>> result = builder
         .group(Type.Repetition.OPTIONAL).as(listType())
         .group(Type.Repetition.REPEATED)
         .group(Type.Repetition.OPTIONAL);
 
-    convertFields(result, descriptor.getMessageType().getFields());
+    convertFields(result, descriptor.getMessageType().getFields(), seen, depth);
 
     return result.named("element").named("list");
   }
 
-  private <T> GroupBuilder<GroupBuilder<T>> addMessageField(FieldDescriptor descriptor, final GroupBuilder<T> builder) {
-    if (descriptor.isMapField() && parquetSpecsCompliant) {
-      // the old schema style did not include the MAP wrapper around map groups
-      return addMapField(descriptor, builder);
-    }
-    if (descriptor.isRepeated() && parquetSpecsCompliant) {
-      // the old schema style did not include the LIST wrapper around repeated messages
-      return addRepeatedMessage(descriptor, builder);
+  private <T> Builder<? extends Builder<?, GroupBuilder<T>>, GroupBuilder<T>> addMessageField(FieldDescriptor descriptor, final GroupBuilder<T> builder, ImmutableSetMultimap<String, Integer> seen, int depth) {
+    // Prevent recursion by terminating with optional proto bytes.
+    depth += 1;
+    String typeName = getInnerTypeName(descriptor);
+    LOG.trace("addMessageField: {} type: {} depth: {}", descriptor.getFullName(), typeName, depth);
+    if (typeName != null) {
+      if (seen.get(typeName).size() > maxRecursion) {
+        return builder.primitive(BINARY, Type.Repetition.OPTIONAL).as((LogicalTypeAnnotation) null);
+      }
     }
 
-    // Plain message
+    if (descriptor.isMapField() && parquetSpecsCompliant) {
+      // the old schema style did not include the MAP wrapper around map groups
+      return addMapField(descriptor, builder, seen, depth);
+    }
+
+    seen = ImmutableSetMultimap.<String, Integer>builder().putAll(seen).put(typeName, depth).build();
+
+    if (descriptor.isRepeated() && parquetSpecsCompliant) {
+      // the old schema style did not include the LIST wrapper around repeated messages
+      return addRepeatedMessage(descriptor, builder, seen, depth);
+    }
+
+    // Plain message.
     GroupBuilder<GroupBuilder<T>> group = builder.group(getRepetition(descriptor));
-    convertFields(group, descriptor.getMessageType().getFields());
+    convertFields(group, descriptor.getMessageType().getFields(), seen, depth);
     return group;
   }
 
-  private <T> GroupBuilder<GroupBuilder<T>> addMapField(FieldDescriptor descriptor, final GroupBuilder<T> builder) {
+  @Nullable
+  private String getInnerTypeName(FieldDescriptor descriptor) {
+    if (descriptor.isMapField() && parquetSpecsCompliant) {
+      descriptor = descriptor.getMessageType().getFields().get(1);
+    }
+    if (descriptor.getJavaType() != JavaType.MESSAGE) {
+      LOG.trace("getInnerTypeName: {} => primitive", descriptor.getFullName());
+      return null;
+    }
+    String name = descriptor.getMessageType().getFullName();
+    LOG.trace("getInnerTypeName: {} => {}", descriptor.getFullName(), name);
+    return name;
+  }
+
+  private <T> GroupBuilder<GroupBuilder<T>> addMapField(FieldDescriptor descriptor, final GroupBuilder<T> builder, ImmutableSetMultimap<String, Integer> seen, int depth) {
     List<FieldDescriptor> fields = descriptor.getMessageType().getFields();
     if (fields.size() != 2) {
       throw new UnsupportedOperationException("Expected two fields for the map (key/value), but got: " + fields);
@@ -161,16 +249,16 @@ public class ProtoSchemaConverter {
     ParquetType mapKeyParquetType = getParquetType(fields.get(0));
 
     GroupBuilder<GroupBuilder<GroupBuilder<T>>> group = builder
-      .group(Type.Repetition.OPTIONAL).as(mapType()) // only optional maps are allowed in Proto3
-      .group(Type.Repetition.REPEATED) // key_value wrapper
-      .primitive(mapKeyParquetType.primitiveType, Type.Repetition.REQUIRED).as(mapKeyParquetType.logicalTypeAnnotation).named("key");
+        .group(Type.Repetition.OPTIONAL).as(mapType()) // only optional maps are allowed in Proto3
+        .group(Type.Repetition.REPEATED) // key_value wrapper
+        .primitive(mapKeyParquetType.primitiveType, Type.Repetition.REQUIRED).as(mapKeyParquetType.logicalTypeAnnotation).named("key");
 
-    return addField(fields.get(1), group).named("value")
-      .named("key_value");
+    return addField(fields.get(1), group, seen, depth)
+        .named("value")
+        .named("key_value");
   }
 
-  private ParquetType getParquetType(FieldDescriptor fieldDescriptor) {
-
+  private static ParquetType getParquetType(FieldDescriptor fieldDescriptor) {
     JavaType javaType = fieldDescriptor.getJavaType();
     switch (javaType) {
       case INT: return ParquetType.of(INT32);
@@ -203,5 +291,4 @@ public class ProtoSchemaConverter {
       return of(primitiveType, null);
     }
   }
-
 }

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoSchemaConverter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoSchemaConverter.java
@@ -24,6 +24,7 @@ import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 import com.google.protobuf.Message;
 import com.twitter.elephantbird.util.Protobufs;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
@@ -49,6 +50,8 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.*;
 public class ProtoSchemaConverter {
 
   private static final Logger LOG = LoggerFactory.getLogger(ProtoSchemaConverter.class);
+  public static final String PB_MAX_RECURSION = "parquet.proto.maxRecursion";
+
   private final boolean parquetSpecsCompliant;
   // TODO: use proto custom options to override per field.
   private final int maxRecursion;

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -52,7 +52,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
   // PARQUET-968 introduces changes to allow writing specs compliant schemas with parquet-protobuf.
   // In the past, collection were not written using the LIST and MAP wrappers and thus were not compliant
   // with the parquet specs. This flag, is set to true, allows to write using spec compliant schemas
-  // but is set to false by default to keep backward compatibility
+  // but is set to false by default to keep backward compatibility.
   public static final String PB_SPECS_COMPLIANT_WRITE = "parquet.proto.writeSpecsCompliant";
 
   private boolean writeSpecsCompliant = false;
@@ -105,7 +105,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
       messageWriter.writeTopLevelMessage(record);
     } catch (RuntimeException e) {
       Message m = (record instanceof Message.Builder) ? ((Message.Builder) record).build() : (Message) record;
-      LOG.error("Cannot write message " + e.getMessage() + " : " + m);
+      LOG.error("Cannot write message {}: {}", e.getMessage(), m);
       throw e;
     }
     recordConsumer.endMessage();
@@ -138,7 +138,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
     }
 
     writeSpecsCompliant = configuration.getBoolean(PB_SPECS_COMPLIANT_WRITE, writeSpecsCompliant);
-    MessageType rootSchema = new ProtoSchemaConverter(writeSpecsCompliant).convert(descriptor);
+    MessageType rootSchema = new ProtoSchemaConverter(configuration).convert(descriptor);
     validatedMapping(descriptor, rootSchema);
 
     this.messageWriter = new MessageWriter(descriptor, rootSchema);
@@ -160,7 +160,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
       StringBuilder nameNumberPairs = new StringBuilder();
       if (enumNameNumberMapping.getValue().isEmpty()) {
         // No enum is ever written to any column of this file, put an empty string as the value in the metadata
-        LOG.info("No enum is written for " + enumNameNumberMapping.getKey());
+        LOG.info("No enum is written for {}", enumNameNumberMapping.getKey());
       }
       int idx = 0;
       for (Map.Entry<String, Integer> nameNumberPair : enumNameNumberMapping.getValue().entrySet()) {
@@ -221,7 +221,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
         Type type = schema.getType(name);
         FieldWriter writer = createWriter(fieldDescriptor, type);
 
-        if(writeSpecsCompliant && fieldDescriptor.isRepeated() && !fieldDescriptor.isMapField()) {
+        if (writeSpecsCompliant && fieldDescriptor.isRepeated() && !fieldDescriptor.isMapField()) {
           writer = new ArrayWriter(writer);
         }
         else if (!writeSpecsCompliant && fieldDescriptor.isRepeated()) {
@@ -256,6 +256,11 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
     private FieldWriter createMessageWriter(FieldDescriptor fieldDescriptor, Type type) {
       if (fieldDescriptor.isMapField() && writeSpecsCompliant) {
         return createMapWriter(fieldDescriptor, type);
+      }
+
+      // This can happen now that recursive schemas get truncated to bytes.  Write the bytes.
+      if (type.isPrimitive() && type.asPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.BINARY) {
+        return new BinaryWriter();
       }
 
       return new MessageWriter(fieldDescriptor.getMessageType(), getGroupType(type));
@@ -305,7 +310,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
       writeAllFields((MessageOrBuilder) value);
     }
 
-    /** Writes message as part of repeated field. It cannot start field*/
+    /** Writes message as part of repeated field. It cannot start field */
     @Override
     final void writeRawValue(Object value) {
       recordConsumer.startGroup();
@@ -313,7 +318,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
       recordConsumer.endGroup();
     }
 
-    /** Used for writing nonrepeated (optional, required) fields*/
+    /** Used for writing nonrepeated (optional, required) fields */
     @Override
     final void writeField(Object value) {
       recordConsumer.startField(fieldName, index);
@@ -326,7 +331,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
       Descriptors.FileDescriptor.Syntax syntax = messageDescriptor.getFile().getSyntax();
 
       if (Descriptors.FileDescriptor.Syntax.PROTO2.equals(syntax)) {
-        //returns changed fields with values. Map is ordered by id.
+        // Returns changed fields with values. Map is ordered by id.
         Map<FieldDescriptor, Object> changedPbFields = pb.getAllFields();
 
         for (Map.Entry<FieldDescriptor, Object> entry : changedPbFields.entrySet()) {
@@ -346,7 +351,7 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
         for (FieldDescriptor fieldDescriptor : fieldDescriptors) {
           FieldDescriptor.Type type = fieldDescriptor.getType();
 
-          //For a field in a oneOf that isn't set don't write anything
+          // For a field in a oneOf that isn't set don't write anything
           if (fieldDescriptor.getContainingOneof() != null && !pb.hasField(fieldDescriptor)) {
             continue;
           }
@@ -559,7 +564,14 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
   class BinaryWriter extends FieldWriter {
     @Override
     final void writeRawValue(Object value) {
-      ByteString byteString = (ByteString) value;
+      // Non-ByteString values can happen when recursions gets truncated.
+      ByteString byteString = value instanceof ByteString
+          ? (ByteString) value
+          // TODO: figure out a way to use MessageOrBuilder
+          : value instanceof Message
+          ? ((Message) value).toByteString()
+          // Worst-case, just dump as plain java string.
+          : ByteString.copyFromUtf8(value.toString());
       Binary binary = Binary.fromConstantByteArray(byteString.toByteArray());
       recordConsumer.addBinary(binary);
     }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaConverterTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaConverterTest.java
@@ -18,10 +18,15 @@
  */
 package org.apache.parquet.proto;
 
+import com.google.common.base.Joiner;
 import com.google.protobuf.Message;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
 import org.junit.Test;
+import org.apache.parquet.proto.TestUtils;
 import org.apache.parquet.proto.test.TestProto3;
 import org.apache.parquet.proto.test.TestProtobuf;
+import org.apache.parquet.proto.test.Trees;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
 
@@ -29,51 +34,57 @@ import static org.junit.Assert.assertEquals;
 
 public class ProtoSchemaConverterTest {
 
+  private static final int PAR_RECURSION_DEPTH = 2;
+  private static final Joiner JOINER = Joiner.on(System.getProperty("line.separator"));
+
   /**
    * Converts given pbClass to parquet schema and compares it with expected parquet schema.
    */
-  private void testConversion(Class<? extends Message> pbClass, String parquetSchemaString, boolean parquetSpecsCompliant) throws
-          Exception {
-    ProtoSchemaConverter protoSchemaConverter = new ProtoSchemaConverter(parquetSpecsCompliant);
-    MessageType schema = protoSchemaConverter.convert(pbClass);
+  private static void testConversion(Class<? extends Message> pbClass, String parquetSchemaString, boolean parquetSpecsCompliant) {
+    testConversion(pbClass, parquetSchemaString, new ProtoSchemaConverter(parquetSpecsCompliant));
+  }
+
+  private static void testConversion(Class<? extends Message> pbClass, String parquetSchemaString) {
+    testConversion(pbClass, parquetSchemaString, true);
+  }
+
+  private static void testConversion(Class<? extends Message> pbClass, String parquetSchemaString, ProtoSchemaConverter converter) {
+    MessageType schema = converter.convert(pbClass);
     MessageType expectedMT = MessageTypeParser.parseMessageType(parquetSchemaString);
     assertEquals(expectedMT.toString(), schema.toString());
   }
 
-  private void testConversion(Class<? extends Message> pbClass, String parquetSchemaString) throws Exception {
-    testConversion(pbClass, parquetSchemaString, true);
-  }
 
   /**
    * Tests that all protocol buffer datatypes are converted to correct parquet datatypes.
    */
   @Test
-  public void testConvertAllDatatypes() throws Exception {
-    String expectedSchema =
-      "message TestProtobuf.SchemaConverterAllDatatypes {\n" +
-      "  optional double optionalDouble = 1;\n" +
-      "  optional float optionalFloat = 2;\n" +
-      "  optional int32 optionalInt32 = 3;\n" +
-      "  optional int64 optionalInt64 = 4;\n" +
-      "  optional int32 optionalUInt32 = 5;\n" +
-      "  optional int64 optionalUInt64 = 6;\n" +
-      "  optional int32 optionalSInt32 = 7;\n" +
-      "  optional int64 optionalSInt64 = 8;\n" +
-      "  optional int32 optionalFixed32 = 9;\n" +
-      "  optional int64 optionalFixed64 = 10;\n" +
-      "  optional int32 optionalSFixed32 = 11;\n" +
-      "  optional int64 optionalSFixed64 = 12;\n" +
-      "  optional boolean optionalBool = 13;\n" +
-      "  optional binary optionalString (UTF8) = 14;\n" +
-      "  optional binary optionalBytes = 15;\n" +
-      "  optional group optionalMessage = 16 {\n" +
-      "    optional int32 someId = 3;\n" +
-      "  }\n" +
-      "  optional group pbgroup = 17 {\n" +
-      "    optional int32 groupInt = 2;\n" +
-      "  }\n" +
-      " optional binary optionalEnum (ENUM)  = 18;" +
-      "}";
+  public void testConvertAllDatatypes() {
+    String expectedSchema = JOINER.join(
+        "message TestProtobuf.SchemaConverterAllDatatypes {",
+        "  optional double optionalDouble = 1;",
+        "  optional float optionalFloat = 2;",
+        "  optional int32 optionalInt32 = 3;",
+        "  optional int64 optionalInt64 = 4;",
+        "  optional int32 optionalUInt32 = 5;",
+        "  optional int64 optionalUInt64 = 6;",
+        "  optional int32 optionalSInt32 = 7;",
+        "  optional int64 optionalSInt64 = 8;",
+        "  optional int32 optionalFixed32 = 9;",
+        "  optional int64 optionalFixed64 = 10;",
+        "  optional int32 optionalSFixed32 = 11;",
+        "  optional int64 optionalSFixed64 = 12;",
+        "  optional boolean optionalBool = 13;",
+        "  optional binary optionalString (UTF8) = 14;",
+        "  optional binary optionalBytes = 15;",
+        "  optional group optionalMessage = 16 {",
+        "    optional int32 someId = 3;",
+        "  }",
+        "  optional group pbgroup = 17 {",
+        "    optional int32 groupInt = 2;",
+        "  }",
+        " optional binary optionalEnum (ENUM)  = 18;",
+        "}");
 
     testConversion(TestProtobuf.SchemaConverterAllDatatypes.class, expectedSchema);
   }
@@ -82,264 +93,447 @@ public class ProtoSchemaConverterTest {
    * Tests that all protocol buffer datatypes are converted to correct parquet datatypes.
    */
   @Test
-  public void testProto3ConvertAllDatatypes() throws Exception {
-    String expectedSchema =
-      "message TestProto3.SchemaConverterAllDatatypes {\n" +
-        "  optional double optionalDouble = 1;\n" +
-        "  optional float optionalFloat = 2;\n" +
-        "  optional int32 optionalInt32 = 3;\n" +
-        "  optional int64 optionalInt64 = 4;\n" +
-        "  optional int32 optionalUInt32 = 5;\n" +
-        "  optional int64 optionalUInt64 = 6;\n" +
-        "  optional int32 optionalSInt32 = 7;\n" +
-        "  optional int64 optionalSInt64 = 8;\n" +
-        "  optional int32 optionalFixed32 = 9;\n" +
-        "  optional int64 optionalFixed64 = 10;\n" +
-        "  optional int32 optionalSFixed32 = 11;\n" +
-        "  optional int64 optionalSFixed64 = 12;\n" +
-        "  optional boolean optionalBool = 13;\n" +
-        "  optional binary optionalString (UTF8) = 14;\n" +
-        "  optional binary optionalBytes = 15;\n" +
-        "  optional group optionalMessage = 16 {\n" +
-        "    optional int32 someId = 3;\n" +
-        "  }\n" +
-        "  optional binary optionalEnum (ENUM) = 18;" +
-        "  optional int32 someInt32 = 19;" +
-        "  optional binary someString (UTF8) = 20;" +
-        "  optional group optionalMap (MAP) = 21 {\n" +
-        "    repeated group key_value {\n" +
-        "      required int64 key;\n" +
-        "      optional group value {\n" +
-        "        optional int32 someId = 3;\n" +
-        "      }\n" +
-        "    }\n" +
-        "  }\n" +
-        "}";
+  public void testProto3ConvertAllDatatypes() {
+    String expectedSchema = JOINER.join(
+        "message TestProto3.SchemaConverterAllDatatypes {",
+        "  optional double optionalDouble = 1;",
+        "  optional float optionalFloat = 2;",
+        "  optional int32 optionalInt32 = 3;",
+        "  optional int64 optionalInt64 = 4;",
+        "  optional int32 optionalUInt32 = 5;",
+        "  optional int64 optionalUInt64 = 6;",
+        "  optional int32 optionalSInt32 = 7;",
+        "  optional int64 optionalSInt64 = 8;",
+        "  optional int32 optionalFixed32 = 9;",
+        "  optional int64 optionalFixed64 = 10;",
+        "  optional int32 optionalSFixed32 = 11;",
+        "  optional int64 optionalSFixed64 = 12;",
+        "  optional boolean optionalBool = 13;",
+        "  optional binary optionalString (UTF8) = 14;",
+        "  optional binary optionalBytes = 15;",
+        "  optional group optionalMessage = 16 {",
+        "    optional int32 someId = 3;",
+        "  }",
+        "  optional binary optionalEnum (ENUM) = 18;",
+        "  optional int32 someInt32 = 19;",
+        "  optional binary someString (UTF8) = 20;",
+        "  optional group optionalMap (MAP) = 21 {",
+        "    repeated group key_value {",
+        "      required int64 key;",
+        "      optional group value {",
+        "        optional int32 someId = 3;",
+        "      }",
+        "    }",
+        "  }",
+        "}");
 
     testConversion(TestProto3.SchemaConverterAllDatatypes.class, expectedSchema);
   }
 
   @Test
-  public void testConvertRepetition() throws Exception {
-    String expectedSchema =
-      "message TestProtobuf.SchemaConverterRepetition {\n" +
-        "  optional int32 optionalPrimitive = 1;\n" +
-        "  required int32 requiredPrimitive = 2;\n" +
-        "  optional group repeatedPrimitive (LIST) = 3 {\n" +
-        "    repeated group list {\n" +
-        "      required int32 element;\n" +
-        "    }\n" +
-        "  }\n" +
-        "  optional group optionalMessage = 7 {\n" +
-        "    optional int32 someId = 3;\n" +
-        "  }\n" +
-        "  required group requiredMessage = 8 {\n" +
-        "    optional int32 someId= 3;\n" +
-        "  }\n" +
-        "  optional group repeatedMessage (LIST) = 9 {\n" +
-        "    repeated group list {\n" +
-        "      optional group element {\n" +
-        "        optional int32 someId = 3;\n" +
-        "      }\n" +
-        "    }\n" +
-        "  }" +
-        "}";
+  public void testConvertRepetition() {
+    String expectedSchema = JOINER.join(
+        "message TestProtobuf.SchemaConverterRepetition {",
+        "  optional int32 optionalPrimitive = 1;",
+        "  required int32 requiredPrimitive = 2;",
+        "  optional group repeatedPrimitive (LIST) = 3 {",
+        "    repeated group list {",
+        "      required int32 element;",
+        "    }",
+        "  }",
+        "  optional group optionalMessage = 7 {",
+        "    optional int32 someId = 3;",
+        "  }",
+        "  required group requiredMessage = 8 {",
+        "    optional int32 someId= 3;",
+        "  }",
+        "  optional group repeatedMessage (LIST) = 9 {",
+        "    repeated group list {",
+        "      optional group element {",
+        "        optional int32 someId = 3;",
+        "      }",
+        "    }",
+        "  }",
+        "}");
 
     testConversion(TestProtobuf.SchemaConverterRepetition.class, expectedSchema);
   }
 
   @Test
-  public void testProto3ConvertRepetition() throws Exception {
-    String expectedSchema =
-      "message TestProto3.SchemaConverterRepetition {\n" +
-        "  optional int32 optionalPrimitive = 1;\n" +
-        "  optional group repeatedPrimitive (LIST) = 3 {\n" +
-        "    repeated group list {\n" +
-        "      required int32 element;\n" +
-        "    }\n" +
-        "  }\n" +
-        "  optional group optionalMessage = 7 {\n" +
-        "    optional int32 someId = 3;\n" +
-        "  }\n" +
-        "  optional group repeatedMessage (LIST) = 9 {\n" +
-        "    repeated group list {\n" +
-        "      optional group element {\n" +
-        "        optional int32 someId = 3;\n" +
-        "      }\n" +
-        "    }\n" +
-        "  }\n" +
-        "}";
+  public void testProto3ConvertRepetition() {
+    String expectedSchema = JOINER.join(
+        "message TestProto3.SchemaConverterRepetition {",
+        "  optional int32 optionalPrimitive = 1;",
+        "  optional group repeatedPrimitive (LIST) = 3 {",
+        "    repeated group list {",
+        "      required int32 element;",
+        "    }",
+        "  }",
+        "  optional group optionalMessage = 7 {",
+        "    optional int32 someId = 3;",
+        "  }",
+        "  optional group repeatedMessage (LIST) = 9 {",
+        "    repeated group list {",
+        "      optional group element {",
+        "        optional int32 someId = 3;",
+        "      }",
+        "    }",
+        "  }",
+        "}");
 
     testConversion(TestProto3.SchemaConverterRepetition.class, expectedSchema);
   }
 
   @Test
-  public void testConvertRepeatedIntMessage() throws Exception {
-    String expectedSchema =
-      "message TestProtobuf.RepeatedIntMessage {\n" +
-        "  optional group repeatedInt (LIST) = 1 {\n" +
-        "    repeated group list {\n" +
-        "      required int32 element;\n" +
-        "      }\n" +
-        "    }\n" +
-        "  }\n" +
-        "}";
+  public void testConvertRepeatedIntMessage() {
+    String expectedSchema = JOINER.join(
+        "message TestProtobuf.RepeatedIntMessage {",
+        "  optional group repeatedInt (LIST) = 1 {",
+        "    repeated group list {",
+        "      required int32 element;",
+        "      }",
+        "    }",
+        "  }",
+        "}");
 
     testConversion(TestProtobuf.RepeatedIntMessage.class, expectedSchema);
   }
 
   @Test
-  public void testConvertRepeatedIntMessageNonSpecsCompliant() throws Exception {
-    String expectedSchema =
-      "message TestProtobuf.RepeatedIntMessage {\n" +
-        "  repeated int32 repeatedInt = 1;\n" +
-        "}";
+  public void testConvertRepeatedIntMessageNonSpecsCompliant() {
+    String expectedSchema = JOINER.join(
+        "message TestProtobuf.RepeatedIntMessage {",
+        "  repeated int32 repeatedInt = 1;",
+        "}");
 
     testConversion(TestProtobuf.RepeatedIntMessage.class, expectedSchema, false);
   }
 
   @Test
-  public void testProto3ConvertRepeatedIntMessage() throws Exception {
-    String expectedSchema =
-      "message TestProto3.RepeatedIntMessage {\n" +
-        "  optional group repeatedInt (LIST) = 1 {\n" +
-        "    repeated group list {\n" +
-        "      required int32 element;\n" +
-        "      }\n" +
-        "    }\n" +
-        "  }\n" +
-        "}";
+  public void testProto3ConvertRepeatedIntMessage() {
+    String expectedSchema = JOINER.join(
+        "message TestProto3.RepeatedIntMessage {",
+        "  optional group repeatedInt (LIST) = 1 {",
+        "    repeated group list {",
+        "      required int32 element;",
+        "      }",
+        "    }",
+        "  }",
+        "}");
 
     testConversion(TestProto3.RepeatedIntMessage.class, expectedSchema);
   }
 
   @Test
-  public void testProto3ConvertRepeatedIntMessageNonSpecsCompliant() throws Exception {
-    String expectedSchema =
-      "message TestProto3.RepeatedIntMessage {\n" +
-        "  repeated int32 repeatedInt = 1;\n" +
-        "}";
+  public void testProto3ConvertRepeatedIntMessageNonSpecsCompliant() {
+    String expectedSchema = JOINER.join(
+        "message TestProto3.RepeatedIntMessage {",
+        "  repeated int32 repeatedInt = 1;",
+        "}");
 
     testConversion(TestProto3.RepeatedIntMessage.class, expectedSchema, false);
   }
 
   @Test
-  public void testConvertRepeatedInnerMessage() throws Exception {
-    String expectedSchema =
-      "message TestProtobuf.RepeatedInnerMessage {\n" +
-        "  optional group repeatedInnerMessage (LIST) = 1 {\n" +
-        "    repeated group list {\n" +
-        "      optional group element {\n" +
-        "        optional binary one (UTF8) = 1;\n" +
-        "        optional binary two (UTF8) = 2;\n" +
-        "        optional binary three (UTF8) = 3;\n" +
-        "      }\n" +
-        "    }\n" +
-        "  }\n" +
-        "}";
+  public void testConvertRepeatedInnerMessage() {
+    String expectedSchema = JOINER.join(
+        "message TestProtobuf.RepeatedInnerMessage {",
+        "  optional group repeatedInnerMessage (LIST) = 1 {",
+        "    repeated group list {",
+        "      optional group element {",
+        "        optional binary one (UTF8) = 1;",
+        "        optional binary two (UTF8) = 2;",
+        "        optional binary three (UTF8) = 3;",
+        "      }",
+        "    }",
+        "  }",
+        "}");
 
     testConversion(TestProtobuf.RepeatedInnerMessage.class, expectedSchema);
   }
 
   @Test
-  public void testConvertRepeatedInnerMessageNonSpecsCompliant() throws Exception {
-    String expectedSchema =
-      "message TestProtobuf.RepeatedInnerMessage {\n" +
-        "  repeated group repeatedInnerMessage = 1 {\n" +
-        "    optional binary one (UTF8) = 1;\n" +
-        "    optional binary two (UTF8) = 2;\n" +
-        "    optional binary three (UTF8) = 3;\n" +
-        "  }\n" +
-        "}";
+  public void testConvertRepeatedInnerMessageNonSpecsCompliant() {
+    String expectedSchema = JOINER.join(
+        "message TestProtobuf.RepeatedInnerMessage {",
+        "  repeated group repeatedInnerMessage = 1 {",
+        "    optional binary one (UTF8) = 1;",
+        "    optional binary two (UTF8) = 2;",
+        "    optional binary three (UTF8) = 3;",
+        "  }",
+        "}");
 
     testConversion(TestProtobuf.RepeatedInnerMessage.class, expectedSchema, false);
   }
 
   @Test
-  public void testProto3ConvertRepeatedInnerMessage() throws Exception {
-    String expectedSchema =
-      "message TestProto3.RepeatedInnerMessage {\n" +
-        "  optional group repeatedInnerMessage (LIST) = 1 {\n" +
-        "    repeated group list {\n" +
-        "      optional group element {\n" +
-        "        optional binary one (UTF8) = 1;\n" +
-        "        optional binary two (UTF8) = 2;\n" +
-        "        optional binary three (UTF8) = 3;\n" +
-        "      }\n" +
-        "    }\n" +
-        "  }\n" +
-        "}";
+  public void testProto3ConvertRepeatedInnerMessage() {
+    String expectedSchema = JOINER.join(
+        "message TestProto3.RepeatedInnerMessage {",
+        "  optional group repeatedInnerMessage (LIST) = 1 {",
+        "    repeated group list {",
+        "      optional group element {",
+        "        optional binary one (UTF8) = 1;",
+        "        optional binary two (UTF8) = 2;",
+        "        optional binary three (UTF8) = 3;",
+        "      }",
+        "    }",
+        "  }",
+        "}");
 
     testConversion(TestProto3.RepeatedInnerMessage.class, expectedSchema);
   }
 
   @Test
-  public void testProto3ConvertRepeatedInnerMessageNonSpecsCompliant() throws Exception {
-    String expectedSchema =
-      "message TestProto3.RepeatedInnerMessage {\n" +
-        "  repeated group repeatedInnerMessage = 1 {\n" +
-        "    optional binary one (UTF8) = 1;\n" +
-        "    optional binary two (UTF8) = 2;\n" +
-        "    optional binary three (UTF8) = 3;\n" +
-        "  }\n" +
-        "}";
+  public void testProto3ConvertRepeatedInnerMessageNonSpecsCompliant() {
+    String expectedSchema = JOINER.join(
+        "message TestProto3.RepeatedInnerMessage {",
+        "  repeated group repeatedInnerMessage = 1 {",
+        "    optional binary one (UTF8) = 1;",
+        "    optional binary two (UTF8) = 2;",
+        "    optional binary three (UTF8) = 3;",
+        "  }",
+        "}");
 
     testConversion(TestProto3.RepeatedInnerMessage.class, expectedSchema, false);
   }
 
   @Test
-  public void testConvertMapIntMessage() throws Exception {
-    String expectedSchema =
-      "message TestProtobuf.MapIntMessage {\n" +
-        "  optional group mapInt (MAP) = 1 {\n" +
-        "    repeated group key_value {\n" +
-        "      required int32 key;\n" +
-        "      optional int32 value;\n" +
-        "    }\n" +
-        "  }\n" +
-        "}";
+  public void testConvertMapIntMessage() {
+    String expectedSchema = JOINER.join(
+        "message TestProtobuf.MapIntMessage {",
+        "  optional group mapInt (MAP) = 1 {",
+        "    repeated group key_value {",
+        "      required int32 key;",
+        "      optional int32 value;",
+        "    }",
+        "  }",
+        "}");
 
     testConversion(TestProtobuf.MapIntMessage.class, expectedSchema);
   }
 
   @Test
-  public void testConvertMapIntMessageNonSpecsCompliant() throws Exception {
-    String expectedSchema =
-      "message TestProtobuf.MapIntMessage {\n" +
-        "  repeated group mapInt = 1 {\n" +
-        "    optional int32 key = 1;\n" +
-        "    optional int32 value = 2;\n" +
-        "  }\n" +
-        "}";
+  public void testConvertMapIntMessageNonSpecsCompliant() {
+    String expectedSchema = JOINER.join(
+        "message TestProtobuf.MapIntMessage {",
+        "  repeated group mapInt = 1 {",
+        "    optional int32 key = 1;",
+        "    optional int32 value = 2;",
+        "  }",
+        "}");
 
     testConversion(TestProtobuf.MapIntMessage.class, expectedSchema, false);
   }
 
   @Test
-  public void testProto3ConvertMapIntMessage() throws Exception {
-    String expectedSchema =
-      "message TestProto3.MapIntMessage {\n" +
-        "  optional group mapInt (MAP) = 1 {\n" +
-        "    repeated group key_value {\n" +
-        "      required int32 key;\n" +
-        "      optional int32 value;\n" +
-        "    }\n" +
-        "  }\n" +
-        "}";
+  public void testProto3ConvertMapIntMessage() {
+    String expectedSchema = JOINER.join(
+        "message TestProto3.MapIntMessage {",
+        "  optional group mapInt (MAP) = 1 {",
+        "    repeated group key_value {",
+        "      required int32 key;",
+        "      optional int32 value;",
+        "    }",
+        "  }",
+        "}");
 
     testConversion(TestProto3.MapIntMessage.class, expectedSchema);
   }
 
   @Test
-  public void testProto3ConvertMapIntMessageNonSpecsCompliant() throws Exception {
-    String expectedSchema =
-      "message TestProto3.MapIntMessage {\n" +
-        "  repeated group mapInt = 1 {\n" +
-        "    optional int32 key = 1;\n" +
-        "    optional int32 value = 2;\n" +
-        "  }\n" +
-        "}";
+  public void testProto3ConvertMapIntMessageNonSpecsCompliant() {
+    String expectedSchema = JOINER.join(
+        "message TestProto3.MapIntMessage {",
+        "  repeated group mapInt = 1 {",
+        "    optional int32 key = 1;",
+        "    optional int32 value = 2;",
+        "  }",
+        "}");
 
     testConversion(TestProto3.MapIntMessage.class, expectedSchema, false);
+  }
+
+  @Test
+  public void testBinaryTreeRecursion() throws Exception {
+    String expectedSchema = JOINER.join(
+        "message Trees.BinaryTree {",
+        "  optional group value = 1 {",
+        "    optional binary type_url (STRING) = 1;",
+        "    optional binary value = 2;",
+        "  }",
+        "  optional group left = 2 {",
+        "    optional group value = 1 {",
+        "      optional binary type_url (STRING) = 1;",
+        "      optional binary value = 2;",
+        "    }",
+        "    optional binary left = 2;",
+        "    optional binary right = 3;",
+        "  }",
+        "  optional group right = 3 {",
+        "    optional group value = 1 {",
+        "      optional binary type_url (STRING) = 1;",
+        "      optional binary value = 2;",
+        "    }",
+        "    optional binary left = 2;",
+        "    optional binary right = 3;",
+        "  }",
+        "}");
+    testConversion(Trees.BinaryTree.class, expectedSchema, new ProtoSchemaConverter(true, 1));
+    testConversion(Trees.BinaryTree.class, TestUtils.readResource("BinaryTree.par"), new ProtoSchemaConverter(true, PAR_RECURSION_DEPTH));
+
+  }
+
+  @Test
+  public void testWideTreeRecursion() throws Exception {
+    String expectedSchema = JOINER.join(
+        "message Trees.WideTree {",
+        "  optional group value = 1 {",
+        "    optional binary type_url (STRING) = 1;",
+        "    optional binary value = 2;",
+        "  }",
+        "  optional group children (LIST) = 2 {",
+        "    repeated group list {",
+        "      optional group element {",
+        "        optional group value = 1 {",
+        "          optional binary type_url (STRING) = 1;",
+        "          optional binary value = 2;",
+        "        }",
+        "        optional binary children = 2;",
+        "      }",
+        "    }",
+        "  }",
+        "}");
+    testConversion(Trees.WideTree.class, expectedSchema, new ProtoSchemaConverter(true, 1));
+    testConversion(Trees.WideTree.class, TestUtils.readResource("WideTree.par"), new ProtoSchemaConverter(true, PAR_RECURSION_DEPTH));
+
+  }
+
+  @Test
+  public void testValueRecursion() throws Exception {
+    String expectedSchema = JOINER.join(
+        "message google.protobuf.Value {",
+        "  optional binary null_value (ENUM) = 1;",
+        "  optional double number_value = 2;",
+        "  optional binary string_value (STRING) = 3;",
+        "  optional boolean bool_value = 4;",
+        "  optional group struct_value = 5 {",
+        "    optional group fields (MAP) = 1 {",
+        "      repeated group key_value {",
+        "        required binary key (STRING);",
+        "        optional group value {",
+        "          optional binary null_value (ENUM) = 1;",
+        "          optional double number_value = 2;",
+        "          optional binary string_value (STRING) = 3;",
+        "          optional boolean bool_value = 4;",
+        "          optional group struct_value = 5 {",
+        "            optional binary fields = 1;",
+        "          }",
+        "          optional group list_value = 6 {",
+        "            optional binary values = 1;",
+        "          }",
+        "        }",
+        "      }",
+        "    }",
+        "  }",
+        "  optional group list_value = 6 {",
+        "    optional group values (LIST) = 1 {",
+        "      repeated group list {",
+        "        optional group element {",
+        "          optional binary null_value (ENUM) = 1;",
+        "          optional double number_value = 2;",
+        "          optional binary string_value (STRING) = 3;",
+        "          optional boolean bool_value = 4;",
+        "          optional group struct_value = 5 {",
+        "            optional binary fields = 1;",
+        "          }",
+        "          optional group list_value = 6 {",
+        "            optional binary values = 1;",
+        "          }",
+        "        }",
+        "      }",
+        "    }",
+        "  }",
+        "}");
+    testConversion(Value.class, expectedSchema, new ProtoSchemaConverter(true, 1));
+    testConversion(Value.class, TestUtils.readResource("Value.par"), new ProtoSchemaConverter(true, PAR_RECURSION_DEPTH));
+  }
+
+  @Test
+  public void testStructRecursion() throws Exception {
+    String expectedSchema = JOINER.join(
+        "message google.protobuf.Struct {",
+        "  optional group fields (MAP) = 1 {",
+        "    repeated group key_value {",
+        "      required binary key (STRING);",
+        "      optional group value {",
+        "        optional binary null_value (ENUM) = 1;",
+        "        optional double number_value = 2;",
+        "        optional binary string_value (STRING) = 3;",
+        "        optional boolean bool_value = 4;",
+        "        optional group struct_value = 5 {",
+        "          optional group fields (MAP) = 1 {",
+        "            repeated group key_value {",
+        "              required binary key (STRING);",
+        "              optional group value {",
+        "                optional binary null_value (ENUM) = 1;",
+        "                optional double number_value = 2;",
+        "                optional binary string_value (STRING) = 3;",
+        "                optional boolean bool_value = 4;",
+        "                optional binary struct_value = 5;",
+        "                optional group list_value = 6 {",
+        "                  optional binary values = 1;",
+        "                }",
+        "              }",
+        "            }",
+        "          }",
+        "        }",
+        "        optional group list_value = 6 {",
+        "          optional group values (LIST) = 1 {",
+        "            repeated group list {",
+        "              optional group element {",
+        "                optional binary null_value (ENUM) = 1;",
+        "                optional double number_value = 2;",
+        "                optional binary string_value (STRING) = 3;",
+        "                optional boolean bool_value = 4;",
+        "                optional group struct_value = 5 {",
+        "                  optional binary fields = 1;",
+        "                }",
+        "                optional group list_value = 6 {",
+        "                  optional binary values = 1;",
+        "                }",
+        "              }",
+        "            }",
+        "          }",
+        "        }",
+        "      }",
+        "    }",
+        "  }",
+        "}");
+    testConversion(Struct.class, expectedSchema, new ProtoSchemaConverter(true, 1));
+    testConversion(Struct.class, TestUtils.readResource("Struct.par"), new ProtoSchemaConverter(true, PAR_RECURSION_DEPTH));
+  }
+
+  @Test
+  public void testDeepRecursion() {
+    // The general idea is to test the fanout of the schema.
+    // TODO: figured out closed forms of the binary tree and struct series.
+    long expectedBinaryTreeSize = 4;
+    long expectedStructSize = 7;
+    for (int i = 0; i < 10; ++i) {
+      MessageType deepSchema = new ProtoSchemaConverter(true, i).convert(Trees.WideTree.class);
+      // 3, 5, 7, 9, 11, 13, 15, 17, 19, 21
+      assertEquals(2 * i + 3, deepSchema.getPaths().size());
+
+      deepSchema = new ProtoSchemaConverter(true, i).convert(Trees.BinaryTree.class);
+      // 4, 10, 22, 46, 94, 190, 382, 766, 1534, 3070
+      assertEquals(expectedBinaryTreeSize, deepSchema.getPaths().size());
+      expectedBinaryTreeSize = 2 * expectedBinaryTreeSize + 2;
+
+      deepSchema = new ProtoSchemaConverter(true, i).convert(Struct.class);
+      // 7, 18, 40, 84, 172, 348, 700, 1404, 2812, 5628
+      assertEquals(expectedStructSize, deepSchema.getPaths().size());
+      expectedStructSize = 2 * expectedStructSize + 4;
+    }
   }
 }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
@@ -21,6 +21,7 @@ package org.apache.parquet.proto;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
+import com.google.protobuf.Value;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
@@ -31,6 +32,7 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.proto.test.TestProto3;
 import org.apache.parquet.proto.test.TestProtobuf;
+import org.apache.parquet.proto.test.Trees;
 
 import java.io.IOException;
 import java.util.List;
@@ -42,7 +44,7 @@ public class ProtoWriteSupportTest {
   }
 
   private <T extends Message> ProtoWriteSupport<T> createReadConsumerInstance(Class<T> cls, RecordConsumer readConsumerMock, Configuration conf) {
-    ProtoWriteSupport support = new ProtoWriteSupport(cls);
+    ProtoWriteSupport<T> support = new ProtoWriteSupport<>(cls);
     support.init(conf);
     support.prepareForWrite(readConsumerMock);
     return support;
@@ -51,7 +53,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testSimplestMessage() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.InnerMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProtobuf.InnerMessage> instance =
+        createReadConsumerInstance(TestProtobuf.InnerMessage.class, readConsumerMock);
 
     TestProtobuf.InnerMessage.Builder msg = TestProtobuf.InnerMessage.newBuilder();
     msg.setOne("oneValue");
@@ -72,7 +75,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testProto3SimplestMessage() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.InnerMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProto3.InnerMessage> instance =
+        createReadConsumerInstance(TestProto3.InnerMessage.class, readConsumerMock);
 
     TestProto3.InnerMessage.Builder msg = TestProto3.InnerMessage.newBuilder();
     msg.setOne("oneValue");
@@ -134,7 +138,8 @@ public class ProtoWriteSupportTest {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
     Configuration conf = new Configuration();
     ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.RepeatedIntMessage.class, readConsumerMock, conf);
+    ProtoWriteSupport<TestProtobuf.RepeatedIntMessage> instance =
+        createReadConsumerInstance(TestProtobuf.RepeatedIntMessage.class, readConsumerMock, conf);
 
     TestProtobuf.RepeatedIntMessage.Builder msg = TestProtobuf.RepeatedIntMessage.newBuilder();
     msg.addRepeatedInt(1323);
@@ -171,7 +176,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testRepeatedIntMessage() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.RepeatedIntMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProtobuf.RepeatedIntMessage> instance =
+        createReadConsumerInstance(TestProtobuf.RepeatedIntMessage.class, readConsumerMock);
 
     TestProtobuf.RepeatedIntMessage.Builder msg = TestProtobuf.RepeatedIntMessage.newBuilder();
     msg.addRepeatedInt(1323);
@@ -195,7 +201,8 @@ public class ProtoWriteSupportTest {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
     Configuration conf = new Configuration();
     ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.RepeatedIntMessage.class, readConsumerMock, conf);
+    ProtoWriteSupport<TestProtobuf.RepeatedIntMessage> instance =
+        createReadConsumerInstance(TestProtobuf.RepeatedIntMessage.class, readConsumerMock, conf);
 
     TestProtobuf.RepeatedIntMessage.Builder msg = TestProtobuf.RepeatedIntMessage.newBuilder();
 
@@ -211,7 +218,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testRepeatedIntMessageEmpty() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.RepeatedIntMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProtobuf.RepeatedIntMessage> instance =
+        createReadConsumerInstance(TestProtobuf.RepeatedIntMessage.class, readConsumerMock);
 
     TestProtobuf.RepeatedIntMessage.Builder msg = TestProtobuf.RepeatedIntMessage.newBuilder();
 
@@ -229,7 +237,8 @@ public class ProtoWriteSupportTest {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
     Configuration conf = new Configuration();
     ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.RepeatedIntMessage.class, readConsumerMock, conf);
+    ProtoWriteSupport<TestProto3.RepeatedIntMessage> instance =
+        createReadConsumerInstance(TestProto3.RepeatedIntMessage.class, readConsumerMock, conf);
 
     TestProto3.RepeatedIntMessage.Builder msg = TestProto3.RepeatedIntMessage.newBuilder();
     msg.addRepeatedInt(1323);
@@ -266,7 +275,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testProto3RepeatedIntMessage() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.RepeatedIntMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProto3.RepeatedIntMessage> instance =
+        createReadConsumerInstance(TestProto3.RepeatedIntMessage.class, readConsumerMock);
 
     TestProto3.RepeatedIntMessage.Builder msg = TestProto3.RepeatedIntMessage.newBuilder();
     msg.addRepeatedInt(1323);
@@ -290,7 +300,8 @@ public class ProtoWriteSupportTest {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
     Configuration conf = new Configuration();
     ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.RepeatedIntMessage.class, readConsumerMock, conf);
+    ProtoWriteSupport<TestProto3.RepeatedIntMessage> instance =
+        createReadConsumerInstance(TestProto3.RepeatedIntMessage.class, readConsumerMock, conf);
 
     TestProto3.RepeatedIntMessage.Builder msg = TestProto3.RepeatedIntMessage.newBuilder();
 
@@ -306,7 +317,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testProto3RepeatedIntMessageEmpty() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.RepeatedIntMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProto3.RepeatedIntMessage> instance =
+        createReadConsumerInstance(TestProto3.RepeatedIntMessage.class, readConsumerMock);
 
     TestProto3.RepeatedIntMessage.Builder msg = TestProto3.RepeatedIntMessage.newBuilder();
 
@@ -324,7 +336,8 @@ public class ProtoWriteSupportTest {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
     Configuration conf = new Configuration();
     ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.MapIntMessage.class, readConsumerMock, conf);
+    ProtoWriteSupport<TestProtobuf.MapIntMessage> instance =
+        createReadConsumerInstance(TestProtobuf.MapIntMessage.class, readConsumerMock, conf);
 
     TestProtobuf.MapIntMessage.Builder msg = TestProtobuf.MapIntMessage.newBuilder();
     msg.putMapInt(123, 1);
@@ -366,7 +379,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testMapIntMessage() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.MapIntMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProtobuf.MapIntMessage> instance =
+        createReadConsumerInstance(TestProtobuf.MapIntMessage.class, readConsumerMock);
 
     TestProtobuf.MapIntMessage.Builder msg = TestProtobuf.MapIntMessage.newBuilder();
     msg.putMapInt(123, 1);
@@ -406,7 +420,8 @@ public class ProtoWriteSupportTest {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
     Configuration conf = new Configuration();
     ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.MapIntMessage.class, readConsumerMock, conf);
+    ProtoWriteSupport<TestProtobuf.MapIntMessage> instance =
+        createReadConsumerInstance(TestProtobuf.MapIntMessage.class, readConsumerMock, conf);
 
     TestProtobuf.MapIntMessage.Builder msg = TestProtobuf.MapIntMessage.newBuilder();
     instance.write(msg.build());
@@ -421,7 +436,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testMapIntMessageEmpty() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.MapIntMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProtobuf.MapIntMessage> instance =
+        createReadConsumerInstance(TestProtobuf.MapIntMessage.class, readConsumerMock);
 
     TestProtobuf.MapIntMessage.Builder msg = TestProtobuf.MapIntMessage.newBuilder();
     instance.write(msg.build());
@@ -438,7 +454,8 @@ public class ProtoWriteSupportTest {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
     Configuration conf = new Configuration();
     ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.MapIntMessage.class, readConsumerMock, conf);
+    ProtoWriteSupport<TestProto3.MapIntMessage> instance =
+        createReadConsumerInstance(TestProto3.MapIntMessage.class, readConsumerMock, conf);
 
     TestProto3.MapIntMessage.Builder msg = TestProto3.MapIntMessage.newBuilder();
     msg.putMapInt(123, 1);
@@ -480,7 +497,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testProto3MapIntMessage() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.MapIntMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProto3.MapIntMessage> instance =
+        createReadConsumerInstance(TestProto3.MapIntMessage.class, readConsumerMock);
 
     TestProto3.MapIntMessage.Builder msg = TestProto3.MapIntMessage.newBuilder();
     msg.putMapInt(123, 1);
@@ -520,7 +538,8 @@ public class ProtoWriteSupportTest {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
     Configuration conf = new Configuration();
     ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.MapIntMessage.class, readConsumerMock, conf);
+    ProtoWriteSupport<TestProto3.MapIntMessage> instance =
+        createReadConsumerInstance(TestProto3.MapIntMessage.class, readConsumerMock, conf);
 
     TestProto3.MapIntMessage.Builder msg = TestProto3.MapIntMessage.newBuilder();
     instance.write(msg.build());
@@ -535,7 +554,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testProto3MapIntMessageEmpty() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.MapIntMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProto3.MapIntMessage> instance =
+        createReadConsumerInstance(TestProto3.MapIntMessage.class, readConsumerMock);
 
     TestProto3.MapIntMessage.Builder msg = TestProto3.MapIntMessage.newBuilder();
     instance.write(msg.build());
@@ -550,7 +570,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testRepeatedInnerMessageMessage_message() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.TopMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProtobuf.TopMessage> instance =
+        createReadConsumerInstance(TestProtobuf.TopMessage.class, readConsumerMock);
 
     TestProtobuf.TopMessage.Builder msg = TestProtobuf.TopMessage.newBuilder();
     msg.addInnerBuilder().setOne("one").setTwo("two");
@@ -581,7 +602,8 @@ public class ProtoWriteSupportTest {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
     Configuration conf = new Configuration();
     ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.TopMessage.class, readConsumerMock, conf);
+    ProtoWriteSupport<TestProtobuf.TopMessage> instance =
+        createReadConsumerInstance(TestProtobuf.TopMessage.class, readConsumerMock, conf);
 
     TestProtobuf.TopMessage.Builder msg = TestProtobuf.TopMessage.newBuilder();
     msg.addInnerBuilder().setOne("one").setTwo("two");
@@ -618,7 +640,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testProto3RepeatedInnerMessageMessage_message() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);;
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.TopMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProto3.TopMessage> instance =
+        createReadConsumerInstance(TestProto3.TopMessage.class, readConsumerMock);
 
     TestProto3.TopMessage.Builder msg = TestProto3.TopMessage.newBuilder();
     msg.addInnerBuilder().setOne("one").setTwo("two");
@@ -652,7 +675,8 @@ public class ProtoWriteSupportTest {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
     Configuration conf = new Configuration();
     ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.TopMessage.class, readConsumerMock, conf);
+    ProtoWriteSupport<TestProto3.TopMessage> instance =
+        createReadConsumerInstance(TestProto3.TopMessage.class, readConsumerMock, conf);
 
     TestProto3.TopMessage.Builder msg = TestProto3.TopMessage.newBuilder();
     msg.addInnerBuilder().setOne("one").setTwo("two");
@@ -695,7 +719,8 @@ public class ProtoWriteSupportTest {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
     Configuration conf = new Configuration();
     ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.TopMessage.class, readConsumerMock, conf);
+    ProtoWriteSupport<TestProtobuf.TopMessage> instance =
+        createReadConsumerInstance(TestProtobuf.TopMessage.class, readConsumerMock, conf);
 
     TestProtobuf.TopMessage.Builder msg = TestProtobuf.TopMessage.newBuilder();
     msg.addInnerBuilder().setOne("one");
@@ -742,7 +767,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testRepeatedInnerMessageMessage_scalar() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.TopMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProtobuf.TopMessage> instance =
+        createReadConsumerInstance(TestProtobuf.TopMessage.class, readConsumerMock);
 
     TestProtobuf.TopMessage.Builder msg = TestProtobuf.TopMessage.newBuilder();
     msg.addInnerBuilder().setOne("one");
@@ -777,7 +803,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testProto3RepeatedInnerMessageMessage_scalar() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.TopMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProto3.TopMessage> instance =
+        createReadConsumerInstance(TestProto3.TopMessage.class, readConsumerMock);
 
     TestProto3.TopMessage.Builder msg = TestProto3.TopMessage.newBuilder();
     msg.addInnerBuilder().setOne("one");
@@ -826,7 +853,8 @@ public class ProtoWriteSupportTest {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
     Configuration conf = new Configuration();
     ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.TopMessage.class, readConsumerMock, conf);
+    ProtoWriteSupport<TestProto3.TopMessage> instance =
+        createReadConsumerInstance(TestProto3.TopMessage.class, readConsumerMock, conf);
 
     TestProto3.TopMessage.Builder msg = TestProto3.TopMessage.newBuilder();
     msg.addInnerBuilder().setOne("one");
@@ -885,7 +913,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testOptionalInnerMessage() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.MessageA.class, readConsumerMock);
+    ProtoWriteSupport<TestProtobuf.MessageA> instance =
+        createReadConsumerInstance(TestProtobuf.MessageA.class, readConsumerMock);
 
     TestProtobuf.MessageA.Builder msg = TestProtobuf.MessageA.newBuilder();
     msg.getInnerBuilder().setOne("one");
@@ -911,7 +940,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testProto3OptionalInnerMessage() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProto3.MessageA.class, readConsumerMock);
+    ProtoWriteSupport<TestProto3.MessageA> instance =
+        createReadConsumerInstance(TestProto3.MessageA.class, readConsumerMock);
 
     TestProto3.MessageA.Builder msg = TestProto3.MessageA.newBuilder();
     msg.getInnerBuilder().setOne("one");
@@ -943,7 +973,8 @@ public class ProtoWriteSupportTest {
   @Test(expected = UnsupportedOperationException.class)
   public void testMessageWithExtensions() throws Exception {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport instance = createReadConsumerInstance(TestProtobuf.Vehicle.class, readConsumerMock);
+    ProtoWriteSupport<TestProtobuf.Vehicle> instance =
+        createReadConsumerInstance(TestProtobuf.Vehicle.class, readConsumerMock);
 
     TestProtobuf.Vehicle.Builder msg = TestProtobuf.Vehicle.newBuilder();
     msg.setHorsePower(300);
@@ -957,7 +988,8 @@ public class ProtoWriteSupportTest {
   @Test
   public void testMessageOneOf() {
     RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
-    ProtoWriteSupport<TestProto3.OneOfTestMessage> spyWriter = createReadConsumerInstance(TestProto3.OneOfTestMessage.class, readConsumerMock);
+    ProtoWriteSupport<TestProto3.OneOfTestMessage> spyWriter =
+        createReadConsumerInstance(TestProto3.OneOfTestMessage.class, readConsumerMock);
     final int theInt = 99;
 
     TestProto3.OneOfTestMessage.Builder msg = TestProto3.OneOfTestMessage.newBuilder();
@@ -980,7 +1012,6 @@ public class ProtoWriteSupportTest {
    */
   @Test
   public void testMessageOneOfRoundTrip() throws IOException {
-
     TestProto3.OneOfTestMessage.Builder msgBuilder = TestProto3.OneOfTestMessage.newBuilder();
     msgBuilder.setSecond(99);
     TestProto3.OneOfTestMessage theMessage = msgBuilder.build();
@@ -1009,6 +1040,165 @@ public class ProtoWriteSupportTest {
     TestProto3.OneOfTestMessage gotBackThird = gotBack.get(2);
     assertEquals(gotBackThird.getFirst(), 42);
     assertEquals(gotBackThird.getTheOneofCase(), TestProto3.OneOfTestMessage.TheOneofCase.FIRST);
+  }
 
+  @Test
+  public void testMessageRecursion() {
+    RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
+    Configuration conf = new Configuration();
+    ProtoSchemaConverter.setMaxRecursion(conf, 1);
+    ProtoWriteSupport<Trees.BinaryTree> spyWriter =
+        createReadConsumerInstance(Trees.BinaryTree.class, readConsumerMock, conf);
+
+    Trees.BinaryTree.Builder msg = Trees.BinaryTree.newBuilder();
+    Trees.BinaryTree.Builder cur = msg;
+    for (int i = 0; i < 10; ++i) {
+      cur.getValueBuilder().setTypeUrl("" + i);
+      cur = cur.getRightBuilder();
+    }
+    Trees.BinaryTree built = msg.build();
+    spyWriter.write(built);
+
+    InOrder inOrder = Mockito.inOrder(readConsumerMock);
+
+    inOrder.verify(readConsumerMock).startMessage();
+    inOrder.verify(readConsumerMock).startField("value", 0);
+    inOrder.verify(readConsumerMock).startGroup();
+    inOrder.verify(readConsumerMock).startField("type_url", 0);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray("0".getBytes()));
+    inOrder.verify(readConsumerMock).endField("type_url", 0);
+    inOrder.verify(readConsumerMock).startField("value", 1);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray("".getBytes()));
+    inOrder.verify(readConsumerMock).endField("value", 1);
+    inOrder.verify(readConsumerMock).endGroup();
+    inOrder.verify(readConsumerMock).endField("value", 0);
+    inOrder.verify(readConsumerMock).startField("right", 2);
+    inOrder.verify(readConsumerMock).startGroup();
+    inOrder.verify(readConsumerMock).startField("value", 0);
+    inOrder.verify(readConsumerMock).startGroup();
+    inOrder.verify(readConsumerMock).startField("type_url", 0);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray("1".getBytes()));
+    inOrder.verify(readConsumerMock).endField("type_url", 0);
+    inOrder.verify(readConsumerMock).startField("value", 1);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray("".getBytes()));
+    inOrder.verify(readConsumerMock).endField("value", 1);
+    inOrder.verify(readConsumerMock).endGroup();
+    inOrder.verify(readConsumerMock).endField("value", 0);
+    inOrder.verify(readConsumerMock).startField("right", 2);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray(built.getRight().getRight().toByteArray()));
+    inOrder.verify(readConsumerMock).endField("right", 2);
+    inOrder.verify(readConsumerMock).endGroup();
+    inOrder.verify(readConsumerMock).endField("right", 2);
+    inOrder.verify(readConsumerMock).endMessage();
+
+    Mockito.verifyNoMoreInteractions(readConsumerMock);
+  }
+
+  @Test
+  public void testRepeatedRecursion() {
+    RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
+    Configuration conf = new Configuration();
+    ProtoSchemaConverter.setMaxRecursion(conf, 1);
+    ProtoWriteSupport<Trees.WideTree> spyWriter =
+        createReadConsumerInstance(Trees.WideTree.class, readConsumerMock, conf);
+
+    Trees.WideTree.Builder msg = Trees.WideTree.newBuilder();
+    Trees.WideTree.Builder cur = msg;
+
+    for (int i = 0; i < 10; ++i) {
+      cur.getValueBuilder().setTypeUrl("" + i);
+      cur = cur.addChildrenBuilder();
+    }
+    Trees.WideTree built = msg.build();
+    spyWriter.write(built);
+
+    InOrder inOrder = Mockito.inOrder(readConsumerMock);
+
+    inOrder.verify(readConsumerMock).startMessage();
+    inOrder.verify(readConsumerMock).startField("value", 0);
+    inOrder.verify(readConsumerMock).startGroup();
+    inOrder.verify(readConsumerMock).startField("type_url", 0);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray("0".getBytes()));
+    inOrder.verify(readConsumerMock).endField("type_url", 0);
+    inOrder.verify(readConsumerMock).startField("value", 1);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray("".getBytes()));
+    inOrder.verify(readConsumerMock).endField("value", 1);
+    inOrder.verify(readConsumerMock).endGroup();
+    inOrder.verify(readConsumerMock).endField("value", 0);
+    inOrder.verify(readConsumerMock).startField("children", 1);
+    inOrder.verify(readConsumerMock).startGroup();
+    inOrder.verify(readConsumerMock).startField("value", 0);
+    inOrder.verify(readConsumerMock).startGroup();
+    inOrder.verify(readConsumerMock).startField("type_url", 0);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray("1".getBytes()));
+    inOrder.verify(readConsumerMock).endField("type_url", 0);
+    inOrder.verify(readConsumerMock).startField("value", 1);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray("".getBytes()));
+    inOrder.verify(readConsumerMock).endField("value", 1);
+    inOrder.verify(readConsumerMock).endGroup();
+    inOrder.verify(readConsumerMock).endField("value", 0);
+    inOrder.verify(readConsumerMock).startField("children", 1);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray(built.getChildren(0).getChildren(0).toByteArray()));
+    inOrder.verify(readConsumerMock).endField("children", 1);
+    inOrder.verify(readConsumerMock).endGroup();
+    inOrder.verify(readConsumerMock).endField("children", 1);
+    inOrder.verify(readConsumerMock).endMessage();
+
+    Mockito.verifyNoMoreInteractions(readConsumerMock);
+  }
+
+  @Test
+  public void testMapRecursion() {
+    RecordConsumer readConsumerMock =  Mockito.mock(RecordConsumer.class);
+    Configuration conf = new Configuration();
+    ProtoSchemaConverter.setMaxRecursion(conf, 1);
+    ProtoWriteSupport<Value> spyWriter =
+        createReadConsumerInstance(Value.class, readConsumerMock, conf);
+
+    // Need to build it backwards due to clunky Struct.Builder interface.
+    Value.Builder msg = Value.newBuilder().setStringValue("last");
+    for (int i = 10; i > -1; --i) {
+      Value.Builder next = Value.newBuilder();
+      next.getStructValueBuilder().putFields("" + i, msg.build());
+      msg = next;
+    }
+    Value built = msg.build();
+    spyWriter.write(built);
+
+    InOrder inOrder = Mockito.inOrder(readConsumerMock);
+
+    inOrder.verify(readConsumerMock).startMessage();
+    inOrder.verify(readConsumerMock).startField("struct_value", 4);
+    inOrder.verify(readConsumerMock).startGroup();
+    inOrder.verify(readConsumerMock).startField("fields", 0);
+    inOrder.verify(readConsumerMock).startGroup();
+    inOrder.verify(readConsumerMock).startField("key", 0);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray("0".getBytes()));
+    inOrder.verify(readConsumerMock).endField("key", 0);
+    inOrder.verify(readConsumerMock).startField("value", 1);
+    inOrder.verify(readConsumerMock).startGroup();
+    inOrder.verify(readConsumerMock).startField("struct_value", 4);
+    inOrder.verify(readConsumerMock).startGroup();
+    inOrder.verify(readConsumerMock).startField("fields", 0);
+    inOrder.verify(readConsumerMock).startGroup();
+    inOrder.verify(readConsumerMock).startField("key", 0);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray("1".getBytes()));
+    inOrder.verify(readConsumerMock).endField("key", 0);
+    inOrder.verify(readConsumerMock).startField("value", 1);
+    inOrder.verify(readConsumerMock).addBinary(Binary.fromConstantByteArray(built.getStructValue().getFieldsOrThrow("0").getStructValue().getFieldsOrThrow("1").toByteArray()));
+    inOrder.verify(readConsumerMock).endField("value", 1);
+    inOrder.verify(readConsumerMock).endGroup();
+    inOrder.verify(readConsumerMock).endField("fields", 0);
+    inOrder.verify(readConsumerMock).endGroup();
+    inOrder.verify(readConsumerMock).endField("struct_value", 4);
+    inOrder.verify(readConsumerMock).endGroup();
+    inOrder.verify(readConsumerMock).endField("value", 1);
+    inOrder.verify(readConsumerMock).endGroup();
+    inOrder.verify(readConsumerMock).endField("fields", 0);
+    inOrder.verify(readConsumerMock).endGroup();
+    inOrder.verify(readConsumerMock).endField("struct_value", 4);
+    inOrder.verify(readConsumerMock).endMessage();
+
+    Mockito.verifyNoMoreInteractions(readConsumerMock);
   }
 }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/TestUtils.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/TestUtils.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.proto;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
@@ -212,4 +214,7 @@ public class TestUtils {
     return file;
   }
 
+  public static String readResource(final String filename) throws IOException {
+    return Resources.toString(Resources.getResource(filename), Charsets.UTF_8);
+  }
 }

--- a/parquet-protobuf/src/test/resources/BinaryTree.par
+++ b/parquet-protobuf/src/test/resources/BinaryTree.par
@@ -1,0 +1,50 @@
+message Trees.BinaryTree {
+  optional group value = 1 {
+    optional binary type_url (STRING) = 1;
+    optional binary value = 2;
+  }
+  optional group left = 2 {
+    optional group value = 1 {
+      optional binary type_url (STRING) = 1;
+      optional binary value = 2;
+    }
+    optional group left = 2 {
+      optional group value = 1 {
+        optional binary type_url (STRING) = 1;
+        optional binary value = 2;
+      }
+      optional binary left = 2;
+      optional binary right = 3;
+    }
+    optional group right = 3 {
+      optional group value = 1 {
+        optional binary type_url (STRING) = 1;
+        optional binary value = 2;
+      }
+      optional binary left = 2;
+      optional binary right = 3;
+    }
+  }
+  optional group right = 3 {
+    optional group value = 1 {
+      optional binary type_url (STRING) = 1;
+      optional binary value = 2;
+    }
+    optional group left = 2 {
+      optional group value = 1 {
+        optional binary type_url (STRING) = 1;
+        optional binary value = 2;
+      }
+      optional binary left = 2;
+      optional binary right = 3;
+    }
+    optional group right = 3 {
+      optional group value = 1 {
+        optional binary type_url (STRING) = 1;
+        optional binary value = 2;
+      }
+      optional binary left = 2;
+      optional binary right = 3;
+    }
+  }
+}

--- a/parquet-protobuf/src/test/resources/Struct.par
+++ b/parquet-protobuf/src/test/resources/Struct.par
@@ -1,0 +1,110 @@
+message google.protobuf.Struct {
+  optional group fields (MAP) = 1 {
+    repeated group key_value {
+      required binary key (STRING);
+      optional group value {
+        optional binary null_value (ENUM) = 1;
+        optional double number_value = 2;
+        optional binary string_value (STRING) = 3;
+        optional boolean bool_value = 4;
+        optional group struct_value = 5 {
+          optional group fields (MAP) = 1 {
+            repeated group key_value {
+              required binary key (STRING);
+              optional group value {
+                optional binary null_value (ENUM) = 1;
+                optional double number_value = 2;
+                optional binary string_value (STRING) = 3;
+                optional boolean bool_value = 4;
+                optional group struct_value = 5 {
+                  optional group fields (MAP) = 1 {
+                    repeated group key_value {
+                      required binary key (STRING);
+                      optional group value {
+                        optional binary null_value (ENUM) = 1;
+                        optional double number_value = 2;
+                        optional binary string_value (STRING) = 3;
+                        optional boolean bool_value = 4;
+                        optional binary struct_value = 5;
+                        optional group list_value = 6 {
+                          optional binary values = 1;
+                        }
+                      }
+                    }
+                  }
+                }
+                optional group list_value = 6 {
+                  optional group values (LIST) = 1 {
+                    repeated group list {
+                      optional group element {
+                        optional binary null_value (ENUM) = 1;
+                        optional double number_value = 2;
+                        optional binary string_value (STRING) = 3;
+                        optional boolean bool_value = 4;
+                        optional group struct_value = 5 {
+                          optional binary fields = 1;
+                        }
+                        optional group list_value = 6 {
+                          optional binary values = 1;
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        optional group list_value = 6 {
+          optional group values (LIST) = 1 {
+            repeated group list {
+              optional group element {
+                optional binary null_value (ENUM) = 1;
+                optional double number_value = 2;
+                optional binary string_value (STRING) = 3;
+                optional boolean bool_value = 4;
+                optional group struct_value = 5 {
+                  optional group fields (MAP) = 1 {
+                    repeated group key_value {
+                      required binary key (STRING);
+                      optional group value {
+                        optional binary null_value (ENUM) = 1;
+                        optional double number_value = 2;
+                        optional binary string_value (STRING) = 3;
+                        optional boolean bool_value = 4;
+                        optional group struct_value = 5 {
+                          optional binary fields = 1;
+                        }
+                        optional group list_value = 6 {
+                          optional binary values = 1;
+                        }
+                      }
+                    }
+                  }
+                }
+                optional group list_value = 6 {
+                  optional group values (LIST) = 1 {
+                    repeated group list {
+                      optional group element {
+                        optional binary null_value (ENUM) = 1;
+                        optional double number_value = 2;
+                        optional binary string_value (STRING) = 3;
+                        optional boolean bool_value = 4;
+                        optional group struct_value = 5 {
+                          optional binary fields = 1;
+                        }
+                        optional group list_value = 6 {
+                          optional binary values = 1;
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/parquet-protobuf/src/test/resources/Trees.proto
+++ b/parquet-protobuf/src/test/resources/Trees.proto
@@ -1,0 +1,37 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+syntax = "proto3";
+
+package Trees;
+
+import "google/protobuf/any.proto";
+
+option java_package = "org.apache.parquet.proto.test";
+
+message BinaryTree {
+    google.protobuf.Any value = 1;
+    BinaryTree left = 2;
+    BinaryTree right = 3;
+}
+
+message WideTree {
+    google.protobuf.Any value = 1;
+    repeated WideTree children = 2;
+}

--- a/parquet-protobuf/src/test/resources/Value.par
+++ b/parquet-protobuf/src/test/resources/Value.par
@@ -1,0 +1,105 @@
+message google.protobuf.Value {
+  optional binary null_value (ENUM) = 1;
+  optional double number_value = 2;
+  optional binary string_value (STRING) = 3;
+  optional boolean bool_value = 4;
+  optional group struct_value = 5 {
+    optional group fields (MAP) = 1 {
+      repeated group key_value {
+        required binary key (STRING);
+        optional group value {
+          optional binary null_value (ENUM) = 1;
+          optional double number_value = 2;
+          optional binary string_value (STRING) = 3;
+          optional boolean bool_value = 4;
+          optional group struct_value = 5 {
+            optional group fields (MAP) = 1 {
+              repeated group key_value {
+                required binary key (STRING);
+                optional group value {
+                  optional binary null_value (ENUM) = 1;
+                  optional double number_value = 2;
+                  optional binary string_value (STRING) = 3;
+                  optional boolean bool_value = 4;
+                  optional group struct_value = 5 {
+                    optional binary fields = 1;
+                  }
+                  optional group list_value = 6 {
+                    optional binary values = 1;
+                  }
+                }
+              }
+            }
+          }
+          optional group list_value = 6 {
+            optional group values (LIST) = 1 {
+              repeated group list {
+                optional group element {
+                  optional binary null_value (ENUM) = 1;
+                  optional double number_value = 2;
+                  optional binary string_value (STRING) = 3;
+                  optional boolean bool_value = 4;
+                  optional group struct_value = 5 {
+                    optional binary fields = 1;
+                  }
+                  optional group list_value = 6 {
+                    optional binary values = 1;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  optional group list_value = 6 {
+    optional group values (LIST) = 1 {
+      repeated group list {
+        optional group element {
+          optional binary null_value (ENUM) = 1;
+          optional double number_value = 2;
+          optional binary string_value (STRING) = 3;
+          optional boolean bool_value = 4;
+          optional group struct_value = 5 {
+            optional group fields (MAP) = 1 {
+              repeated group key_value {
+                required binary key (STRING);
+                optional group value {
+                  optional binary null_value (ENUM) = 1;
+                  optional double number_value = 2;
+                  optional binary string_value (STRING) = 3;
+                  optional boolean bool_value = 4;
+                  optional group struct_value = 5 {
+                    optional binary fields = 1;
+                  }
+                  optional group list_value = 6 {
+                    optional binary values = 1;
+                  }
+                }
+              }
+            }
+          }
+          optional group list_value = 6 {
+            optional group values (LIST) = 1 {
+              repeated group list {
+                optional group element {
+                  optional binary null_value (ENUM) = 1;
+                  optional double number_value = 2;
+                  optional binary string_value (STRING) = 3;
+                  optional boolean bool_value = 4;
+                  optional group struct_value = 5 {
+                    optional binary fields = 1;
+                  }
+                  optional group list_value = 6 {
+                    optional binary values = 1;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/parquet-protobuf/src/test/resources/WideTree.par
+++ b/parquet-protobuf/src/test/resources/WideTree.par
@@ -1,0 +1,27 @@
+message Trees.WideTree {
+  optional group value = 1 {
+    optional binary type_url (STRING) = 1;
+    optional binary value = 2;
+  }
+  optional group children (LIST) = 2 {
+    repeated group list {
+      optional group element {
+        optional group value = 1 {
+          optional binary type_url (STRING) = 1;
+          optional binary value = 2;
+        }
+        optional group children (LIST) = 2 {
+          repeated group list {
+            optional group element {
+              optional group value = 1 {
+                optional binary type_url (STRING) = 1;
+                optional binary value = 2;
+              }
+              optional binary children = 2;
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- This is an alternative approach to supporting recursion to apache#445 and apache#988.
- This approach could address the other recursion related issues (PARQUET-129, PARQUET-554).
- TODO: ReadSupport

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1711
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - `ProtoSchemaConverterTest#test*Recursion`
  - `ProtoWriteSupportTest#test*Recursion`

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
