### PR TITLE
PARQUET-2265: Don't set default Model in AvroParquetWriter

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
@@ -160,7 +160,7 @@ public class AvroParquetWriter<T> extends ParquetWriter<T> {
 
   public static class Builder<T> extends ParquetWriter.Builder<T, Builder<T>> {
     private Schema schema = null;
-    private GenericData model = SpecificData.get();
+    private GenericData model = null;
 
     private Builder(Path file) {
       super(file);


### PR DESCRIPTION
This PR removes the default `model` setting in `AvroParquetWriter.Builder`. The reasons for this change are:

1) `AvroWriteSupport` already sets a default `model` value (also to `SpecificDataSupplier`) in [AvroWriteSupport::init](https://github.com/apache/parquet-mr/blob/d38044f5395494e1543581a4b763f624305d3022/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java#L126-L135), so setting a default in `AvroParquetWriter` is redundant. 

2) It created some confusion for me, since I expected that the class I set in [parquet.avro.write.data.supplier](https://github.com/apache/parquet-mr/blob/d38044f5395494e1543581a4b763f624305d3022/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java#L54) would automatically be used as the `model`. This change ensures that if no data model is supplied in the `AvroParquetWriter.Builder`, then `AvroWriteSupport` will select a data model based on the `parquet.avro.write.data.supplier` config value, if present, and `SpecificDataSupplier` if not present.

3. `AvroParquetReader` [sets](https://github.com/apache/parquet-mr/blob/master/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetReader.java#L133) `model = null`, so this PR makes the behavior of AvroParquetReader|Writer consistent.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2265
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] **My PR adds the following unit tests** __OR__ does not need testing for this extremely good reason:
     - Added a test to verify that AvroParquetWriter allows AvroWriteSupport to parse model from Configuration if .withDataModel is not set
     - Since AvroWriteSupport still sets `model` to a default value of `SpecificDataSupplier` in [init](https://github.com/apache/parquet-mr/blob/master/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java#L403-L406), the existing SpecificRecord writer tests continuing to pass should effectively test that the default behavior is unchanged

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
