### PR TITLE
PARQUET-2263: Upgrade maven-shade-plugin to 3.4.1

### DIFF
--- a/parquet-avro/pom.xml
+++ b/parquet-avro/pom.xml
@@ -54,11 +54,6 @@
       <version>${avro.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
       <groupId>it.unimi.dsi</groupId>
       <artifactId>fastutil</artifactId>
       <version>${fastutil.version}</version>
@@ -77,6 +72,12 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -108,11 +108,6 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
       <version>${project.version}</version>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -108,6 +108,12 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-column</artifactId>
       <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>23</version>
+    <version>29</version>
   </parent>
 
   <groupId>org.apache.parquet</groupId>
@@ -310,7 +310,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.4.1</version>
           <executions>
             <execution>
               <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
+          <version>3.4.1</version>
           <executions>
             <execution>
               <phase>package</phase>


### PR DESCRIPTION
Upgrade maven-shade-plugin to 3.4.1 to fix it does not work under Java 17:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.1.1:shade (default) on project parquet-format-structures: Error creating shaded jar: null: IllegalArgumentException -> [Help 1]
```
Please see MSHADE-289 for more details.