### PR TITLE
PARQUET-1629: Support CRC for data page v2

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -1932,13 +1932,43 @@ public class ParquetMetadataConverter {
       int valueCount, int nullCount, int rowCount,
       org.apache.parquet.column.Encoding dataEncoding,
       int rlByteLength, int dlByteLength) {
-    // TODO: pageHeader.crc = ...;
     DataPageHeaderV2 dataPageHeaderV2 = new DataPageHeaderV2(
         valueCount, nullCount, rowCount,
         getEncoding(dataEncoding),
         dlByteLength, rlByteLength);
     PageHeader pageHeader = new PageHeader(PageType.DATA_PAGE_V2, uncompressedSize, compressedSize);
     pageHeader.setData_page_header_v2(dataPageHeaderV2);
+    return pageHeader;
+  }
+
+  public void writeDataPageV2Header(
+    int uncompressedSize, int compressedSize,
+    int valueCount, int nullCount, int rowCount,
+    org.apache.parquet.column.Encoding dataEncoding,
+    int rlByteLength, int dlByteLength, int crc,
+    OutputStream to, BlockCipher.Encryptor blockEncryptor,
+    byte[] pageHeaderAAD) throws IOException {
+    writePageHeader(
+      newDataPageV2Header(
+        uncompressedSize, compressedSize,
+        valueCount, nullCount, rowCount,
+        dataEncoding,
+        rlByteLength, dlByteLength, crc),
+      to, blockEncryptor, pageHeaderAAD);
+  }
+
+  private PageHeader newDataPageV2Header(
+    int uncompressedSize, int compressedSize,
+    int valueCount, int nullCount, int rowCount,
+    org.apache.parquet.column.Encoding dataEncoding,
+    int rlByteLength, int dlByteLength, int crc) {
+    DataPageHeaderV2 dataPageHeaderV2 = new DataPageHeaderV2(
+      valueCount, nullCount, rowCount,
+      getEncoding(dataEncoding),
+      dlByteLength, rlByteLength);
+    PageHeader pageHeader = new PageHeader(PageType.DATA_PAGE_V2, uncompressedSize, compressedSize);
+    pageHeader.setData_page_header_v2(dataPageHeaderV2);
+    pageHeader.setCrc(crc);
     return pageHeader;
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
@@ -251,9 +251,10 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
           } catch (IOException e) {
             throw new ParquetDecodingException("could not decompress page", e);
           }
-          
+
+          final DataPageV2 decompressedPage;
           if (offsetIndex == null) {
-            return DataPageV2.uncompressed(
+            decompressedPage = DataPageV2.uncompressed(
                 dataPageV2.getRowCount(),
                 dataPageV2.getNullCount(),
                 dataPageV2.getValueCount(),
@@ -263,7 +264,7 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
                 pageBytes,
                 dataPageV2.getStatistics());
           } else {
-            return DataPageV2.uncompressed(
+            decompressedPage = DataPageV2.uncompressed(
                 dataPageV2.getRowCount(),
                 dataPageV2.getNullCount(),
                 dataPageV2.getValueCount(),
@@ -274,6 +275,10 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
                 pageBytes,
                 dataPageV2.getStatistics());
           }
+          if (dataPageV2.getCrc().isPresent()) {
+            decompressedPage.setCrc(dataPageV2.getCrc().getAsInt());
+          }
+          return decompressedPage;
         } 
       });
     }


### PR DESCRIPTION
### Jira

https://issues.apache.org/jira/browse/PARQUET-1629

### Tests

Refactored `TestDataPageV1Checksums` to support both V1 and V2 data pages in all cases.

### Commits

- Writer computes crc and writes it into data page v2 header if enabled.
- Reader verifies crc from data page v2 header if enabled.
