### PR TITLE
PARQUET-2244: Fix notIn for columns with null values

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilter.java
@@ -447,6 +447,14 @@ public class DictionaryFilter implements FilterPredicate.Visitor<Boolean> {
       return BLOCK_MIGHT_MATCH;
     }
 
+    boolean mayContainNull = (meta.getStatistics() == null
+      || !meta.getStatistics().isNumNullsSet()
+      || meta.getStatistics().getNumNulls() > 0);
+    // The column may contain nulls and the values set contains no null, so the row group cannot be eliminated.
+    if (mayContainNull) {
+      return BLOCK_MIGHT_MATCH;
+    }
+
     // if the chunk has non-dictionary pages, don't bother decoding the
     // dictionary because the row group can't be eliminated.
     if (hasNonDictionaryPages(meta)) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
@@ -35,6 +35,7 @@ import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.filter2.predicate.LogicalInverseRewriter;
+import org.apache.parquet.filter2.predicate.Operators;
 import org.apache.parquet.filter2.predicate.Operators.BinaryColumn;
 import org.apache.parquet.filter2.predicate.Operators.DoubleColumn;
 import org.apache.parquet.filter2.predicate.Operators.FloatColumn;
@@ -504,6 +505,17 @@ public class DictionaryFilterTest {
     FilterPredicate predNotIn4 = notIn(b, set4);
     assertFalse("Should not drop block for null", canDrop(predIn4, ccmd, dictionaries));
     assertFalse("Should not drop block for null", canDrop(predNotIn4, ccmd, dictionaries));
+
+    BinaryColumn sharpAndNull = binaryColumn("optional_single_value_field");
+
+    // Test the case that all non-null values are in the set but the column may have nulls and the set has no nulls.
+    Set<Binary> set5 = new HashSet<>();
+    set5.add(Binary.fromString("sharp"));
+    FilterPredicate predNotIn5 = notIn(sharpAndNull, set5);
+    FilterPredicate predIn5 = in(sharpAndNull, set5);
+    assertFalse("Should not drop block",
+      canDrop(predNotIn5, ccmd, dictionaries));
+    assertFalse("Should not drop block", canDrop(predIn5, ccmd, dictionaries));
   }
 
   @Test


### PR DESCRIPTION
Jira: [PARQUET-2244](https://issues.apache.org/jira/browse/PARQUET-2244)
This fixes a bug similar to [PARQUET-1510](https://issues.apache.org/jira/browse/PARQUET-1510).

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2244
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
