### PR TITLE
PARQUET-2260 Bloom filter size shouldn't be larger than maxBytes in the configuration

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterBase.java
@@ -97,7 +97,7 @@ abstract class ColumnWriterBase implements ColumnWriter {
       int optimalNumOfBits = BlockSplitBloomFilter.optimalNumOfBits(ndv.getAsLong(), fpp.getAsDouble());
       this.bloomFilter = new BlockSplitBloomFilter(optimalNumOfBits / 8, maxBloomFilterSize);
     } else {
-      this.bloomFilter = BlockSplitBloomFilter.of(maxBloomFilterSize);
+      this.bloomFilter = new BlockSplitBloomFilter(maxBloomFilterSize, maxBloomFilterSize);
     }
   }
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterBase.java
@@ -97,7 +97,7 @@ abstract class ColumnWriterBase implements ColumnWriter {
       int optimalNumOfBits = BlockSplitBloomFilter.optimalNumOfBits(ndv.getAsLong(), fpp.getAsDouble());
       this.bloomFilter = new BlockSplitBloomFilter(optimalNumOfBits / 8, maxBloomFilterSize);
     } else {
-      this.bloomFilter = new BlockSplitBloomFilter(maxBloomFilterSize);
+      this.bloomFilter = BlockSplitBloomFilter.of(maxBloomFilterSize);
     }
   }
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
@@ -86,22 +86,6 @@ public class BlockSplitBloomFilter implements BloomFilter {
     0x705495c7, 0x2df1424b, 0x9efc4947, 0x5c6bfb31};
 
   /**
-   * Create a Bloom filter within the maximum bytes size. The bloom filter bytes size
-   * will be a largest power of 2 less than the maximum bytes size.
-   *
-   * @param maxBytes The max number of bytes for Bloom filter.
-   * @return
-   */
-  public static BlockSplitBloomFilter of(int maxBytes) {
-    if (maxBytes < LOWER_BOUND_BYTES) {
-      maxBytes = LOWER_BOUND_BYTES;
-    }
-    int upperBound = Math.min(maxBytes, UPPER_BOUND_BYTES);
-    int byteSize = largestTwoPowerInRange(LOWER_BOUND_BYTES, upperBound);
-    return new BlockSplitBloomFilter(byteSize);
-  }
-
-  /**
    * Constructor of block-based Bloom filter.
    *
    * @param numBytes The number of bytes for Bloom filter bitset. The range of num_bytes should be within
@@ -232,19 +216,6 @@ public class BlockSplitBloomFilter implements BloomFilter {
     }
     this.bitset = new byte[numBytes];
     this.intBuffer = ByteBuffer.wrap(bitset).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
-  }
-
-  /**
-   * Calculate the largest power of 2 in the range [lowerBound,upperBound].
-   */
-  public static int largestTwoPowerInRange(int lowerBound, int upperBound) {
-    int result = upperBound;
-    // if `upperBound` is not power of 2, get the next largest power of two less than `upperBound`
-    if ((result & (result - 1)) != 0) {
-      result = Integer.highestOneBit(result);
-    }
-    result = Math.max(result, lowerBound);
-    return result;
   }
 
   @Override

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
@@ -97,7 +97,7 @@ public class BlockSplitBloomFilter implements BloomFilter {
       maxBytes = LOWER_BOUND_BYTES;
     }
     int upperBound = Math.min(maxBytes, UPPER_BOUND_BYTES);
-    int byteSize = largestTwoPowerNumberInRange(LOWER_BOUND_BYTES, upperBound);
+    int byteSize = largestTwoPowerInRange(LOWER_BOUND_BYTES, upperBound);
     return new BlockSplitBloomFilter(byteSize);
   }
 
@@ -237,15 +237,13 @@ public class BlockSplitBloomFilter implements BloomFilter {
   /**
    * Calculate the largest power of 2 in the range [lowerBound,upperBound].
    */
-  public static int largestTwoPowerNumberInRange(int lowerBound, int upperBound) {
+  public static int largestTwoPowerInRange(int lowerBound, int upperBound) {
     int result = upperBound;
     // if `upperBound` is not power of 2, get the next largest power of two less than `upperBound`
     if ((result & (result - 1)) != 0) {
       result = Integer.highestOneBit(result);
     }
-    if (result < lowerBound) {
-      result = lowerBound;
-    }
+    result = Math.max(result, lowerBound);
     return result;
   }
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BlockSplitBloomFilter.java
@@ -86,6 +86,22 @@ public class BlockSplitBloomFilter implements BloomFilter {
     0x705495c7, 0x2df1424b, 0x9efc4947, 0x5c6bfb31};
 
   /**
+   * Create a Bloom filter within the maximum bytes size. The bloom filter bytes size
+   * will be a largest power of 2 less than the maximum bytes size.
+   *
+   * @param maxBytes The max number of bytes for Bloom filter.
+   * @return
+   */
+  public static BlockSplitBloomFilter of(int maxBytes) {
+    if (maxBytes < LOWER_BOUND_BYTES) {
+      maxBytes = LOWER_BOUND_BYTES;
+    }
+    int upperBound = Math.min(maxBytes, UPPER_BOUND_BYTES);
+    int byteSize = largestTwoPowerNumberInRange(LOWER_BOUND_BYTES, upperBound);
+    return new BlockSplitBloomFilter(byteSize);
+  }
+
+  /**
    * Constructor of block-based Bloom filter.
    *
    * @param numBytes The number of bytes for Bloom filter bitset. The range of num_bytes should be within
@@ -216,6 +232,21 @@ public class BlockSplitBloomFilter implements BloomFilter {
     }
     this.bitset = new byte[numBytes];
     this.intBuffer = ByteBuffer.wrap(bitset).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
+  }
+
+  /**
+   * Calculate the largest power of 2 in the range [lowerBound,upperBound].
+   */
+  public static int largestTwoPowerNumberInRange(int lowerBound, int upperBound) {
+    int result = upperBound;
+    // if `upperBound` is not power of 2, get the next largest power of two less than `upperBound`
+    if ((result & (result - 1)) != 0) {
+      result = Integer.highestOneBit(result);
+    }
+    if (result < lowerBound) {
+      result = lowerBound;
+    }
+    return result;
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -590,6 +590,17 @@ public class ParquetWriter<T> implements Closeable {
     }
 
     /**
+     * Set max Bloom filter bytes for related columns.
+     *
+     * @param maxBloomFilterBytes the max bytes of a Bloom filter bitset for a column.
+     * @return this builder for method chaining
+     */
+    public SELF withMaxBloomFilterBytes(int maxBloomFilterBytes) {
+      encodingPropsBuilder.withMaxBloomFilterBytes(maxBloomFilterBytes);
+      return self();
+    }
+
+    /**
      * Sets the NDV (number of distinct values) for the specified column.
      *
      * @param columnPath the path of the column (dot-string)

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
@@ -386,16 +386,6 @@ public class TestParquetWriter {
     }
   }
 
-  static final int tableSizeFor(int cap) {
-    int n = cap - 1;
-    n |= n >>> 1;
-    n |= n >>> 2;
-    n |= n >>> 4;
-    n |= n >>> 8;
-    n |= n >>> 16;
-    return n + 1;
-  }
-
   @Test
   public void testParquetFileWritesExpectedNumberOfBlocks() throws IOException {
     testParquetFileNumberOfBlocks(ParquetProperties.DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK,

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
@@ -346,8 +346,7 @@ public class TestParquetWriter {
 
   /**
    * If `parquet.bloom.filter.max.bytes` is set, the bytes size of bloom filter should not
-   * be larger than this value and it will be the next largest power of 2 less than the max
-   * bytes size.
+   * be larger than this value
    */
   @Test
   public void testBloomFilterMaxBytesSize() throws IOException {
@@ -380,9 +379,7 @@ public class TestParquetWriter {
       BlockMetaData blockMetaData = reader.getFooter().getBlocks().get(0);
       BloomFilter bloomFilter = reader.getBloomFilterDataReader(blockMetaData)
         .readBloomFilter(blockMetaData.getColumns().get(0));
-      // `maxBloomFilterBytes` = 1024 * 1024 + 1 = 1048577, bloom filter bytes size should be
-      // the next largest power of 2 less than 1048577
-      assertEquals(bloomFilter.getBitsetSize(), 1024 * 1024);
+      assertEquals(bloomFilter.getBitsetSize(), maxBloomFilterBytes);
     }
   }
 


### PR DESCRIPTION
Before this PR: If `parquet.bloom.filter.max.bytes` configuration is not a power of 2 value,  the size of the bloom filter generated will exceed this value. For example, if set `parquet.bloom.filter.max.bytes` as 1024 * 1024+1= 1048577 , the bytes size of bloom filter generated will be 1024 * 1024 * 2 = 2097152. This does not match the definition of the parameter

After this PR: If `parquet.bloom.filter.max.bytes` configuration is not a power of 2, and the size of `parquet.bloom.filter.max.bytes` is the final bloom filter bytes size.