### PR TITLE
PARQUET-2230: [CLI] Deprecate commands replaced by rewrite

### DIFF
--- a/parquet-cli/README.md
+++ b/parquet-cli/README.md
@@ -105,6 +105,12 @@ Usage: parquet [options] [command] [command options]
         Prints the column and offset indexes of a Parquet file
     column-size
         Print the column sizes of a parquet file
+    prune
+        (Deprecated: will be removed in 2.0.0, use rewrite command instead) Prune column(s) in a Parquet file and save it to a new file. The columns left are not changed.
+    trans-compression
+        (Deprecated: will be removed in 2.0.0, use rewrite command instead) Translate the compression from one to another (It doesn't support bloom filter feature yet).
+    masking
+        (Deprecated: will be removed in 2.0.0, use rewrite command instead) Replace columns with masked values and write to a new Parquet file
     footer
         Print the Parquet file footer in json format
     bloom-filter

--- a/parquet-cli/README.md
+++ b/parquet-cli/README.md
@@ -105,12 +105,6 @@ Usage: parquet [options] [command] [command options]
         Prints the column and offset indexes of a Parquet file
     column-size
         Print the column sizes of a parquet file
-    prune
-        Prune column(s) in a Parquet file and save it to a new file. The columns left are not changed.
-    trans-compression
-        Translate the compression from one to another (It doesn't support bloom filter feature yet).
-    masking
-        Replace columns with masked values and write to a new Parquet file
     footer
         Print the Parquet file footer in json format
     bloom-filter

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/Main.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/Main.java
@@ -98,6 +98,9 @@ public class Main extends Configured implements Tool {
     jc.addCommand("head", new CatCommand(console, 10));
     jc.addCommand("column-index", new ShowColumnIndexCommand(console));
     jc.addCommand("column-size", new ColumnSizeCommand(console));
+    jc.addCommand("prune", new PruneColumnsCommand(console));
+    jc.addCommand("trans-compression", new TransCompressionCommand(console));
+    jc.addCommand("masking", new ColumnMaskingCommand(console));
     jc.addCommand("footer", new ShowFooterCommand(console));
     jc.addCommand("bloom-filter", new ShowBloomFilterCommand(console));
     jc.addCommand("scan", new ScanCommand(console));

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/Main.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/Main.java
@@ -98,9 +98,6 @@ public class Main extends Configured implements Tool {
     jc.addCommand("head", new CatCommand(console, 10));
     jc.addCommand("column-index", new ShowColumnIndexCommand(console));
     jc.addCommand("column-size", new ColumnSizeCommand(console));
-    jc.addCommand("prune", new PruneColumnsCommand(console));
-    jc.addCommand("trans-compression", new TransCompressionCommand(console));
-    jc.addCommand("masking", new ColumnMaskingCommand(console));
     jc.addCommand("footer", new ShowFooterCommand(console));
     jc.addCommand("bloom-filter", new ShowBloomFilterCommand(console));
     jc.addCommand("scan", new ScanCommand(console));

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnMaskingCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnMaskingCommand.java
@@ -41,6 +41,7 @@ import java.util.List;
 
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 
+@Deprecated
 @Parameters(commandDescription="Replace columns with masked values and write to a new Parquet file")
 public class ColumnMaskingCommand extends BaseCommand {
 

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnMaskingCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnMaskingCommand.java
@@ -41,8 +41,8 @@ import java.util.List;
 
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 
-@Deprecated
-@Parameters(commandDescription="Replace columns with masked values and write to a new Parquet file")
+@Parameters(commandDescription="(Deprecated: will be removed in 2.0.0, use rewrite command instead) " +
+        "Replace columns with masked values and write to a new Parquet file")
 public class ColumnMaskingCommand extends BaseCommand {
 
   private ColumnMasker masker;

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/PruneColumnsCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/PruneColumnsCommand.java
@@ -30,9 +30,9 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.List;
 
-@Deprecated
-@Parameters(commandDescription="Prune column(s) in a Parquet file and save it to a new file. " +
-  "The columns left are not changed.")
+@Parameters(commandDescription="(Deprecated: will be removed in 2.0.0, use rewrite command instead) " +
+        "Prune column(s) in a Parquet file and save it to a new file. " +
+        "The columns left are not changed.")
 public class PruneColumnsCommand extends BaseCommand {
 
   public PruneColumnsCommand(Logger console) {

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/PruneColumnsCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/PruneColumnsCommand.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.util.List;
 
+@Deprecated
 @Parameters(commandDescription="Prune column(s) in a Parquet file and save it to a new file. " +
   "The columns left are not changed.")
 public class PruneColumnsCommand extends BaseCommand {

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/RewriteCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/RewriteCommand.java
@@ -68,7 +68,7 @@ public class RewriteCommand extends BaseCommand {
 
   @Parameter(
           names = {"-c", "--compression-codec"},
-          description = "<new compression codec",
+          description = "<new compression codec>",
           required = false)
   String codec;
 

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/TransCompressionCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/TransCompressionCommand.java
@@ -41,6 +41,7 @@ import java.util.List;
 
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 
+@Deprecated
 @Parameters(commandDescription="Translate the compression from one to another (It doesn't support bloom filter feature yet).")
 public class TransCompressionCommand extends BaseCommand {
 
@@ -61,7 +62,7 @@ public class TransCompressionCommand extends BaseCommand {
 
   @Parameter(
     names = {"-c", "--compression-codec"},
-    description = "<new compression codec")
+    description = "<new compression codec>")
   String codec;
 
   @Override

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/TransCompressionCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/TransCompressionCommand.java
@@ -41,8 +41,8 @@ import java.util.List;
 
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 
-@Deprecated
-@Parameters(commandDescription="Translate the compression from one to another (It doesn't support bloom filter feature yet).")
+@Parameters(commandDescription="(Deprecated: will be removed in 2.0.0, use rewrite command instead) " +
+        "Translate the compression from one to another (It doesn't support bloom filter feature yet).")
 public class TransCompressionCommand extends BaseCommand {
 
   private CompressionConverter compressionConverter;


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. 
  - https://issues.apache.org/jira/browse/PARQUET-2230

### Tests

- [x] My PR does not need testing.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - Remove all deprecated commands supported by parquet-cli from README.md.