### PR TITLE
PARQUET-2229: ParquetRewriter masks and encrypts the same column

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
@@ -152,14 +152,6 @@ public class RewriteOptions {
         }
       }
 
-      // TODO: support masking and encrypting same columns
-      if (maskColumns != null && encryptColumns != null) {
-        for (String encryptColumn : encryptColumns) {
-          Preconditions.checkArgument(!maskColumns.containsKey(encryptColumn),
-                  "Cannot encrypt and mask same column");
-        }
-      }
-
       if (encryptColumns != null && !encryptColumns.isEmpty()) {
         Preconditions.checkArgument(fileEncryptionProperties != null,
                 "FileEncryptionProperties is required when encrypting columns");


### PR DESCRIPTION
### Jira

- My PR addresses [PARQUET-2229](https://issues.apache.org/jira/browse/PARQUET-2229)

### Tests

- Added ParquetRewriterTest.testNullifyAndEncryptColumn to verify the implementation.

### Commits

- `ParquetRewriter` supports masking (now only nullify) and encrypting same columns when rewriting files.
- Remove the restriction off `RewriteOptions`.