### PR TITLE
PARQUET-2226 Support merge bloom filters

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
@@ -400,14 +400,14 @@ public class BlockSplitBloomFilter implements BloomFilter {
   public void merge(BloomFilter otherBloomFilter) throws IOException {
     Preconditions.checkArgument(otherBloomFilter != null, "Cannot merge a null BloomFilter");
     Preconditions.checkArgument((getAlgorithm() == otherBloomFilter.getAlgorithm()),
-      String.format("BloomFilters must have the same algorithm (%s != %s)",
-        getAlgorithm(), otherBloomFilter.getAlgorithm()));
+      "BloomFilters must have the same algorithm (%s != %s)",
+        getAlgorithm(), otherBloomFilter.getAlgorithm());
     Preconditions.checkArgument((getHashStrategy() == otherBloomFilter.getHashStrategy()),
-      String.format("BloomFilters must have the same hashStrategy (%s != %s)",
-        getHashStrategy(), otherBloomFilter.getHashStrategy()));
+      "BloomFilters must have the same hashStrategy (%s != %s)",
+        getHashStrategy(), otherBloomFilter.getHashStrategy());
     Preconditions.checkArgument((getBitsetSize() == otherBloomFilter.getBitsetSize()),
-      String.format("BloomFilters must have the same size of bitsets (%s != %s)",
-        getBitsetSize(), otherBloomFilter.getBitsetSize()));
+      "BloomFilters must have the same size of bitsets (%s != %s)",
+        getBitsetSize(), otherBloomFilter.getBitsetSize());
     ByteArrayOutputStream otherOutputStream = new ByteArrayOutputStream();
     otherBloomFilter.writeTo(otherOutputStream);
     byte[] otherBits = otherOutputStream.toByteArray();

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
@@ -22,6 +22,7 @@ package org.apache.parquet.column.values.bloomfilter;
 import org.apache.parquet.Preconditions;
 import org.apache.parquet.io.api.Binary;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
@@ -393,5 +394,22 @@ public class BlockSplitBloomFilter implements BloomFilter {
   @Override
   public long hash(Binary value) {
     return hashFunction.hashBytes(value.getBytes());
+  }
+
+  @Override
+  public void putAll(BloomFilter otherBloomFilter) throws IOException {
+    Preconditions.checkArgument((otherBloomFilter.getAlgorithm() == getAlgorithm()),
+      "BloomFilter algorithm should be same");
+    Preconditions.checkArgument((otherBloomFilter.getHashStrategy() == getHashStrategy()),
+      "BloomFilter hashStrategy should be same");
+    Preconditions.checkArgument((otherBloomFilter.getBitsetSize() == getBitsetSize()),
+      "BloomFilter bitset size should be same");
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    otherBloomFilter.writeTo(outputStream);
+    byte[] otherBits = outputStream.toByteArray();
+    for (int i = 0; i < otherBits.length; i++) {
+      byte otherBit = otherBits[i];
+      bitset[i] |= otherBit;
+    }
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
@@ -397,16 +397,16 @@ public class BlockSplitBloomFilter implements BloomFilter {
   }
 
   @Override
-  public void putAll(BloomFilter otherBloomFilter) throws IOException {
+  public void merge(BloomFilter otherBloomFilter) throws IOException {
     Preconditions.checkArgument((otherBloomFilter.getAlgorithm() == getAlgorithm()),
       "BloomFilter algorithm should be same");
     Preconditions.checkArgument((otherBloomFilter.getHashStrategy() == getHashStrategy()),
       "BloomFilter hashStrategy should be same");
     Preconditions.checkArgument((otherBloomFilter.getBitsetSize() == getBitsetSize()),
       "BloomFilter bitset size should be same");
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    otherBloomFilter.writeTo(outputStream);
-    byte[] otherBits = outputStream.toByteArray();
+    ByteArrayOutputStream otherOutputStream = new ByteArrayOutputStream();
+    otherBloomFilter.writeTo(otherOutputStream);
+    byte[] otherBits = otherOutputStream.toByteArray();
     for (int i = 0; i < otherBits.length; i++) {
       byte otherBit = otherBits[i];
       bitset[i] |= otherBit;

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
@@ -398,18 +398,21 @@ public class BlockSplitBloomFilter implements BloomFilter {
 
   @Override
   public void merge(BloomFilter otherBloomFilter) throws IOException {
-    Preconditions.checkArgument((otherBloomFilter.getAlgorithm() == getAlgorithm()),
-      "BloomFilter algorithm should be same");
-    Preconditions.checkArgument((otherBloomFilter.getHashStrategy() == getHashStrategy()),
-      "BloomFilter hashStrategy should be same");
-    Preconditions.checkArgument((otherBloomFilter.getBitsetSize() == getBitsetSize()),
-      "BloomFilter bitset size should be same");
+    Preconditions.checkArgument(otherBloomFilter != null, "Cannot merge a null BloomFilter");
+    Preconditions.checkArgument((getAlgorithm() == otherBloomFilter.getAlgorithm()),
+      String.format("BloomFilters must have the same algorithm (%s != %s)",
+        getAlgorithm(), otherBloomFilter.getAlgorithm()));
+    Preconditions.checkArgument((getHashStrategy() == otherBloomFilter.getHashStrategy()),
+      String.format("BloomFilters must have the same hashStrategy (%s != %s)",
+        getHashStrategy(), otherBloomFilter.getHashStrategy()));
+    Preconditions.checkArgument((getBitsetSize() == otherBloomFilter.getBitsetSize()),
+      String.format("BloomFilters must have the same size of bitsets (%s != %s)",
+        getBitsetSize(), otherBloomFilter.getBitsetSize()));
     ByteArrayOutputStream otherOutputStream = new ByteArrayOutputStream();
     otherBloomFilter.writeTo(otherOutputStream);
     byte[] otherBits = otherOutputStream.toByteArray();
     for (int i = 0; i < otherBits.length; i++) {
-      byte otherBit = otherBits[i];
-      bitset[i] |= otherBit;
+      bitset[i] |= otherBits[i];
     }
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
@@ -397,17 +397,23 @@ public class BlockSplitBloomFilter implements BloomFilter {
   }
 
   @Override
+  public boolean canMergeFrom(BloomFilter otherBloomFilter) {
+    return otherBloomFilter != null
+      && getBitsetSize() == otherBloomFilter.getBitsetSize()
+      && getAlgorithm() == otherBloomFilter.getAlgorithm()
+      && getHashStrategy() == otherBloomFilter.getHashStrategy();
+  }
+
+  @Override
   public void merge(BloomFilter otherBloomFilter) throws IOException {
-    Preconditions.checkArgument(otherBloomFilter != null, "Cannot merge a null BloomFilter");
-    Preconditions.checkArgument((getAlgorithm() == otherBloomFilter.getAlgorithm()),
-      "BloomFilters must have the same algorithm (%s != %s)",
-        getAlgorithm(), otherBloomFilter.getAlgorithm());
-    Preconditions.checkArgument((getHashStrategy() == otherBloomFilter.getHashStrategy()),
-      "BloomFilters must have the same hashStrategy (%s != %s)",
-        getHashStrategy(), otherBloomFilter.getHashStrategy());
-    Preconditions.checkArgument((getBitsetSize() == otherBloomFilter.getBitsetSize()),
-      "BloomFilters must have the same size of bitsets (%s != %s)",
-        getBitsetSize(), otherBloomFilter.getBitsetSize());
+    Preconditions.checkArgument(otherBloomFilter != null,
+      "The BloomFilter to merge shouldn't be null");
+    Preconditions.checkArgument(canMergeFrom(otherBloomFilter),
+      "BloomFilters must have the same size of bitset, hashStrategy and algorithm." +
+        "This BloomFilter's size of bitset is %s , hashStrategy is %s, algorithm is %s ," +
+        "but the other BloomFilter's size of bitset is %s , hashStrategy is %s, algorithm is %s.",
+      getBitsetSize(), getHashStrategy(), getAlgorithm(),
+      otherBloomFilter.getBitsetSize(), otherBloomFilter.getHashStrategy(), otherBloomFilter.getAlgorithm());
     ByteArrayOutputStream otherOutputStream = new ByteArrayOutputStream();
     otherBloomFilter.writeTo(otherOutputStream);
     byte[] otherBits = otherOutputStream.toByteArray();

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
@@ -193,7 +193,7 @@ public interface BloomFilter {
   }
 
   /**
-   * Combines this Bloom filter with another Bloom filter by performing a bitwise OR of the underlying bits
+   * Merges this Bloom filter with another Bloom filter by performing a bitwise OR of the underlying bitsets
    *
    * @param otherBloomFilter The Bloom filter to merge this Bloom filter with.
    */

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
@@ -178,8 +178,11 @@ public interface BloomFilter {
   Compression getCompression();
 
   /**
-   * Combines this Bloom filter with another Bloom filter by performing a bitwise OR of the underlying data
+   * Combines this Bloom filter with another Bloom filter by performing a bitwise OR of the underlying bits
+   *
    * @param otherBloomFilter The Bloom filter to combine this Bloom filter with.
    */
-  void putAll(BloomFilter otherBloomFilter) throws IOException;
+  default void merge(BloomFilter otherBloomFilter) throws IOException {
+    throw new UnsupportedOperationException("Not supported merge operation.");
+  }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
@@ -187,7 +187,6 @@ public interface BloomFilter {
    * </ul>
    *
    * @param otherBloomFilter The Bloom filter to merge this Bloom filter with.
-   * @return
    */
   default boolean canMergeFrom(BloomFilter otherBloomFilter) {
     throw new UnsupportedOperationException("Merge API is not implemented.");

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
@@ -176,4 +176,10 @@ public interface BloomFilter {
    * @return compress algorithm that the bloom filter apply
    */
   Compression getCompression();
+
+  /**
+   * Combines this Bloom filter with another Bloom filter by performing a bitwise OR of the underlying data
+   * @param otherBloomFilter The Bloom filter to combine this Bloom filter with.
+   */
+  void putAll(BloomFilter otherBloomFilter) throws IOException;
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
@@ -183,6 +183,6 @@ public interface BloomFilter {
    * @param otherBloomFilter The Bloom filter to combine this Bloom filter with.
    */
   default void merge(BloomFilter otherBloomFilter) throws IOException {
-    throw new UnsupportedOperationException("Not supported merge operation.");
+    throw new UnsupportedOperationException("Merge is not implemented.");
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilter.java
@@ -178,11 +178,27 @@ public interface BloomFilter {
   Compression getCompression();
 
   /**
+   * Determines whether a given Bloom filter can be merged into this Bloom filter. For two Bloom
+   * filters to merge, they must:
+   * <ul>
+   * <li> have the same bit size </li>
+   * <li> have the same algorithm</li>
+   * <li> have the same hash strategy</li>
+   * </ul>
+   *
+   * @param otherBloomFilter The Bloom filter to merge this Bloom filter with.
+   * @return
+   */
+  default boolean canMergeFrom(BloomFilter otherBloomFilter) {
+    throw new UnsupportedOperationException("Merge API is not implemented.");
+  }
+
+  /**
    * Combines this Bloom filter with another Bloom filter by performing a bitwise OR of the underlying bits
    *
-   * @param otherBloomFilter The Bloom filter to combine this Bloom filter with.
+   * @param otherBloomFilter The Bloom filter to merge this Bloom filter with.
    */
   default void merge(BloomFilter otherBloomFilter) throws IOException {
-    throw new UnsupportedOperationException("Merge is not implemented.");
+    throw new UnsupportedOperationException("Merge API is not implemented.");
   }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bloomfilter/TestBlockSplitBloomFilter.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bloomfilter/TestBlockSplitBloomFilter.java
@@ -194,11 +194,11 @@ public class TestBlockSplitBloomFilter {
     }
     for (int i = 1024; i < 2048; i++) {
       otherBloomFilter.insertHash(otherBloomFilter.hash(i));
-      // To be merged BloomFilter don't have any value in otherBloomFilter
+      // Before merging BloomFilter, `mergedBloomFilter` doesn't have any value in `otherBloomFilter`
       assertFalse(mergedBloomFilter.findHash(mergedBloomFilter.hash(i)));
     }
     mergedBloomFilter.merge(otherBloomFilter);
-    // After merging BloomFilter, merged BloomFilter should have all values in otherBloomFilter
+    // After merging BloomFilter, `mergedBloomFilter` should have all values in `otherBloomFilter`
     for (int i = 0; i < 2048; i++) {
       assertTrue(mergedBloomFilter.findHash(mergedBloomFilter.hash(i)));
     }


### PR DESCRIPTION
Bloom filters support merge operation. We need to collect Parquet's bloom filters of multiple files, and then generate a more comprehensive bloom filter for common use.  Guava also supports similar api
https://guava.dev/releases/31.0.1-jre/api/docs/src-html/com/google/common/hash/BloomFilter.html#line.252