### PR TITLE
PARQUET-2212: Add ByteBuffer api for decryptors to allow direct memory to be decrypted

### DIFF
--- a/parquet-column/pom.xml
+++ b/parquet-column/pom.xml
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.9</version>
+      <version>${commons-lang3.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
@@ -536,5 +536,10 @@ abstract public class BytesInput {
     public long size() {
       return buffer.remaining();
     }
+    
+    @Override
+    public ByteBuffer toByteBuffer() throws IOException {
+      return buffer.slice();
+    }
   }
 }

--- a/parquet-format-structures/src/main/java/org/apache/parquet/format/BlockCipher.java
+++ b/parquet-format-structures/src/main/java/org/apache/parquet/format/BlockCipher.java
@@ -21,11 +21,12 @@ package org.apache.parquet.format;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 
 public interface BlockCipher{
 
 
-  public interface Encryptor{
+  interface Encryptor{
     /**
      * Encrypts the plaintext.
      * 
@@ -36,11 +37,11 @@ public interface BlockCipher{
      * The ciphertext includes the nonce and (in case of GCM cipher) the tag, as detailed in the 
      * Parquet Modular Encryption specification.
      */
-    public byte[] encrypt(byte[] plaintext, byte[] AAD);
+    byte[] encrypt(byte[] plaintext, byte[] AAD);
   }
 
 
-  public interface Decryptor{  
+  interface Decryptor{
     /**
      * Decrypts the ciphertext. 
      * 
@@ -51,17 +52,26 @@ public interface BlockCipher{
      * @param AAD - Additional Authenticated Data for the decryption (ignored in case of CTR cipher)
      * @return plaintext - starts at offset 0 of the output value, and fills up the entire byte array.
      */
-    public byte[] decrypt(byte[] lengthAndCiphertext, byte[] AAD);
+    byte[] decrypt(byte[] lengthAndCiphertext, byte[] AAD);
 
     /**
+     * Convenience decryption method that reads the length and ciphertext from a ByteBuffer
+     *
+     * @param from ByteBuffer with length and ciphertext.
+     * @param AAD - Additional Authenticated Data for the decryption (ignored in case of CTR cipher)
+     * @return plaintext -  starts at offset 0 of the output, and fills up the entire byte array.
+     */
+    ByteBuffer decrypt(ByteBuffer from, byte[] AAD);
+
+  /**
      * Convenience decryption method that reads the length and ciphertext from the input stream.
-     * 
+     *
      * @param from Input stream with length and ciphertext.
      * @param AAD - Additional Authenticated Data for the decryption (ignored in case of CTR cipher)
      * @return plaintext -  starts at offset 0 of the output, and fills up the entire byte array.
      * @throws IOException - Stream I/O problems
      */
-    public byte[] decrypt(InputStream from, byte[] AAD) throws IOException;
+    byte[] decrypt(InputStream from, byte[] AAD) throws IOException;
   }
 }
 

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -175,6 +175,11 @@
       <version>3.9</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import static org.apache.parquet.hadoop.ParquetInputFormat.COLUMN_INDEX_FILTERING_ENABLED;
 import static org.apache.parquet.hadoop.ParquetInputFormat.DICTIONARY_FILTERING_ENABLED;
 import static org.apache.parquet.hadoop.ParquetInputFormat.BLOOM_FILTERING_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.OFF_HEAP_DECRYPT_BUFFER_ENABLED;
 import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
 import static org.apache.parquet.hadoop.ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED;
 import static org.apache.parquet.hadoop.ParquetInputFormat.RECORD_FILTERING_ENABLED;
@@ -52,6 +53,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
                             boolean useColumnIndexFilter,
                             boolean usePageChecksumVerification,
                             boolean useBloomFilter,
+                            boolean useOffHeapDecryptBuffer,
                             FilterCompat.Filter recordFilter,
                             MetadataFilter metadataFilter,
                             CompressionCodecFactory codecFactory,
@@ -62,7 +64,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
                             FileDecryptionProperties fileDecryptionProperties) {
     super(
         useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter, useColumnIndexFilter,
-        usePageChecksumVerification, useBloomFilter, recordFilter, metadataFilter, codecFactory, allocator,
+        usePageChecksumVerification, useBloomFilter, useOffHeapDecryptBuffer, recordFilter, metadataFilter, codecFactory, allocator,
         maxAllocationSize, properties, fileDecryptionProperties
     );
     this.conf = conf;
@@ -108,6 +110,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
       usePageChecksumVerification(conf.getBoolean(PAGE_VERIFY_CHECKSUM_ENABLED,
         usePageChecksumVerification));
       useBloomFilter(conf.getBoolean(BLOOM_FILTERING_ENABLED, true));
+      useOffHeapDecryptBuffer(conf.getBoolean(OFF_HEAP_DECRYPT_BUFFER_ENABLED, false));
       withCodecFactory(HadoopCodecs.newFactory(conf, 0));
       withRecordFilter(getFilter(conf));
       withMaxAllocationInBytes(conf.getInt(ALLOCATION_SIZE, 8388608));
@@ -120,12 +123,12 @@ public class HadoopReadOptions extends ParquetReadOptions {
     @Override
     public ParquetReadOptions build() {
       if (null == fileDecryptionProperties) {
-        // if not set, check if Hadoop conf defines decryption factory and properties 
+        // if not set, check if Hadoop conf defines decryption factory and properties
         fileDecryptionProperties = createDecryptionProperties(filePath, conf);
       }
       return new HadoopReadOptions(
         useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter,
-        useColumnIndexFilter, usePageChecksumVerification, useBloomFilter, recordFilter, metadataFilter,
+        useColumnIndexFilter, usePageChecksumVerification, useBloomFilter, useOffHeapDecryptBuffer, recordFilter, metadataFilter,
         codecFactory, allocator, maxAllocationSize, properties, conf, fileDecryptionProperties);
     }
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesCtrDecryptor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesCtrDecryptor.java
@@ -19,6 +19,7 @@
 
 package org.apache.parquet.crypto;
 
+import java.nio.ByteBuffer;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 
@@ -80,6 +81,48 @@ public class AesCtrDecryptor extends AesCipher implements BlockCipher.Decryptor{
       } 
 
       cipher.doFinal(ciphertext, inputOffset, inputLength, plainText, outputOffset);
+    } catch (GeneralSecurityException e) {
+      throw new ParquetCryptoRuntimeException("Failed to decrypt", e);
+    }
+
+    return plainText;
+  }
+  public ByteBuffer decrypt(ByteBuffer ciphertext, byte[] AAD) {
+
+    int cipherTextOffset = SIZE_LENGTH;
+    int cipherTextLength = ciphertext.limit() - ciphertext.position() - SIZE_LENGTH;
+
+    int plainTextLength = cipherTextLength - NONCE_LENGTH;
+    if (plainTextLength < 1) {
+      throw new ParquetCryptoRuntimeException("Wrong input length " + plainTextLength);
+    }
+
+    // skip size
+    ciphertext.position(ciphertext.position() + cipherTextOffset);
+    // Get the nonce from ciphertext
+    ciphertext.get(ctrIV, 0, NONCE_LENGTH);
+
+    // Reuse the input buffer as the output buffer
+    ByteBuffer plainText = ciphertext.slice();
+    plainText.limit(plainTextLength);
+    int inputLength = cipherTextLength - NONCE_LENGTH;
+    int inputOffset = cipherTextOffset + NONCE_LENGTH;
+    try {
+      IvParameterSpec spec = new IvParameterSpec(ctrIV);
+      cipher.init(Cipher.DECRYPT_MODE, aesKey, spec);
+
+      // Breaking decryption into multiple updates, to trigger h/w acceleration in Java 9+
+      while (inputLength > CHUNK_LENGTH) {
+        ciphertext.position(inputOffset);
+        ciphertext.limit(inputOffset + CHUNK_LENGTH);
+        cipher.update(ciphertext, plainText);
+        inputOffset += CHUNK_LENGTH;
+        inputLength -= CHUNK_LENGTH;
+      }
+      ciphertext.position(inputOffset);
+      ciphertext.limit(inputOffset + inputLength);
+      cipher.doFinal(ciphertext, plainText);
+      plainText.flip();
     } catch (GeneralSecurityException e) {
       throw new ParquetCryptoRuntimeException("Failed to decrypt", e);
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesGcmDecryptor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesGcmDecryptor.java
@@ -19,6 +19,7 @@
 
 package org.apache.parquet.crypto;
 
+import java.nio.ByteBuffer;
 import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
@@ -69,6 +70,38 @@ public class AesGcmDecryptor extends AesCipher implements BlockCipher.Decryptor{
       if (null != AAD) cipher.updateAAD(AAD);
 
       cipher.doFinal(ciphertext, inputOffset, inputLength, plainText, outputOffset);
+    }  catch (AEADBadTagException e) {
+      throw new TagVerificationException("GCM tag check failed", e);
+    } catch (GeneralSecurityException e) {
+      throw new ParquetCryptoRuntimeException("Failed to decrypt", e);
+    }
+
+    return plainText;
+  }
+
+  public ByteBuffer decrypt(ByteBuffer ciphertext, byte[] AAD) {
+
+    int cipherTextOffset = SIZE_LENGTH;
+    int cipherTextLength = ciphertext.limit() - ciphertext.position() - SIZE_LENGTH;
+    int plainTextLength = cipherTextLength - GCM_TAG_LENGTH - NONCE_LENGTH;
+    if (plainTextLength < 1) {
+      throw new ParquetCryptoRuntimeException("Wrong input length " + plainTextLength);
+    }
+
+    ciphertext.position(ciphertext.position() + cipherTextOffset);
+    // Get the nonce from ciphertext
+    ciphertext.get(localNonce);
+
+    // Reuse the input buffer as the output buffer
+    ByteBuffer plainText = ciphertext.slice();
+    plainText.limit(plainTextLength);
+    try {
+      GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH_BITS, localNonce);
+      cipher.init(Cipher.DECRYPT_MODE, aesKey, spec);
+      if (null != AAD) cipher.updateAAD(AAD);
+
+      cipher.doFinal(ciphertext, plainText);
+      plainText.flip();
     }  catch (AEADBadTagException e) {
       throw new TagVerificationException("GCM tag check failed", e);
     } catch (GeneralSecurityException e) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -1615,7 +1615,7 @@ public class ParquetFileReader implements Closeable {
       }
       BytesInputDecompressor decompressor = options.getCodecFactory().getDecompressor(descriptor.metadata.getCodec());
       return new ColumnChunkPageReader(decompressor, pagesInChunk, dictionaryPage, offsetIndex,
-        rowCount, pageBlockDecryptor, aadPrefix, rowGroupOrdinal, columnOrdinal);
+        rowCount, pageBlockDecryptor, aadPrefix, rowGroupOrdinal, columnOrdinal, options);
     }
 
     private boolean hasMorePages(long valuesCountReadSoFar, int dataPageCountReadSoFar) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -145,6 +145,11 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
   public static final String BLOOM_FILTERING_ENABLED = "parquet.filter.bloom.enabled";
 
   /**
+    * Key to configure if off-heap buffer should be used for decryption
+    */
+  public static final String OFF_HEAP_DECRYPT_BUFFER_ENABLED = "parquet.decrypt.off-heap.buffer.enabled";
+
+  /**
    * key to turn on or off task side metadata loading (default true)
    * if true then metadata is read on the task side and some tasks may finish immediately.
    * if false metadata is read on the client which is slower if there is a lot of metadata but tasks will only be spawn if there is work to do.

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetReader.java
@@ -33,6 +33,8 @@ import org.apache.hadoop.fs.Path;
 
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.Preconditions;
+import org.apache.parquet.bytes.ByteBufferAllocator;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.crypto.FileDecryptionProperties;
 import org.apache.parquet.filter.UnboundRecordFilter;
@@ -187,6 +189,7 @@ public class ParquetReader<T> implements Closeable {
     private final InputFile file;
     private final Path path;
     private Filter filter = null;
+    private ByteBufferAllocator  allocator = new HeapByteBufferAllocator();
     protected Configuration conf;
     private ParquetReadOptions.Builder optionsBuilder;
 
@@ -239,6 +242,12 @@ public class ParquetReader<T> implements Closeable {
     public Builder<T> withFilter(Filter filter) {
       this.filter = filter;
       optionsBuilder.withRecordFilter(filter);
+      return this;
+    }
+
+    public Builder<T> withAllocator(ByteBufferAllocator allocator) {
+      this.allocator = allocator;
+      optionsBuilder.withAllocator(allocator);
       return this;
     }
 
@@ -340,7 +349,9 @@ public class ParquetReader<T> implements Closeable {
     }
 
     public ParquetReader<T> build() throws IOException {
-      ParquetReadOptions options = optionsBuilder.build();
+      ParquetReadOptions options = optionsBuilder
+          .withAllocator(allocator)
+          .build();
 
       if (path != null) {
         FileSystem fs = path.getFileSystem(conf);

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
     <zstd-jni.version>1.5.0-1</zstd-jni.version>
     <commons-text.version>1.8</commons-text.version>
     <jsr305.version>3.0.2</jsr305.version>
+    <commons-lang3.version>3.12.0</commons-lang3.version>
 
     <!-- properties for the profiles -->
     <surefire.logLevel>INFO</surefire.logLevel>


### PR DESCRIPTION
The PR adds the new ByteBuffer api and also updates ColumnChunkPageReadStore.readPage to use the new API.
A few additional classes were touched (ParquetReader.Builder, BytesInput) to allow an allocator to be specified and/or to avoid ByteBuffer -> byte array copying. These changes were necessary to enable the unit test.
A user option has been added to explicitly enable/disable the use of the ByteBuffer api for decryption.
### Jira

-  My PR addresses t [Parquet 2212](https://issues.apache.org/jira/browse/PARQUET-2212) 

### Tests

- Updates Unit test(s) in `org.apache.parquet.crypto.TestPropertiesDrivenEncryption`
