### PR TITLE
PARQUET-2262: Fix local build failure due to missing surefire.argLine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
     <jsr305.version>3.0.2</jsr305.version>
 
     <!-- properties for the profiles -->
+    <surefire.argLine> </surefire.argLine>
     <surefire.logLevel>INFO</surefire.logLevel>
 
     <!-- Resource intesive tests are enabled by default but disabled in the CI envrionment -->


### PR DESCRIPTION
### Jira

https://issues.apache.org/jira/browse/PARQUET-2262

### Tests

Tested it locally.

### Commits

Add a default `surefire.argLine` properties to make local test happy.

