### PR TITLE
PARQUET-2195: Add scan command to parquet-cli

### DIFF
--- a/parquet-cli/README.md
+++ b/parquet-cli/README.md
@@ -96,6 +96,22 @@ Usage: parquet [options] [command] [command options]
         Print the first N records from a file
     head
         Print the first N records from a file
+    column-index
+        Prints the column and offset indexes of a Parquet file
+    column-size
+        Print the column sizes of a parquet file
+    prune
+        Prune column(s) in a Parquet file and save it to a new file. The columns left are not changed.
+    trans-compression
+        Translate the compression from one to another (It doesn't support bloom filter feature yet).
+    masking
+        Replace columns with masked values and write to a new Parquet file
+    footer
+        Print the Parquet file footer in json format
+    bloom-filter
+        Check bloom filters for a Parquet column
+    scan
+        Scan all records from a file
 
   Examples:
 

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/Main.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/Main.java
@@ -34,6 +34,7 @@ import org.apache.parquet.cli.commands.ConvertCSVCommand;
 import org.apache.parquet.cli.commands.ConvertCommand;
 import org.apache.parquet.cli.commands.ParquetMetadataCommand;
 import org.apache.parquet.cli.commands.PruneColumnsCommand;
+import org.apache.parquet.cli.commands.ScanCommand;
 import org.apache.parquet.cli.commands.SchemaCommand;
 import org.apache.parquet.cli.commands.ShowBloomFilterCommand;
 import org.apache.parquet.cli.commands.ShowColumnIndexCommand;
@@ -101,6 +102,7 @@ public class Main extends Configured implements Tool {
     jc.addCommand("masking", new ColumnMaskingCommand(console));
     jc.addCommand("footer", new ShowFooterCommand(console));
     jc.addCommand("bloom-filter", new ShowBloomFilterCommand(console));
+    jc.addCommand("scan", new ScanCommand(console));
   }
 
   @Override

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ScanCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ScanCommand.java
@@ -36,7 +36,7 @@ import java.util.List;
 public class ScanCommand extends BaseCommand {
 
   @Parameter(description = "<file>")
-  List<String> sourceFiles;
+  String sourceFile;
 
   @Parameter(
     names = {"-c", "--column", "--columns"},
@@ -50,17 +50,14 @@ public class ScanCommand extends BaseCommand {
   @Override
   public int run() throws IOException {
     Preconditions.checkArgument(
-      sourceFiles != null && !sourceFiles.isEmpty(),
+      sourceFile != null && !sourceFile.isEmpty(),
       "Missing file name");
-    Preconditions.checkArgument(sourceFiles.size() == 1,
-      "Only one file can be given");
 
-    final String source = sourceFiles.get(0);
-    Schema schema = getAvroSchema(source);
+    Schema schema = getAvroSchema(sourceFile);
     Schema projection = Expressions.filterSchema(schema, columns);
 
     long startTime = System.currentTimeMillis();
-    Iterable<Object> reader = openDataFile(source, projection);
+    Iterable<Object> reader = openDataFile(sourceFile, projection);
     boolean threw = true;
     long count = 0;
     try {
@@ -77,7 +74,7 @@ public class ScanCommand extends BaseCommand {
     }
     long endTime = System.currentTimeMillis();
 
-    console.info("Scanned " + count + " records from " + source);
+    console.info("Scanned " + count + " records from " + sourceFile);
     console.info("Time: " + (endTime - startTime) / 1000.0 + " s");
     return 0;
   }

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ScanCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ScanCommand.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.io.Closeables;
+import org.apache.avro.Schema;
+import org.apache.parquet.cli.BaseCommand;
+import org.apache.parquet.cli.util.Expressions;
+import org.slf4j.Logger;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+
+@Parameters(commandDescription = "Scan all records from a file")
+public class ScanCommand extends BaseCommand {
+
+  @Parameter(description = "<file>")
+  List<String> sourceFiles;
+
+  @Parameter(
+    names = {"-c", "--column", "--columns"},
+    description = "List of columns")
+  List<String> columns;
+
+  public ScanCommand(Logger console) {
+    super(console);
+  }
+
+  @Override
+  public int run() throws IOException {
+    Preconditions.checkArgument(
+      sourceFiles != null && !sourceFiles.isEmpty(),
+      "Missing file name");
+    Preconditions.checkArgument(sourceFiles.size() == 1,
+      "Only one file can be given");
+
+    final String source = sourceFiles.get(0);
+    Schema schema = getAvroSchema(source);
+    Schema projection = Expressions.filterSchema(schema, columns);
+
+    long startTime = System.currentTimeMillis();
+    Iterable<Object> reader = openDataFile(source, projection);
+    boolean threw = true;
+    long count = 0;
+    try {
+      for (Object record : reader) {
+        count += 1;
+      }
+      threw = false;
+    } catch (RuntimeException e) {
+      throw new RuntimeException("Failed on record " + count, e);
+    } finally {
+      if (reader instanceof Closeable) {
+        Closeables.close((Closeable) reader, threw);
+      }
+    }
+    long endTime = System.currentTimeMillis();
+
+    console.info("Scanned " + count + " records from " + source);
+    console.info("Time: " + (endTime - startTime) / 1000.0 + " s");
+    return 0;
+  }
+
+  @Override
+  public List<String> getExamples() {
+    return Lists.newArrayList(
+      "# Scan all the records from file \"data.avro\":",
+      "data.avro",
+      "# Scan all the records from file \"data.parquet\":",
+      "data.parquet"
+    );
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ScanCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ScanCommandTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class ScanCommandTest extends ParquetFileTest {
+  @Test
+  public void testScanCommand() throws IOException {
+    File file = parquetFile();
+    ScanCommand command = new ScanCommand(createLogger());
+    command.sourceFiles = Arrays.asList(file.getAbsolutePath());
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ScanCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ScanCommandTest.java
@@ -31,7 +31,7 @@ public class ScanCommandTest extends ParquetFileTest {
   public void testScanCommand() throws IOException {
     File file = parquetFile();
     ScanCommand command = new ScanCommand(createLogger());
-    command.sourceFiles = Arrays.asList(file.getAbsolutePath());
+    command.sourceFile = file.getAbsolutePath();
     command.setConf(new Configuration());
     Assert.assertEquals(0, command.run());
   }


### PR DESCRIPTION
This PR enhances parquet-cli by adding a scan command to go through all records without printing them. This is useful when users need to verify if the parquet file is corrupted.

Added ScanCommandTest to make sure no error happens. Test it manually with local parquet files.