### PR TITLE
PARQUET-2202: Review usage and implementation of Preconditions.checkargument method

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroIndexedRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroIndexedRecordConverter.java
@@ -392,7 +392,7 @@ class AvroIndexedRecordConverter<T extends IndexedRecord> extends GroupConverter
       @Override
       public Converter getConverter(int fieldIndex) {
         Preconditions.checkArgument(
-            fieldIndex == 0, "Illegal field index: " + fieldIndex);
+            fieldIndex == 0, "Illegal field index: %s", fieldIndex);
         return elementConverter;
       }
 

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -548,7 +548,7 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
       @Override
       public Converter getConverter(int fieldIndex) {
         Preconditions.checkArgument(
-            fieldIndex == 0, "Illegal field index: " + fieldIndex);
+            fieldIndex == 0, "Illegal field index: %s", fieldIndex);
         return elementConverter;
       }
 
@@ -592,7 +592,7 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
       this.avroSchema = avroSchema;
 
       Preconditions.checkArgument(arrayClass.isArray(),
-          "Cannot convert non-array: " + arrayClass.getName());
+          "Cannot convert non-array: %s", arrayClass.getName());
       this.elementClass = arrayClass.getComponentType();
 
       ParentValueContainer setter = createSetterAndContainer();
@@ -817,7 +817,7 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
       @Override
       public Converter getConverter(int fieldIndex) {
         Preconditions.checkArgument(
-            fieldIndex == 0, "Illegal field index: " + fieldIndex);
+            fieldIndex == 0, "Illegal field index: %s", fieldIndex);
         return elementConverter;
       }
 

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
@@ -425,7 +425,7 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
       } else {
         Class<?> arrayClass = value.getClass();
         Preconditions.checkArgument(arrayClass.isArray(),
-            "Cannot write unless collection or array: " + arrayClass.getName());
+            "Cannot write unless collection or array: %s", arrayClass.getName());
         writeJavaArray(schema, avroSchema, arrayClass, value);
       }
       recordConsumer.endGroup();
@@ -443,7 +443,7 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
       switch (avroSchema.getElementType().getType()) {
         case BOOLEAN:
           Preconditions.checkArgument(elementClass == boolean.class,
-              "Cannot write as boolean array: " + arrayClass.getName());
+              "Cannot write as boolean array: %s", arrayClass.getName());
           writeBooleanArray((boolean[]) value);
           break;
         case INT:
@@ -462,17 +462,17 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
           break;
         case LONG:
           Preconditions.checkArgument(elementClass == long.class,
-              "Cannot write as long array: " + arrayClass.getName());
+              "Cannot write as long array: %s", arrayClass.getName());
           writeLongArray((long[]) value);
           break;
         case FLOAT:
           Preconditions.checkArgument(elementClass == float.class,
-              "Cannot write as float array: " + arrayClass.getName());
+              "Cannot write as float array: %s", arrayClass.getName());
           writeFloatArray((float[]) value);
           break;
         case DOUBLE:
           Preconditions.checkArgument(elementClass == double.class,
-              "Cannot write as double array: " + arrayClass.getName());
+              "Cannot write as double array: %s", arrayClass.getName());
           writeDoubleArray((double[]) value);
           break;
         default:

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/BaseCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/BaseCommand.java
@@ -299,11 +299,11 @@ public abstract class BaseCommand implements Command, Configurable {
         // final URLs must end in '/' for URLClassLoader
         File path = lib.endsWith("/") ? new File(lib) : new File(lib + "/");
         Preconditions.checkArgument(path.exists(),
-            "Lib directory does not exist: " + lib);
+            "Lib directory does not exist: %s", lib);
         Preconditions.checkArgument(path.isDirectory(),
-            "Not a directory: " + lib);
+            "Not a directory: %s", lib);
         Preconditions.checkArgument(path.canRead() && path.canExecute(),
-            "Insufficient permissions to access lib directory: " + lib);
+            "Insufficient permissions to access lib directory: %s", lib);
         urls.add(path.toURI().toURL());
       }
     }
@@ -311,11 +311,11 @@ public abstract class BaseCommand implements Command, Configurable {
       for (String jar : jars) {
         File path = new File(jar);
         Preconditions.checkArgument(path.exists(),
-            "Jar files does not exist: " + jar);
+            "Jar files does not exist: %s", jar);
         Preconditions.checkArgument(path.isFile(),
-            "Not a file: " + jar);
+            "Not a file: %s", jar);
         Preconditions.checkArgument(path.canRead(),
-            "Cannot read jar file: " + jar);
+            "Cannot read jar file: %s", jar);
         urls.add(path.toURI().toURL());
       }
     }

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/Util.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/Util.java
@@ -243,7 +243,7 @@ public class Util {
   public static ColumnDescriptor descriptor(String column, MessageType schema) {
     String[] path = Iterables.toArray(DOT.split(column), String.class);
     Preconditions.checkArgument(schema.containsPath(path),
-        "Schema doesn't have column: " + column);
+        "Schema doesn't have column: %s", column);
     return schema.getColumnDescription(path);
   }
 
@@ -265,7 +265,7 @@ public class Util {
   public static PrimitiveType primitive(String column, MessageType schema) {
     String[] path = Iterables.toArray(DOT.split(column), String.class);
     Preconditions.checkArgument(schema.containsPath(path),
-        "Schema doesn't have column: " + column);
+        "Schema doesn't have column: %s", column);
     return primitive(schema, path);
   }
 

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/SchemaCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/SchemaCommand.java
@@ -70,7 +70,7 @@ public class SchemaCommand extends BaseCommand {
 
     if (targets.size() > 1) {
       Preconditions.checkArgument(outputPath == null,
-          "Cannot output multiple schemas to file " + outputPath);
+          "Cannot output multiple schemas to file %s", outputPath);
       for (String source : targets) {
         console.info("{}: {}", source, getSchema(source));
       }

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/json/AvroJson.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/json/AvroJson.java
@@ -524,7 +524,7 @@ public class AvroJson {
     switch (node.getNodeType()) {
       case OBJECT:
         Preconditions.checkArgument(node instanceof ObjectNode,
-            "Expected instance of ObjectNode: " + node);
+            "Expected instance of ObjectNode: %s", node);
 
         // use LinkedHashMap to preserve field order
         Map<String, T> fields = Maps.newLinkedHashMap();
@@ -542,7 +542,7 @@ public class AvroJson {
 
       case ARRAY:
         Preconditions.checkArgument(node instanceof ArrayNode,
-            "Expected instance of ArrayNode: " + node);
+            "Expected instance of ArrayNode: %s", node);
 
         List<T> elements = Lists.newArrayListWithExpectedSize(node.size());
 
@@ -554,36 +554,36 @@ public class AvroJson {
 
       case BINARY:
         Preconditions.checkArgument(node instanceof BinaryNode,
-            "Expected instance of BinaryNode: " + node);
+            "Expected instance of BinaryNode: %s", node);
         return visitor.binary((BinaryNode) node);
 
       case STRING:
         Preconditions.checkArgument(node instanceof TextNode,
-            "Expected instance of TextNode: " + node);
+            "Expected instance of TextNode: %s", node);
 
         return visitor.text((TextNode) node);
 
       case NUMBER:
         Preconditions.checkArgument(node instanceof NumericNode,
-            "Expected instance of NumericNode: " + node);
+            "Expected instance of NumericNode: %s", node);
 
         return visitor.number((NumericNode) node);
 
       case BOOLEAN:
         Preconditions.checkArgument(node instanceof BooleanNode,
-            "Expected instance of BooleanNode: " + node);
+            "Expected instance of BooleanNode: %s", node);
 
         return visitor.bool((BooleanNode) node);
 
       case MISSING:
         Preconditions.checkArgument(node instanceof MissingNode,
-            "Expected instance of MissingNode: " + node);
+            "Expected instance of MissingNode: %s", node);
 
         return visitor.missing((MissingNode) node);
 
       case NULL:
         Preconditions.checkArgument(node instanceof NullNode,
-            "Expected instance of NullNode: " + node);
+            "Expected instance of NullNode: %s", node);
 
         return visitor.nullNode((NullNode) node);
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -477,7 +477,7 @@ public class ParquetProperties {
      * @return this builder for method chaining
      */
     public Builder withBloomFilterNDV(String columnPath, long ndv) {
-      Preconditions.checkArgument(ndv > 0, "Invalid NDV for column \"%s\": %d", columnPath, ndv);
+      Preconditions.checkArgument(ndv > 0, "Invalid NDV for column \"%s\": %s", columnPath, ndv);
       this.bloomFilterNDVs.withValue(columnPath, ndv);
       // Setting an NDV for a column implies writing a bloom filter
       this.bloomFilterEnabled.withValue(columnPath, true);
@@ -485,7 +485,7 @@ public class ParquetProperties {
     }
 
     public Builder withBloomFilterFPP(String columnPath, double fpp) {
-      Preconditions.checkArgument(fpp > 0.0 && fpp < 1.0, "Invalid FPP for column \"%s\": %d", columnPath, fpp);
+      Preconditions.checkArgument(fpp > 0.0 && fpp < 1.0, "Invalid FPP for column \"%s\": %s", columnPath, fpp);
       this.bloomFilterFPPs.withValue(columnPath, fpp);
       return this;
     }

--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -520,7 +520,7 @@ public class ParquetProperties {
     }
 
     public Builder withPageRowCountLimit(int rowCount) {
-      Preconditions.checkArgument(rowCount > 0, "Invalid row count limit for pages: " + rowCount);
+      Preconditions.checkArgument(rowCount > 0, "Invalid row count limit for pages: %s", rowCount);
       pageRowCountLimit = rowCount;
       return this;
     }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingConfig.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingConfig.java
@@ -38,7 +38,7 @@ class DeltaBinaryPackingConfig {
     this.blockSizeInValues = blockSizeInValues;
     this.miniBlockNumInABlock = miniBlockNumInABlock;
     double miniSize = (double) blockSizeInValues / miniBlockNumInABlock;
-    Preconditions.checkArgument(miniSize % 8 == 0, "miniBlockSize must be multiple of 8, but it's " + miniSize);
+    Preconditions.checkArgument(miniSize % 8 == 0, "miniBlockSize must be multiple of 8, but it's %s", miniSize);
     this.miniBlockSizeInValues = (int) miniSize;
   }
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/PlainValuesDictionary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/PlainValuesDictionary.java
@@ -106,7 +106,7 @@ public abstract class PlainValuesDictionary extends Dictionary {
       } else {
         // dictionary values are stored as fixed-length arrays
         Preconditions.checkArgument(length > 0,
-            "Invalid byte array length: " + length);
+            "Invalid byte array length: %s", length);
         for (int i = 0; i < binaryDictionaryContent.length; i++) {
           // wrap the content in a Binary
           binaryDictionaryContent[i] = Binary.fromConstantByteBuffer(

--- a/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/PrimitiveToBoxedClass.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/PrimitiveToBoxedClass.java
@@ -42,7 +42,7 @@ public class PrimitiveToBoxedClass {
   }
 
   public static Class<?> get(Class<?> c) {
-    checkArgument(c.isPrimitive(), "Class " + c + " is not primitive!");
+    checkArgument(c.isPrimitive(), "Class %s is not primitive!", c);
     return primitiveToBoxed.get(c);
   }
 

--- a/parquet-column/src/main/java/org/apache/parquet/filter2/recordlevel/FilteringGroupConverter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter2/recordlevel/FilteringGroupConverter.java
@@ -90,7 +90,7 @@ public class FilteringGroupConverter extends GroupConverter {
 
   private PrimitiveColumnIO getColumnIO(List<Integer> indexFieldPath) {
     PrimitiveColumnIO found = columnIOsByIndexFieldPath.get(indexFieldPath);
-    checkArgument(found != null, "Did not find PrimitiveColumnIO for index field path" + indexFieldPath);
+    checkArgument(found != null, "Did not find PrimitiveColumnIO for index field path %s", indexFieldPath);
     return found;
   }
 

--- a/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
@@ -279,8 +279,8 @@ public abstract class LogicalTypeAnnotation {
   public static IntLogicalTypeAnnotation intType(final int bitWidth, final boolean isSigned) {
     Preconditions.checkArgument(
       bitWidth == 8 || bitWidth == 16 || bitWidth == 32 || bitWidth == 64,
-      "Invalid bit width for integer logical type, " + bitWidth + " is not allowed, " +
-        "valid bit width values: 8, 16, 32, 64");
+      "Invalid bit width for integer logical type, %s is not allowed, " +
+        "valid bit width values: 8, 16, 32, 64", bitWidth);
     return new IntLogicalTypeAnnotation(bitWidth, isSigned);
   }
 

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
@@ -545,11 +545,11 @@ public final class PrimitiveType extends Type {
   private ColumnOrder requireValidColumnOrder(ColumnOrder columnOrder) {
     if (primitive == PrimitiveTypeName.INT96) {
       Preconditions.checkArgument(columnOrder.getColumnOrderName() == ColumnOrderName.UNDEFINED,
-          "The column order {} is not supported by INT96", columnOrder);
+          "The column order %s is not supported by INT96", columnOrder);
     }
     if (getLogicalTypeAnnotation() != null) {
       Preconditions.checkArgument(getLogicalTypeAnnotation().isValidColumnOrder(columnOrder),
-        "The column order {} is not supported by {} ({})", columnOrder, primitive, getLogicalTypeAnnotation());
+        "The column order %s is not supported by %s (%s)", columnOrder, primitive, getLogicalTypeAnnotation());
     }
     return columnOrder;
   }

--- a/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
@@ -437,7 +437,7 @@ public class Types {
     protected PrimitiveType build(String name) {
       if (PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY == primitiveType) {
         Preconditions.checkArgument(length > 0,
-            "Invalid FIXED_LEN_BYTE_ARRAY length: " + length);
+            "Invalid FIXED_LEN_BYTE_ARRAY length: %s", length);
       }
 
       DecimalMetadata meta = decimalMetadata();
@@ -612,9 +612,9 @@ public class Types {
           precision = decimalType.getPrecision();
         }
         Preconditions.checkArgument(precision > 0,
-            "Invalid DECIMAL precision: " + precision);
+            "Invalid DECIMAL precision: %s", precision);
         Preconditions.checkArgument(this.scale >= 0,
-            "Invalid DECIMAL scale: " + this.scale);
+            "Invalid DECIMAL scale: %s", this.scale);
         Preconditions.checkArgument(this.scale <= precision,
             "Invalid DECIMAL scale: cannot be greater than precision");
         meta = new DecimalMetadata(precision, scale);

--- a/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
@@ -477,13 +477,13 @@ public class Types {
             if (primitiveType == PrimitiveTypeName.INT32) {
               Preconditions.checkState(
                   meta.getPrecision() <= MAX_PRECISION_INT32,
-                  "INT32 cannot store " + meta.getPrecision() + " digits " +
-                      "(max " + MAX_PRECISION_INT32 + ")");
+                  "INT32 cannot store %s digits (max %s)", 
+                  meta.getPrecision(), MAX_PRECISION_INT32);
             } else if (primitiveType == PrimitiveTypeName.INT64) {
               Preconditions.checkState(
                   meta.getPrecision() <= MAX_PRECISION_INT64,
-                  "INT64 cannot store " + meta.getPrecision() + " digits " +
-                  "(max " + MAX_PRECISION_INT64 + ")");
+                  "INT64 cannot store %s digits (max %s)", 
+                  meta.getPrecision(), MAX_PRECISION_INT64);
               if (meta.getPrecision() <= MAX_PRECISION_INT32) {
                 LOGGER.warn("Decimal with {} digits is stored in an INT64, but fits in an INT32. See {}.",
                             precision, LOGICAL_TYPES_DOC_URL);
@@ -491,8 +491,8 @@ public class Types {
             } else if (primitiveType == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
               Preconditions.checkState(
                   meta.getPrecision() <= maxPrecision(length),
-                  "FIXED(" + length + ") cannot store " + meta.getPrecision() +
-                  " digits (max " + maxPrecision(length) + ")");
+                  "FIXED(%s) cannot store %s digits (max %s)", 
+                  length, meta.getPrecision(), maxPrecision(length));
             }
             return Optional.of(true);
           }
@@ -555,26 +555,26 @@ public class Types {
           private Optional<Boolean> checkFixedPrimitiveType(int l, LogicalTypeAnnotation logicalTypeAnnotation) {
             Preconditions.checkState(
                 primitiveType == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY && length == l,
-              logicalTypeAnnotation.toString() + " can only annotate FIXED_LEN_BYTE_ARRAY(" + l + ')');
+              "%s can only annotate FIXED_LEN_BYTE_ARRAY(%s)", logicalTypeAnnotation, l);
             return Optional.of(true);
           }
 
           private Optional<Boolean> checkBinaryPrimitiveType(LogicalTypeAnnotation logicalTypeAnnotation) {
             Preconditions.checkState(
                 primitiveType == PrimitiveTypeName.BINARY,
-              logicalTypeAnnotation.toString() + " can only annotate BINARY");
+              "%s can only annotate BINARY", logicalTypeAnnotation);
             return Optional.of(true);
           }
 
           private Optional<Boolean> checkInt32PrimitiveType(LogicalTypeAnnotation logicalTypeAnnotation) {
             Preconditions.checkState(primitiveType == PrimitiveTypeName.INT32,
-              logicalTypeAnnotation.toString() + " can only annotate INT32");
+              "%s can only annotate INT32", logicalTypeAnnotation);
             return Optional.of(true);
           }
 
           private Optional<Boolean> checkInt64PrimitiveType(LogicalTypeAnnotation logicalTypeAnnotation) {
             Preconditions.checkState(primitiveType == PrimitiveTypeName.INT64,
-              logicalTypeAnnotation.toString() + " can only annotate INT64");
+              "%s can only annotate INT64", logicalTypeAnnotation);
             return Optional.of(true);
           }
         }).orElseThrow(() -> new IllegalStateException(logicalTypeAnnotation + " can not be applied to a primitive type"));

--- a/parquet-common/src/main/java/org/apache/parquet/Preconditions.java
+++ b/parquet-common/src/main/java/org/apache/parquet/Preconditions.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -66,6 +66,69 @@ public final class Preconditions {
    *          thrown
    * @param message
    *          A String message for the exception.
+   * @param arg0
+   *          First parameter of the message string template
+   * @throws IllegalArgumentException if {@code isValid} is false
+   */
+  public static void checkArgument(boolean isValid, String message, Object arg0) throws IllegalArgumentException {
+    if (!isValid) {
+      throw new IllegalArgumentException(
+          String.format(String.valueOf(message), strings(arg0)));
+    }
+  }
+
+  /**
+   * Precondition-style validation that throws {@link IllegalArgumentException}.
+   *
+   * @param isValid
+   *          {@code true} if valid, {@code false} if an exception should be
+   *          thrown
+   * @param message
+   *          A String message for the exception.
+   * @param arg0
+   *          First parameter of the message string template
+   * @param arg1
+   *          Second parameter of the message string template
+   * @throws IllegalArgumentException if {@code isValid} is false
+   */
+  public static void checkArgument(boolean isValid, String message, Object arg0, Object arg1) throws IllegalArgumentException {
+    if (!isValid) {
+      throw new IllegalArgumentException(
+          String.format(String.valueOf(message), strings(arg0, arg1)));
+    }
+  }
+
+  /**
+   * Precondition-style validation that throws {@link IllegalArgumentException}.
+   *
+   * @param isValid
+   *          {@code true} if valid, {@code false} if an exception should be
+   *          thrown
+   * @param message
+   *          A String message for the exception.
+   * @param arg0
+   *          First parameter of the message string template
+   * @param arg1
+   *          Second parameter of the message string template
+   * @param arg2
+   *          Third parameter of the message string template
+   * @throws IllegalArgumentException if {@code isValid} is false
+   */
+  public static void checkArgument(boolean isValid, String message, Object arg0, Object arg1, Object arg2) throws IllegalArgumentException {
+    if (!isValid) {
+      throw new IllegalArgumentException(
+          String.format(String.valueOf(message), strings(arg0, arg1, arg2)));
+    }
+  }
+
+  /**
+   * Precondition-style validation that throws {@link IllegalArgumentException}.
+   *
+   * @param isValid
+   *          {@code true} if valid, {@code false} if an exception should be
+   *          thrown
+   * @param message
+   *          A String message for the exception.
    * @param args
    *          Objects used to fill in {@code %s} placeholders in the message
    * @throws IllegalArgumentException if {@code isValid} is false
@@ -102,6 +165,69 @@ public final class Preconditions {
    *          thrown
    * @param message
    *          A String message for the exception.
+   * @param arg0
+   *          First parameter of the message string template
+   * @throws IllegalStateException if {@code isValid} is false
+   */
+  public static void checkState(boolean isValid, String message, Object arg0) throws IllegalStateException {
+    if (!isValid) {
+      throw new IllegalStateException(
+          String.format(String.valueOf(message), strings(arg0)));
+    }
+  }
+
+  /**
+   * Precondition-style validation that throws {@link IllegalStateException}.
+   *
+   * @param isValid
+   *          {@code true} if valid, {@code false} if an exception should be
+   *          thrown
+   * @param message
+   *          A String message for the exception.
+   * @param arg0
+   *          First parameter of the message string template
+   * @param arg1
+   *          Second parameter of the message string template
+   * @throws IllegalStateException if {@code isValid} is false
+   */
+  public static void checkState(boolean isValid, String message, Object arg0, Object arg1) throws IllegalStateException {
+    if (!isValid) {
+      throw new IllegalStateException(
+          String.format(String.valueOf(message), strings(arg0, arg1)));
+    }
+  }
+
+  /**
+   * Precondition-style validation that throws {@link IllegalStateException}.
+   *
+   * @param isValid
+   *          {@code true} if valid, {@code false} if an exception should be
+   *          thrown
+   * @param message
+   *          A String message for the exception.
+   * @param arg0
+   *          First parameter of the message string template
+   * @param arg1
+   *          Second parameter of the message string template
+   * @param arg2
+   *          Third parameter of the message string template
+   * @throws IllegalStateException if {@code isValid} is false
+   */
+  public static void checkState(boolean isValid, String message, Object arg0, Object arg1, Object arg2) throws IllegalStateException {
+    if (!isValid) {
+      throw new IllegalStateException(
+          String.format(String.valueOf(message), strings(arg0, arg1, arg2)));
+    }
+  }
+
+  /**
+   * Precondition-style validation that throws {@link IllegalStateException}.
+   *
+   * @param isValid
+   *          {@code true} if valid, {@code false} if an exception should be
+   *          thrown
+   * @param message
+   *          A String message for the exception.
    * @param args
    *          Objects used to fill in {@code %s} placeholders in the message
    * @throws IllegalStateException if {@code isValid} is false
@@ -114,7 +240,7 @@ public final class Preconditions {
     }
   }
 
-  private static String[] strings(Object[] objects) {
+  private static String[] strings(Object... objects) {
     String[] strings = new String[objects.length];
     for (int i = 0; i < objects.length; i += 1) {
       strings[i] = String.valueOf(objects[i]);

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
@@ -150,7 +150,7 @@ public class CapacityByteArrayOutputStream extends OutputStream {
   public CapacityByteArrayOutputStream(int initialSlabSize, int maxCapacityHint, ByteBufferAllocator allocator) {
     checkArgument(initialSlabSize > 0, "initialSlabSize must be > 0");
     checkArgument(maxCapacityHint > 0, "maxCapacityHint must be > 0");
-    checkArgument(maxCapacityHint >= initialSlabSize, String.format("maxCapacityHint can't be less than initialSlabSize %d %d", initialSlabSize, maxCapacityHint));
+    checkArgument(maxCapacityHint >= initialSlabSize, "maxCapacityHint can't be less than initialSlabSize %s %s", initialSlabSize, maxCapacityHint);
     this.initialSlabSize = initialSlabSize;
     this.maxCapacityHint = maxCapacityHint;
     this.allocator = allocator;
@@ -300,7 +300,7 @@ public class CapacityByteArrayOutputStream extends OutputStream {
    * @param value the value to replace it with
    */
   public void setByte(long index, byte value) {
-    checkArgument(index < bytesUsed, "Index: " + index + " is >= the current size of: " + bytesUsed);
+    checkArgument(index < bytesUsed, "Index: %d is >= the current size of: %d", index, bytesUsed);
 
     long seen = 0;
     for (int i = 0; i < slabs.size(); i++) {

--- a/parquet-common/src/main/java/org/apache/parquet/util/DynMethods.java
+++ b/parquet-common/src/main/java/org/apache/parquet/util/DynMethods.java
@@ -88,8 +88,8 @@ public class DynMethods {
           "Cannot bind static method " + method.toGenericString());
       Preconditions.checkArgument(
           method.getDeclaringClass().isAssignableFrom(receiver.getClass()),
-          "Cannot bind " + method.toGenericString() + " to instance of " +
-              receiver.getClass());
+          "Cannot bind %s to instance of %s", method.toGenericString(), 
+          receiver.getClass());
 
       return new BoundMethod(this, receiver);
     }

--- a/parquet-common/src/main/java/org/apache/parquet/util/DynMethods.java
+++ b/parquet-common/src/main/java/org/apache/parquet/util/DynMethods.java
@@ -85,7 +85,7 @@ public class DynMethods {
      */
     public BoundMethod bind(Object receiver) {
       Preconditions.checkState(!isStatic(),
-          "Cannot bind static method " + method.toGenericString());
+          "Cannot bind static method %s", method.toGenericString());
       Preconditions.checkArgument(
           method.getDeclaringClass().isAssignableFrom(receiver.getClass()),
           "Cannot bind %s to instance of %s", method.toGenericString(), 

--- a/parquet-common/src/test/java/org/apache/parquet/TestPreconditions.java
+++ b/parquet-common/src/test/java/org/apache/parquet/TestPreconditions.java
@@ -22,22 +22,108 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestPreconditions {
+
   @Test
-  public void testCheckArgument() {
+  public void testCheckArgumentWithoutParams() {
     try {
-      Preconditions.checkArgument(true, "Test message: %s %s", 12, null);
+      Preconditions.checkArgument(true, "Test message");
     } catch (IllegalArgumentException e) {
       Assert.fail("Should not throw exception when isValid is true");
     }
 
     try {
-      Preconditions.checkArgument(false, "Test message: %s %s", 12, null);
+      Preconditions.checkArgument(false, "Test message");
       Assert.fail("Should throw exception when isValid is false");
     } catch (IllegalArgumentException e) {
       Assert.assertEquals("Should format message",
-          "Test message: 12 null", e.getMessage());
+          "Test message", e.getMessage());
     }
   }
+
+  @Test
+  public void testCheckArgumentWithOneParam() {
+    try {
+      Preconditions.checkArgument(true, "Test message %s", 12);
+    } catch (IllegalArgumentException e) {
+      Assert.fail("Should not throw exception when isValid is true");
+    }
+
+    try {
+      Preconditions.checkArgument(false, "Test message %s", 12);
+      Assert.fail("Should throw exception when isValid is false");
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("Should format message",
+          "Test message 12", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckArgumentWithTwoParams() {
+    try {
+      Preconditions.checkArgument(true, "Test message %s %s", 12, null);
+    } catch (IllegalArgumentException e) {
+      Assert.fail("Should not throw exception when isValid is true");
+    }
+
+    try {
+      Preconditions.checkArgument(false, "Test message %s %s", 12, null);
+      Assert.fail("Should throw exception when isValid is false");
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("Should format message",
+          "Test message 12 null", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckArgumentWithThreeParams() {
+    try {
+      Preconditions.checkArgument(true, "Test message %s %s %s", 12, null, "column");
+    } catch (IllegalArgumentException e) {
+      Assert.fail("Should not throw exception when isValid is true");
+    }
+
+    try {
+      Preconditions.checkArgument(false, "Test message %s %s %s", 12, null, "column");
+      Assert.fail("Should throw exception when isValid is false");
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("Should format message",
+          "Test message 12 null column", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckArgumentWithMoreThanThreeParams() {
+    try {
+      Preconditions.checkArgument(true, "Test message %s %s %s %s", 12, null, "column", true);
+    } catch (IllegalArgumentException e) {
+      Assert.fail("Should not throw exception when isValid is true");
+    }
+
+    try {
+      Preconditions.checkArgument(false, "Test message %s %s %s %s", 12, null, "column", true);
+      Assert.fail("Should throw exception when isValid is false");
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("Should format message",
+          "Test message 12 null column true", e.getMessage());
+    }
+  }
+
+  @Test
+  public void checkArgumentMessageOnlySupportsStringTypeTemplate() {
+    try {
+      Preconditions.checkArgument(true, "Test message %d", 12);
+    } catch (IllegalArgumentException e) {
+      Assert.fail("Should not throw exception when isValid is true");
+    }
+
+    try {
+      Preconditions.checkArgument(false, "Test message %d", 12);
+      Assert.fail("Should throw exception when isValid is false");
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("%d is not a valid format option",
+          "d != java.lang.String", e.getMessage());
+    }
+  }  
 
   @Test
   public void testCheckState() {
@@ -55,4 +141,106 @@ public class TestPreconditions {
           "Test message: 12 null", e.getMessage());
     }
   }
+
+  @Test
+  public void testCheckStateWithoutArguments() {
+    try {
+      Preconditions.checkState(true, "Test message");
+    } catch (IllegalStateException e) {
+      Assert.fail("Should not throw exception when isValid is true");
+    }
+
+    try {
+      Preconditions.checkState(false, "Test message");
+      Assert.fail("Should throw exception when isValid is false");
+    } catch (IllegalStateException e) {
+      Assert.assertEquals("Should format message",
+          "Test message", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckStateWithOneArgument() {
+    try {
+      Preconditions.checkState(true, "Test message %s", 12);
+    } catch (IllegalStateException e) {
+      Assert.fail("Should not throw exception when isValid is true");
+    }
+
+    try {
+      Preconditions.checkState(false, "Test message %s", 12);
+      Assert.fail("Should throw exception when isValid is false");
+    } catch (IllegalStateException e) {
+      Assert.assertEquals("Should format message",
+          "Test message 12", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckStateWithTwoArguments() {
+    try {
+      Preconditions.checkState(true, "Test message %s %s", 12, null);
+    } catch (IllegalStateException e) {
+      Assert.fail("Should not throw exception when isValid is true");
+    }
+
+    try {
+      Preconditions.checkState(false, "Test message %s %s", 12, null);
+      Assert.fail("Should throw exception when isValid is false");
+    } catch (IllegalStateException e) {
+      Assert.assertEquals("Should format message",
+          "Test message 12 null", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckStateWithThreeArguments() {
+    try {
+      Preconditions.checkState(true, "Test message %s %s %s", 12, null, "column");
+    } catch (IllegalStateException e) {
+      Assert.fail("Should not throw exception when isValid is true");
+    }
+
+    try {
+      Preconditions.checkState(false, "Test message %s %s %s", 12, null, "column");
+      Assert.fail("Should throw exception when isValid is false");
+    } catch (IllegalStateException e) {
+      Assert.assertEquals("Should format message",
+          "Test message 12 null column", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckStateWithMoreThanThreeParams() {
+    try {
+      Preconditions.checkState(true, "Test message %s %s %s %s", 12, null, "column", true);
+    } catch (IllegalStateException e) {
+      Assert.fail("Should not throw exception when isValid is true");
+    }
+
+    try {
+      Preconditions.checkState(false, "Test message %s %s %s %s", 12, null, "column", true);
+      Assert.fail("Should throw exception when isValid is false");
+    } catch (IllegalStateException e) {
+      Assert.assertEquals("Should format message",
+          "Test message 12 null column true", e.getMessage());
+    }
+  }  
+
+  @Test
+  public void checkStateMessageOnlySupportsStringTypeTemplate() {
+    try {
+      Preconditions.checkState(true, "Test message %d", 12);
+    } catch (IllegalStateException e) {
+      Assert.fail("Should not throw exception when isValid is true");
+    }
+
+    try {
+      Preconditions.checkState(false, "Test message %d", 12);
+      Assert.fail("Should throw exception when isValid is false");
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("%d is not a valid format option",
+          "d != java.lang.String", e.getMessage());
+    }
+  }  
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -216,7 +216,7 @@ public class ParquetMetadataConverter {
       }
       if (preBlockStartPos != 0) {
         Preconditions.checkState(blockStartPos >= preBlockStartPos + preBlockCompressedSize,
-          "Invalid block starting position:" + blockStartPos);
+          "Invalid block starting position: %s", blockStartPos);
       }
       preBlockStartPos = blockStartPos;
       preBlockCompressedSize = block.getCompressedSize();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -1471,7 +1471,7 @@ public class ParquetFileWriter {
   @Deprecated
   public static void writeMetadataFile(Configuration configuration, Path outputPath, List<Footer> footers, JobSummaryLevel level) throws IOException {
     Preconditions.checkArgument(level == JobSummaryLevel.ALL || level == JobSummaryLevel.COMMON_ONLY,
-        "Unsupported level: " + level);
+        "Unsupported level: %s", level);
 
     FileSystem fs = outputPath.getFileSystem(configuration);
     outputPath = outputPath.makeQualified(fs);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -339,7 +339,7 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
       // receiving ParquetInputSplit. Translation is required at some point.
       for (InputSplit split : super.getSplits(jobContext)) {
         Preconditions.checkArgument(split instanceof FileSplit,
-            "Cannot wrap non-FileSplit: " + split);
+            "Cannot wrap non-FileSplit: %s", split);
         splits.add(ParquetInputSplit.from((FileSplit) split));
       }
       return splits;


### PR DESCRIPTION
The [original Jira ticket ](https://issues.apache.org/jira/browse/PARQUET-2202) references to a concrete bad usage of the `Preconditions.checkArgument` method, where a String is calculated before validating the check, creating an overhead when in theory 100% of the cases the composed String will not be used.

The proposed solution inlines the call to `Preconditions.checkArgument`, but the correct approach is to call the `checkArgument` method with a String to format if the argument check is not valid.

A similar issue ocurrs in the [constructor](https://github.com/apache/parquet-mr/blob/62b774cd0f0c60cfbe540bbfa60bee15929af5d4/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java#L153) of the `CapacityByteArrayOutputStream` class, where the error message is always created using the `String.format`, instead of passing the template String and its params to the `checkArgument` method. This performance issue is also visible in a profiling.

The MR fixes both cases, and reviews the usage of `Preconditions` class, to ensure that error messages are not calculated before checking the boolean expression.

I've also reviewed `Preconditions` methods to improve the performance. When you call to a method with a varargs argument, Java internally allocates an array containing all values. To avoid this allocation when the number of params is very low, is recomended to overload the method with versions of the method with different number of arguments. This approach is heavily used in logging frameworks, or in [Guava Preconditions implementation](https://github.com/google/guava/blob/4312d949967f3fb245636f66437a00dd8c346d38/guava/src/com/google/common/base/Preconditions.java#L118)
Because nearly 100% of cases are going to check the condition as valid, the Array associated with varargs call to `Preconditions.strings` method will never be created.

Because all changes are related with `Preconditions.checkargument`, I've created a single PR. I can split it in multiple PRs if needed. Each commit of the PR makes a type of change, but I can squash into a single commit if needed.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-2202: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2202
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds test cases to the following unit tests:
  1. https://github.com/jerolba/parquet-mr/blob/review_usage_of_preconditions_checkargument/parquet-common/src/test/java/org/apache/parquet/TestPreconditions.java

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
