### PR TITLE
PARQUET-2228: ParquetRewriter supports more than one input file

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
@@ -107,6 +107,12 @@ public class RewriteOptions {
       this.outputFile = outputFile;
     }
 
+    public Builder(Configuration conf, List<Path> inputFiles, Path outputFile) {
+      this.conf = conf;
+      this.inputFiles = inputFiles;
+      this.outputFile = outputFile;
+    }
+
     public Builder prune(List<String> columns) {
       this.pruneColumns = columns;
       return this;
@@ -129,6 +135,11 @@ public class RewriteOptions {
 
     public Builder encryptionProperties(FileEncryptionProperties fileEncryptionProperties) {
       this.fileEncryptionProperties = fileEncryptionProperties;
+      return this;
+    }
+
+    public Builder addInputFile(Path path) {
+      this.inputFiles.add(path);
       return this;
     }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
@@ -28,7 +28,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-// A set of options to create a ParquetRewriter.
+/**
+ * A set of options to create a ParquetRewriter.
+ */
 public class RewriteOptions {
 
   final Configuration conf;
@@ -101,48 +103,121 @@ public class RewriteOptions {
     private List<String> encryptColumns;
     private FileEncryptionProperties fileEncryptionProperties;
 
+    /**
+     * Create a builder to create a RewriterOptions.
+     *
+     * @param conf       configuration for reading from input files and writing to output file
+     * @param inputFile  input file path to read from
+     * @param outputFile output file path to rewrite to
+     */
     public Builder(Configuration conf, Path inputFile, Path outputFile) {
       this.conf = conf;
       this.inputFiles = Arrays.asList(inputFile);
       this.outputFile = outputFile;
     }
 
+    /**
+     * Create a builder to create a RewriterOptions.
+     * <p>
+     * Please note that if merging more than one file, the schema of all files must be the same.
+     * Otherwise, the rewrite will fail.
+     * <p>
+     * The rewrite will keep original row groups from all input files. This may not be optimal
+     * if row groups are very small and will not solve small file problems. Instead, it will
+     * make it worse to have a large file footer in the output file.
+     * TODO: support rewrite by record to break the original row groups into reasonable ones.
+     *
+     * @param conf       configuration for reading from input files and writing to output file
+     * @param inputFiles list of input file paths to read from
+     * @param outputFile output file path to rewrite to
+     */
     public Builder(Configuration conf, List<Path> inputFiles, Path outputFile) {
       this.conf = conf;
       this.inputFiles = inputFiles;
       this.outputFile = outputFile;
     }
 
+    /**
+     * Set the columns to prune.
+     * <p>
+     * By default, all columns are kept.
+     *
+     * @param columns list of columns to prune
+     * @return self
+     */
     public Builder prune(List<String> columns) {
       this.pruneColumns = columns;
       return this;
     }
 
+    /**
+     * Set the compression codec to use for the output file.
+     * <p>
+     * By default, the codec is the same as the input file.
+     *
+     * @param newCodecName compression codec to use
+     * @return self
+     */
     public Builder transform(CompressionCodecName newCodecName) {
       this.newCodecName = newCodecName;
       return this;
     }
 
+    /**
+     * Set the columns to mask.
+     * <p>
+     * By default, no columns are masked.
+     *
+     * @param maskColumns map of columns to mask to the masking mode
+     * @return self
+     */
     public Builder mask(Map<String, MaskMode> maskColumns) {
       this.maskColumns = maskColumns;
       return this;
     }
 
+    /**
+     * Set the columns to encrypt.
+     * <p>
+     * By default, no columns are encrypted.
+     *
+     * @param encryptColumns list of columns to encrypt
+     * @return self
+     */
     public Builder encrypt(List<String> encryptColumns) {
       this.encryptColumns = encryptColumns;
       return this;
     }
 
+    /**
+     * Set the encryption properties to use for the output file.
+     * <p>
+     * This is required if encrypting columns are not empty.
+     *
+     * @param fileEncryptionProperties encryption properties to use
+     * @return self
+     */
     public Builder encryptionProperties(FileEncryptionProperties fileEncryptionProperties) {
       this.fileEncryptionProperties = fileEncryptionProperties;
       return this;
     }
 
+    /**
+     * Add an input file to read from.
+     *
+     * @param path input file path to read from
+     * @return self
+     */
     public Builder addInputFile(Path path) {
       this.inputFiles.add(path);
       return this;
     }
 
+    /**
+     * Build the RewriterOptions.
+     *
+     * @return a RewriterOptions
+     */
     public RewriteOptions build() {
       Preconditions.checkArgument(inputFiles != null && !inputFiles.isEmpty(), "Input file is required");
       Preconditions.checkArgument(outputFile != null, "Output file is required");

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
@@ -679,15 +679,18 @@ public class ParquetRewriterTest {
       createdBySet.add(pmd.getFileMetaData().getCreatedBy());
       assertNull(pmd.getFileMetaData().getKeyValueMetaData().get(ParquetRewriter.ORIGINAL_CREATED_BY_KEY));
     }
+
+    // Verify created_by from input files have been deduplicated
     Object[] inputCreatedBys = createdBySet.toArray();
     assertEquals(1, inputCreatedBys.length);
-    String inputCreatedBy = (String) inputCreatedBys[0];
 
+    // Verify created_by has been set
     FileMetaData outFMD = getFileMetaData(outputFile, null).getFileMetaData();
+    String inputCreatedBy = (String) inputCreatedBys[0];
     assertEquals(inputCreatedBy, outFMD.getCreatedBy());
 
+    // Verify original.created.by has been set
     String originalCreatedBy = outFMD.getKeyValueMetaData().get(ParquetRewriter.ORIGINAL_CREATED_BY_KEY);
-    assertNotNull(originalCreatedBy);
     assertEquals(inputCreatedBy, originalCreatedBy);
   }
 


### PR DESCRIPTION
### Jira

https://issues.apache.org/jira/browse/PARQUET-2228

### Tests

- Refactor and add various cases to `ParquetRewriterTest` for merging files.

### Commits

- RewriteOptions supports merging more than one input file.
- Enforce schema equality of all input files.
- ParquetRewriter supports various rewrite operations on several input files.