### PR TITLE
PARQUET-831: fix estimate page size check overflow corrupting parquet

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreV2.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreV2.java
@@ -152,7 +152,7 @@ public class ColumnWriteStoreV2 implements ColumnWriteStore {
       long rowsToFillPage =
           usedMem == 0 ?
               props.getMaxRowCountForPageSizeCheck()
-              : (long)((float)rows) / usedMem * remainingMem;
+              : (long)((float)rows / usedMem * remainingMem);
       if (rowsToFillPage < minRecordToWait) {
         minRecordToWait = rowsToFillPage;
       }

--- a/parquet-column/src/test/java/org/apache/parquet/column/impl/TestColumnWriterV1.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/impl/TestColumnWriterV1.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.impl;
+
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.column.page.PageWriter;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Type.Repetition;
+import org.junit.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class TestColumnWriterV1 {
+
+  @Test
+  public void testEstimateNextSizeCheckOnZeroUsedMem() throws Exception {
+    ColumnDescriptor col = new ColumnDescriptor(
+        new String[] { "val" },
+        new PrimitiveType(Repetition.OPTIONAL, PrimitiveTypeName.INT32, "val"),
+        0, 0);
+    PageWriter pageWriter = mock(PageWriter.class);
+    ParquetProperties props = ParquetProperties.builder().build();
+    ColumnWriterV1 columnWriter = new ColumnWriterV1(col, pageWriter, props);
+
+    // Write enough NULLs to exceed initial valueCountForNextSizeCheck which is
+    // initialized to MinRowCountForPageSizeCheck. These NULLs result in used
+    // memSize == 0. Estimating valueCountForNextSizeCheck needs to handle that
+    // correctly.
+    for (int i = 0; i < props.getMinRowCountForPageSizeCheck() * 2; i++) {
+      columnWriter.writeNull(0, 0);
+    }
+
+    // Emit enough data to trigger used memSize exceed page size. This should
+    // trigger writePage() if valueCountForNextSizeCheck is estimated correctly.
+    for (int i = 0; i < props.getPageSizeThreshold() * 2; i++) {
+      columnWriter.write(i, 0, 0);
+    }
+
+    // Verify writePage() must have been called
+    verify(pageWriter, atLeastOnce())
+        .writePage(any(), anyInt(), any(), any(), any(), any());
+  }
+
+}


### PR DESCRIPTION
When used memSize is 0, ColumnWriterV1 runs into floating point div by 0 issue, resulting in valueCountForNextSizeCheck become about 1G. (floating point div by 0 is Infinity, casting to int becomes MAX_INT.) Then it will keep buffering data and won't emit a page until 1G rows or close().

This potential too much buffering can easily overflow underlying CapacityByteArrayOutputStream, which uses int type as size count and does not check for overflow. When CapacityByteArrayOutputStream size overflows int it becomes negative. Parquet write path does not check negative size and writes asis into V1PageHeader uncompressed_page_size.

This corrupts parquet file, as parquet reader allocates uncompressed_page_size read buffer, and throws
NegativeArraySizeException when it's negative.

Fixed by applying an upper bound to valueCountForNextSizeCheck, also added overflow check.

This bug exists in 1.10.x and before.

ColumnWriteStoreV2 has a small parenthesis misplacement bug, resulting in unintended casting to float then back to long before division. So it is an integer division instead of intended floating point division. It doesn't cause problem because it applies other min/max constraints. Fixed as well. (This issue also exists in 1.11.x)

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
