### PR TITLE
PARQUET-2192: Add Java 17 build test to GitHub action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,4 @@ jobs:
         run: |
           EXTRA_JAVA_TEST_ARGS=$(mvn help:evaluate -Dexpression=extraJavaTestArgs -q -DforceStdout)
           export MAVEN_OPTS="$MAVEN_OPTS $EXTRA_JAVA_TEST_ARGS"
-          if [ "$JAVA_VERSION" = "17" ]; then
-              mvn verify --batch-mode -Pci-test
-          else
-              mvn verify --batch-mode javadoc:javadoc -Pci-test
-          fi
+          mvn verify --batch-mode javadoc:javadoc -Pci-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '1.8', '11' ]
+        java: [ '1.8', '11', '17' ]
         codes: [ 'uncompressed,brotli', 'gzip,snappy' ]
     name: Build Parquet with JDK ${{ matrix.java }} and ${{ matrix.codes }}
 
@@ -43,9 +43,18 @@ jobs:
           bash dev/ci-before_install.sh
       - name: install
         run: |
+          EXTRA_JAVA_TEST_ARGS=$(mvn help:evaluate -Dexpression=extraJavaTestArgs -q -DforceStdout)
+          export MAVEN_OPTS="$MAVEN_OPTS $EXTRA_JAVA_TEST_ARGS"
           mvn install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true -Djava.version=${{ matrix.java }}
       - name: verify
         env:
           TEST_CODECS: ${{ matrix.codes }}
+          JAVA_VERSION: ${{ matrix.java }}
         run: |
-          mvn verify --batch-mode javadoc:javadoc -Pci-test
+          EXTRA_JAVA_TEST_ARGS=$(mvn help:evaluate -Dexpression=extraJavaTestArgs -q -DforceStdout)
+          export MAVEN_OPTS="$MAVEN_OPTS $EXTRA_JAVA_TEST_ARGS"
+          if [ "$JAVA_VERSION" = "17" ]; then
+              mvn verify --batch-mode -Pci-test
+          else
+              mvn verify --batch-mode javadoc:javadoc -Pci-test
+          fi

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/package-info.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/package-info.java
@@ -29,7 +29,5 @@
  * In a standalone java app:
  * @see org.apache.parquet.hadoop.ParquetWriter
  * @see org.apache.parquet.hadoop.ParquetReader
- *
- * </p>
  */
 package org.apache.parquet.hadoop;

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,23 @@
 
     <!-- Resource intesive tests are enabled by default but disabled in the CI envrionment -->
     <enableResourceIntensiveTests>true</enableResourceIntensiveTests>
+
+    <extraJavaTestArgs>
+      -XX:+IgnoreUnrecognizedVMOptions
+      --add-opens=java.base/java.lang=ALL-UNNAMED
+      --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+      --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+      --add-opens=java.base/java.io=ALL-UNNAMED
+      --add-opens=java.base/java.net=ALL-UNNAMED
+      --add-opens=java.base/java.nio=ALL-UNNAMED
+      --add-opens=java.base/java.util=ALL-UNNAMED
+      --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+      --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+      --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+      --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
+      --add-opens=java.base/sun.security.action=ALL-UNNAMED
+      --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+    </extraJavaTestArgs>
   </properties>
 
   <modules>
@@ -407,7 +424,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${surefire.argLine}</argLine>
+          <argLine>${surefire.argLine} ${extraJavaTestArgs}</argLine>
           <systemPropertyVariables>
             <!-- Configure Parquet logging during tests
                  See http://www.slf4j.org/api/org/slf4j/impl/SimpleLogger.html


### PR DESCRIPTION
We plan to run Spark on JDK 17 due to the performance issue([SPARK-40303](https://issues.apache.org/jira/browse/SPARK-40303)). Spark's dependencies could run on JDK 17 as well.

This PR add Java 17 build test to GitHub action.