### PR TITLE
PARQUET-2224: Publish SBOM artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,6 +566,19 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <version>2.7.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>makeBom</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
### Goal

This PR aims to publish `SBOM` artifacts.

Here is an article to give some context.
- https://www.activestate.com/blog/why-the-us-government-is-mandating-software-bill-of-materials-sbom/

Software Bill of Materials (SBOM) are additional artifacts containing the aggregate of all direct and transitive dependencies of a project. The US Government (based on NIST recommendations) currently accepts only the three most popular SBOM standards as valid, namely: [CycloneDX](https://cyclonedx.org/), [Software Identification (SWID) tag](https://csrc.nist.gov/projects/Software-Identification-SWID), [Software Package Data Exchange® (SPDX)](https://spdx.dev/).

This PR uses [CycloneDX maven plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin), a lightweight software bill of materials (SBOM) standard designed for use in application security contexts and supply chain component analysis.

For example, `parquet-common-1.13.0-SNAPSHOT.jar` will have `parquet-common-1.13.0-SNAPSHOT-cyclonedx.xml` and `parquet-common-1.13.0-SNAPSHOT-cyclonedx.json`.
```
$ ls -al ~/.m2/repository/org/apache/parquet/parquet-common/1.13.0-SNAPSHOT/
total 744
drwxr-xr-x  19 dongjoon  staff    608 Jan  5 09:34 .
drwxr-xr-x  10 dongjoon  staff    320 Jan  5 09:34 ..
-rw-r--r--   1 dongjoon  staff    544 Jan  5 09:35 _remote.repositories
-rw-r--r--   1 dongjoon  staff    998 Jan  5 09:27 maven-metadata-apache.snapshots.xml
-rw-r--r--   1 dongjoon  staff     41 Jan  5 09:27 maven-metadata-apache.snapshots.xml.sha1
-rw-r--r--   1 dongjoon  staff   1342 Jan  5 09:35 maven-metadata-local.xml
-rw-r--r--   1 dongjoon  staff  44494 Jan  5 09:27 parquet-common-1.13.0-20220510.162626-2-tests.jar
-rw-r--r--   1 dongjoon  staff     40 Jan  5 09:27 parquet-common-1.13.0-20220510.162626-2-tests.jar.sha1
-rw-r--r--   1 dongjoon  staff  96523 Jan  5 09:27 parquet-common-1.13.0-20220510.162626-2.jar
-rw-r--r--   1 dongjoon  staff     40 Jan  5 09:27 parquet-common-1.13.0-20220510.162626-2.jar.sha1
-rw-r--r--   1 dongjoon  staff   3432 Jan  5 09:28 parquet-common-1.13.0-20220510.162626-2.pom
-rw-r--r--   1 dongjoon  staff    283 Jan  5 09:28 parquet-common-1.13.0-20220510.162626-2.pom.lastUpdated
-rw-r--r--   1 dongjoon  staff     40 Jan  5 09:28 parquet-common-1.13.0-20220510.162626-2.pom.sha1
-rw-r--r--   1 dongjoon  staff   5655 Jan  5 09:35 parquet-common-1.13.0-SNAPSHOT-cyclonedx.json
-rw-r--r--   1 dongjoon  staff   4971 Jan  5 09:35 parquet-common-1.13.0-SNAPSHOT-cyclonedx.xml
-rw-r--r--   1 dongjoon  staff  44420 Jan  5 09:35 parquet-common-1.13.0-SNAPSHOT-tests.jar
-rw-r--r--   1 dongjoon  staff  96767 Jan  5 09:35 parquet-common-1.13.0-SNAPSHOT.jar
-rw-r--r--   1 dongjoon  staff   3432 Dec 29 21:38 parquet-common-1.13.0-SNAPSHOT.pom
-rw-r--r--   1 dongjoon  staff    756 Jan  5 09:27 resolver-status.properties
```

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2224
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"