### PR TITLE
PARQUET-2164: Check size of buffered data to prevent page data from overflowing

### DIFF
--- a/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
@@ -164,6 +164,12 @@ public class CapacityByteArrayOutputStream extends OutputStream {
   private void addSlab(int minimumSize) {
     int nextSlabSize;
 
+    if (bytesUsed + minimumSize < 0) {
+      // This is interpreted as a request for a value greater than Integer.MAX_VALUE
+      // We throw OOM because that is what java.io.ByteArrayOutputStream also does
+      throw new OutOfMemoryError("Size of data exceeded 2GB");
+    }
+
     if (bytesUsed == 0) {
       nextSlabSize = initialSlabSize;
     } else if (bytesUsed > maxCapacityHint / 5) {

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
@@ -164,10 +164,13 @@ public class CapacityByteArrayOutputStream extends OutputStream {
   private void addSlab(int minimumSize) {
     int nextSlabSize;
 
-    if (bytesUsed + minimumSize < 0) {
+    // check for overflow 
+    try {
+      Math.addExact(bytesUsed, minimumSize);
+    } catch (ArithmeticException e) {
       // This is interpreted as a request for a value greater than Integer.MAX_VALUE
       // We throw OOM because that is what java.io.ByteArrayOutputStream also does
-      throw new OutOfMemoryError("Size of data exceeded 2GB");
+      throw new OutOfMemoryError("Size of data exceeded 2GB (" + e.getMessage() + ")");
     }
 
     if (bytesUsed == 0) {

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
@@ -170,7 +170,7 @@ public class CapacityByteArrayOutputStream extends OutputStream {
     } catch (ArithmeticException e) {
       // This is interpreted as a request for a value greater than Integer.MAX_VALUE
       // We throw OOM because that is what java.io.ByteArrayOutputStream also does
-      throw new OutOfMemoryError("Size of data exceeded 2GB (" + e.getMessage() + ")");
+      throw new OutOfMemoryError("Size of data exceeded Integer.MAX_VALUE (" + e.getMessage() + ")");
     }
 
     if (bytesUsed == 0) {


### PR DESCRIPTION
This PR addresses the following [PARQUET-2164](https://issues.apache.org/jira/browse/PARQUET-2164) 
The configuration parameters 
```
    parquet.page.size.check.estimate=false
    parquet.page.size.row.check.min=<check_size>
    parquet.page.size.row.check.max=<check_size>
```
address the reported problem. However the issue can still be hit because the default value of `parquet.page.size.check.estimate` is `true`.
This PR simply adds a check to make sure that `CapacityByteArrayOutputStream` cannot overflow but will instead throw an exception.