### PR TITLE
PARQUET-2290: Add CI for Hadoop 2

### DIFF
--- a/.github/workflows/ci-hadoop2.yml
+++ b/.github/workflows/ci-hadoop2.yml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: CI Hadoop 2
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        codes: [ 'uncompressed,brotli', 'gzip,snappy' ]
+    name: Build Parquet with JDK ${{ matrix.java }} and ${{ matrix.codes }}
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up JDK8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: before_install
+        env:
+          CI_TARGET_BRANCH: $GITHUB_HEAD_REF
+        run: |
+          bash dev/ci-before_install.sh
+      - name: install
+        run: |
+          EXTRA_JAVA_TEST_ARGS=$(mvn help:evaluate -Dexpression=extraJavaTestArgs -q -DforceStdout)
+          export MAVEN_OPTS="$MAVEN_OPTS $EXTRA_JAVA_TEST_ARGS"
+          mvn install --batch-mode -P hadoop2 -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true -Djava.version=1.8
+      - name: verify
+        env:
+          TEST_CODECS: ${{ matrix.codes }}
+          JAVA_VERSION: ${{ matrix.java }}
+        run: |
+          EXTRA_JAVA_TEST_ARGS=$(mvn help:evaluate -Dexpression=extraJavaTestArgs -q -DforceStdout)
+          export MAVEN_OPTS="$MAVEN_OPTS $EXTRA_JAVA_TEST_ARGS"
+          mvn verify --batch-mode -P hadoop2 javadoc:javadoc -Pci-test

--- a/.github/workflows/ci-hadoop3.yml
+++ b/.github/workflows/ci-hadoop3.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Test
+name: CI Hadoop 3
 
 on: [push, pull_request]
 

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/projection/deprecated/PathGlobPattern.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/projection/deprecated/PathGlobPattern.java
@@ -18,8 +18,6 @@
  */
 package org.apache.parquet.thrift.projection.deprecated;
 
-import org.apache.hadoop.fs.GlobPattern;
-
 import com.google.re2j.Pattern;
 import com.google.re2j.PatternSyntaxException;
 
@@ -43,16 +41,6 @@ public class PathGlobPattern {
    */
   public PathGlobPattern(String globPattern) {
     set(globPattern);
-  }
-
-  /**
-   * Compile glob pattern string
-   *
-   * @param globPattern the glob pattern
-   * @return the pattern object
-   */
-  public static Pattern compile(String globPattern) {
-    return new GlobPattern(globPattern).compiled();
   }
 
   private static void error(String message, String pattern, int pos) {

--- a/pom.xml
+++ b/pom.xml
@@ -59,13 +59,6 @@
     </repository>
   </repositories>
 
-  <developers>
-    <developer>
-      <name>Julien Le Dem</name>
-      <email>julien@twitter.com</email>
-    </developer>
-  </developers>
-
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -601,6 +594,13 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>hadoop2</id>
+      <properties>
+        <hadoop.version>2.9.2</hadoop.version>
+      </properties>
+    </profile>
+
     <profile>
       <id>update-github-site</id>
       <reporting>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

While upgrading Parquet in Iceberg, I noticed that we broke compatibility. Iceberg is still at Hadoop 2.7.3. The `hasCapability` method that is used in https://github.com/apache/parquet-mr/pull/951 is not available in Hadoop <2.9.x. There is no serious workaround. I think it is good to add this CI to at least know the lower bound Hadoop 2 version that we're still supporting.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2290
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
