### PR TITLE
PARQUET-2289: Avoid using `hasCapability`

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/H1SeekableInputStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/H1SeekableInputStream.java
@@ -26,7 +26,9 @@ import java.io.IOException;
 /**
  * SeekableInputStream implementation that implements read(ByteBuffer) for
  * Hadoop 1 FSDataInputStream.
+ * @deprecated will be removed in 2.0.0.
  */
+@Deprecated
 class H1SeekableInputStream extends DelegatingSeekableInputStream {
 
   private final FSDataInputStream stream;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoop2ByteBufferReads.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoop2ByteBufferReads.java
@@ -401,22 +401,6 @@ public class TestHadoop2ByteBufferReads {
   }
 
   @Test
-  public void testCreateStreamNoByteBufferReadable() {
-    final SeekableInputStream s = wrap(new FSDataInputStream(
-      new MockHadoopInputStream()));
-    Assert.assertTrue("Wrong wrapper: " + s,
-      s instanceof H1SeekableInputStream);
-  }
-
-  @Test
-  public void testDoubleWrapNoByteBufferReadable() {
-    final SeekableInputStream s = wrap(new FSDataInputStream(
-      new FSDataInputStream(new MockHadoopInputStream())));
-    Assert.assertTrue("Wrong wrapper: " + s,
-      s instanceof H1SeekableInputStream);
-  }
-
-  @Test
   public void testCreateStreamWithByteBufferReadable() {
     final SeekableInputStream s = wrap(new FSDataInputStream(
       new MockByteBufferInputStream()));


### PR DESCRIPTION
We should avoid using `hasCapability` to maintain compatibility with Hadoop 2. I think we can remove the whole check since Hadoop 1 isn't supported anymore.

This allows us to use Hadoop 2. Relates to https://github.com/apache/parquet-mr/pull/951 

cc @steveloughran 

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
