### PR TITLE
PARQUET-2292: Default SpecificRecord model reflects from MODEL$ field

### DIFF
--- a/parquet-avro/pom.xml
+++ b/parquet-avro/pom.xml
@@ -74,6 +74,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-annotations</artifactId>
+      <version>${hadoop.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
@@ -95,6 +101,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
@@ -104,8 +111,20 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.23.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-core</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/parquet-avro/pom.xml
+++ b/parquet-avro/pom.xml
@@ -77,7 +77,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -96,7 +95,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>

--- a/parquet-avro/pom.xml
+++ b/parquet-avro/pom.xml
@@ -105,6 +105,18 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parquet-avro/pom.xml
+++ b/parquet-avro/pom.xml
@@ -74,12 +74,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-annotations</artifactId>
-      <version>${hadoop.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
@@ -27,6 +27,8 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.parquet.hadoop.api.ReadSupport;
 import org.apache.parquet.io.api.RecordMaterializer;
 import org.apache.parquet.schema.MessageType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Avro implementation of {@link ReadSupport} for avro generic, specific, and
@@ -36,6 +38,8 @@ import org.apache.parquet.schema.MessageType;
  * @param <T> the Java type of records created by this ReadSupport
  */
 public class AvroReadSupport<T> extends ReadSupport<T> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AvroReadSupport.class);
 
   public static String AVRO_REQUESTED_PROJECTION = "parquet.avro.projection";
   private static final String AVRO_READ_SCHEMA = "parquet.avro.read.schema";
@@ -155,7 +159,14 @@ public class AvroReadSupport<T> extends ReadSupport<T> {
     }
 
     if (conf.get(AVRO_DATA_SUPPLIER) == null && schema != null) {
-      final GenericData modelForSchema = AvroRecordConverter.getModelForSchema(schema);
+      GenericData modelForSchema;
+      try {
+        modelForSchema = AvroRecordConverter.getModelForSchema(schema);
+      } catch (Exception e) {
+        LOG.warn(String.format("Failed to derive data model for Avro schema %s. Parquet will use default " +
+          "SpecificData model for reading from source.", schema), e);
+        modelForSchema = null;
+      }
 
       if (modelForSchema != null) {
         return modelForSchema;

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
@@ -154,7 +154,7 @@ public class AvroReadSupport<T> extends ReadSupport<T> {
       return model;
     }
 
-    if (conf.get(AVRO_DATA_SUPPLIER) == null) {
+    if (conf.get(AVRO_DATA_SUPPLIER) == null && schema != null) {
       final GenericData modelForSchema = AvroRecordConverter.getModelForSchema(schema);
 
       if (modelForSchema != null) {
@@ -165,6 +165,6 @@ public class AvroReadSupport<T> extends ReadSupport<T> {
     Class<? extends AvroDataSupplier> suppClass = conf.getClass(
       AVRO_DATA_SUPPLIER, SpecificDataSupplier.class, AvroDataSupplier.class);
 
-      return ReflectionUtils.newInstance(suppClass, conf).get();
+    return ReflectionUtils.newInstance(suppClass, conf).get();
   }
 }

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
@@ -163,8 +163,7 @@ public class AvroReadSupport<T> extends ReadSupport<T> {
     }
 
     Class<? extends AvroDataSupplier> suppClass = conf.getClass(
-      AVRO_DATA_SUPPLIER, SpecificDataSupplier.class, AvroDataSupplier.class);
-
+        AVRO_DATA_SUPPLIER, SpecificDataSupplier.class, AvroDataSupplier.class);
     return ReflectionUtils.newInstance(suppClass, conf).get();
   }
 }

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -190,6 +190,11 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
       return null;
     }
 
+    // If clazz == null, the underlying Avro class for the schema is not on the classpath
+    if (clazz == null) {
+      return null;
+    }
+
     final SpecificData model;
     try {
       final Field modelField = clazz.getDeclaredField("MODEL$");
@@ -203,7 +208,7 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
       return null;
     } catch (IllegalAccessException e) {
       LOG.warn(String.format(
-        "The MODEL$ field on Avro class %s was inaccessible. Parquet will use default SpecificData model for " +
+        "Field `MODEL$` in class %s was inaccessible. Parquet will use default SpecificData model for " +
           "reading and writing.", clazz), e);
       return null;
     }
@@ -218,13 +223,13 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
         // Avro classes without logical types (denoted by the "conversions" field) can be returned as-is
         return model;
       }
-      conversionsField.setAccessible(true);
 
       final Conversion<?>[] conversions;
       try {
+        conversionsField.setAccessible(true);
         conversions = (Conversion<?>[]) conversionsField.get(null);
       } catch (IllegalAccessException e) {
-        LOG.warn(String.format("Field conversions in class %s was inaccessible. Parquet will use default " +
+        LOG.warn(String.format("Field `conversions` in class %s was inaccessible. Parquet will use default " +
           "SpecificData model for reading and writing.", clazz));
         return null;
       }

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -51,7 +51,6 @@ import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.reflect.Stringable;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.util.ClassUtils;
-import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.parquet.Preconditions;
 import org.apache.parquet.avro.AvroConverters.FieldStringConverter;
 import org.apache.parquet.avro.AvroConverters.FieldStringableConverter;
@@ -240,7 +239,6 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
     return model;
   }
 
-  @VisibleForTesting
   static String getRuntimeAvroVersion() {
     return Schema.Parser.class.getPackage().getImplementationVersion();
   }

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -233,7 +233,11 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
         return null;
       }
 
-      Arrays.stream(conversions).filter(Objects::nonNull).forEach(model::addLogicalTypeConversion);
+      for (int i = 0; i < conversions.length; i++) {
+        if (conversions[i] != null) {
+          model.addLogicalTypeConversion(conversions[i]);
+        }
+      }
     }
 
     return model;

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -206,7 +206,7 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
         Arrays.stream(conversions).filter(Objects::nonNull).forEach(model::addLogicalTypeConversion);
       }
     } catch (Exception e) {
-      return model;
+      return null;
     }
 
     return model;

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -51,6 +51,7 @@ import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.reflect.Stringable;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.util.ClassUtils;
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.parquet.Preconditions;
 import org.apache.parquet.avro.AvroConverters.FieldStringConverter;
 import org.apache.parquet.avro.AvroConverters.FieldStringableConverter;
@@ -196,9 +197,9 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
     }
 
     try {
-      final String avroVersion = Schema.Parser.class.getPackage().getImplementationVersion();
-      // Avro 1.8 doesn't include conversions in the MODEL$ field
-      if (avroVersion.startsWith("1.8.")) {
+      final String avroVersion = getRuntimeAvroVersion();
+      // Avro 1.7 and 1.8 don't include conversions in the MODEL$ field
+      if (avroVersion != null && (avroVersion.startsWith("1.8.") || avroVersion.startsWith("1.7."))) {
         final Field conversionsField = clazz.getDeclaredField("conversions");
         conversionsField.setAccessible(true);
 
@@ -210,6 +211,11 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
     }
 
     return model;
+  }
+
+  @VisibleForTesting
+  static String getRuntimeAvroVersion() {
+    return Schema.Parser.class.getPackage().getImplementationVersion();
   }
 
   // this was taken from Avro's ReflectData

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
@@ -410,8 +410,7 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
     }
 
     Class<? extends AvroDataSupplier> suppClass = conf.getClass(
-      AVRO_DATA_SUPPLIER, SpecificDataSupplier.class, AvroDataSupplier.class);
-
+        AVRO_DATA_SUPPLIER, SpecificDataSupplier.class, AvroDataSupplier.class);
     return ReflectionUtils.newInstance(suppClass, conf).get();
   }
 

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
@@ -131,7 +131,7 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
     }
 
     if (model == null) {
-      this.model = getDataModel(configuration);
+      this.model = getDataModel(configuration, rootAvroSchema);
     }
 
     boolean writeOldListStructure = configuration.getBoolean(
@@ -400,9 +400,18 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
     return Binary.fromCharSequence(value.toString());
   }
 
-  private static GenericData getDataModel(Configuration conf) {
+  private static GenericData getDataModel(Configuration conf, Schema schema) {
+    if (conf.get(AVRO_DATA_SUPPLIER) == null) {
+      final GenericData modelForSchema = AvroRecordConverter.getModelForSchema(schema);
+
+      if (modelForSchema != null) {
+        return modelForSchema;
+      }
+    }
+
     Class<? extends AvroDataSupplier> suppClass = conf.getClass(
-        AVRO_DATA_SUPPLIER, SpecificDataSupplier.class, AvroDataSupplier.class);
+      AVRO_DATA_SUPPLIER, SpecificDataSupplier.class, AvroDataSupplier.class);
+
     return ReflectionUtils.newInstance(suppClass, conf).get();
   }
 

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
@@ -401,7 +401,7 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
   }
 
   private static GenericData getDataModel(Configuration conf, Schema schema) {
-    if (conf.get(AVRO_DATA_SUPPLIER) == null) {
+    if (conf.get(AVRO_DATA_SUPPLIER) == null && schema != null) {
       final GenericData modelForSchema = AvroRecordConverter.getModelForSchema(schema);
 
       if (modelForSchema != null) {

--- a/parquet-avro/src/test/avro/logicalType.avsc
+++ b/parquet-avro/src/test/avro/logicalType.avsc
@@ -1,0 +1,14 @@
+{
+    "type": "record",
+    "name": "LogicalTypesTest",
+    "namespace": "org.apache.parquet.avro",
+    "doc": "Record for testing logical types",
+    "fields": [
+        {
+          "name": "timestamp",
+          "type": {
+            "type": "long", "logicalType": "timestamp-millis"
+          }
+        }
+    ]
+}

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
@@ -122,7 +122,7 @@ public class TestAvroRecordConverter {
   // Test Avro record class stubs, generated using different versions of the Avro compiler
   public abstract static class Avro110GeneratedClass extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
     private static final long serialVersionUID = 5558880508010468207L;
-    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro110GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"Record for testing logical types - generated with Avro 1.10.2\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
+    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro110GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
 
     public static org.apache.avro.Schema getClassSchema() {
       return SCHEMA$;
@@ -137,7 +137,7 @@ public class TestAvroRecordConverter {
 
   public abstract static class Avro19GeneratedClass extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
     private static final long serialVersionUID = 5558880508010468207L;
-    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro19GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"Record for testing logical types - generated with Avro 1.10.2\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
+    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro19GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
 
     public static org.apache.avro.Schema getClassSchema() {
       return SCHEMA$;
@@ -152,7 +152,7 @@ public class TestAvroRecordConverter {
 
   public abstract static class Avro18GeneratedClass extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
     private static final long serialVersionUID = 5558880508010468207L;
-    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro18GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"Record for testing logical types - generated with Avro 1.10.2\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
+    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro18GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
 
     public static org.apache.avro.Schema getClassSchema() {
       return SCHEMA$;
@@ -176,7 +176,7 @@ public class TestAvroRecordConverter {
 
   public abstract static class Avro17GeneratedClass extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
     private static final long serialVersionUID = 5558880508010468207L;
-    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro17GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"Record for testing logical types - generated with Avro 1.10.2\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
+    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro17GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
 
     public static org.apache.avro.Schema getClassSchema() {
       return SCHEMA$;

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
@@ -27,7 +27,7 @@ import org.apache.avro.specific.SpecificData;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.BDDMockito;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -83,7 +83,7 @@ public class TestAvroRecordConverter {
   // Test logical type support for older Avro versions
   @Test
   public void testGetModelAvro1_7() {
-    BDDMockito.given(AvroRecordConverter.getRuntimeAvroVersion()).willReturn("1.7.7");
+    Mockito.when(AvroRecordConverter.getRuntimeAvroVersion()).thenReturn("1.7.7");
 
     // Test that model is generated correctly
     final SpecificData model = AvroRecordConverter.getModelForSchema(Avro17GeneratedClass.SCHEMA$);
@@ -93,7 +93,7 @@ public class TestAvroRecordConverter {
 
   @Test
   public void testGetModelAvro1_8() {
-    BDDMockito.given(AvroRecordConverter.getRuntimeAvroVersion()).willReturn("1.8.2");
+    Mockito.when(AvroRecordConverter.getRuntimeAvroVersion()).thenReturn("1.8.2");
 
     // Test that model is generated correctly
     final SpecificData model = AvroRecordConverter.getModelForSchema(Avro18GeneratedClass.SCHEMA$);
@@ -103,7 +103,7 @@ public class TestAvroRecordConverter {
 
   @Test
   public void testGetModelAvro1_9() {
-    BDDMockito.given(AvroRecordConverter.getRuntimeAvroVersion()).willReturn("1.9.2");
+    Mockito.when(AvroRecordConverter.getRuntimeAvroVersion()).thenReturn("1.9.2");
 
     // Test that model is generated correctly
     final SpecificData model = AvroRecordConverter.getModelForSchema(Avro19GeneratedClass.SCHEMA$);
@@ -113,7 +113,7 @@ public class TestAvroRecordConverter {
 
   @Test
   public void testGetModelAvro1_10() {
-    BDDMockito.given(AvroRecordConverter.getRuntimeAvroVersion()).willReturn("1.10.2");
+    Mockito.when(AvroRecordConverter.getRuntimeAvroVersion()).thenReturn("1.10.2");
 
     // Test that model is generated correctly
     final SpecificData model = AvroRecordConverter.getModelForSchema(Avro110GeneratedClass.SCHEMA$);

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.avro;
+
+import org.apache.avro.Conversion;
+import org.apache.avro.Conversions;
+import org.apache.avro.data.TimeConversions;
+import org.apache.avro.specific.SpecificData;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AvroRecordConverter.class)
+public class TestAvroRecordConverter {
+
+  @Before
+  public void setup() {
+    // Default to calling real methods unless overridden in specific test
+    PowerMockito.mockStatic(AvroRecordConverter.class, CALLS_REAL_METHODS);
+  }
+
+  @Test
+  public void testGetModelAvro1_7() {
+    BDDMockito.given(AvroRecordConverter.getRuntimeAvroVersion()).willReturn("1.7.7");
+
+    // Test that model is generated correctly
+    final SpecificData model = AvroRecordConverter.getModelForSchema(Avro17GeneratedClass.SCHEMA$);
+    Conversion<?> conversion = model.getConversionByClass(BigDecimal.class);
+    assertEquals(Conversions.DecimalConversion.class, conversion.getClass());
+  }
+
+  @Test
+  public void testGetModelAvro1_8() {
+    BDDMockito.given(AvroRecordConverter.getRuntimeAvroVersion()).willReturn("1.8.2");
+
+    // Test that model is generated correctly
+    final SpecificData model = AvroRecordConverter.getModelForSchema(Avro18GeneratedClass.SCHEMA$);
+    Conversion<?> conversion = model.getConversionByClass(BigDecimal.class);
+    assertEquals(Conversions.DecimalConversion.class, conversion.getClass());
+  }
+
+  @Test
+  public void testGetModelAvro1_9() {
+    BDDMockito.given(AvroRecordConverter.getRuntimeAvroVersion()).willReturn("1.9.2");
+
+    // Test that model is generated correctly
+    final SpecificData model = AvroRecordConverter.getModelForSchema(Avro19GeneratedClass.SCHEMA$);
+    Conversion<?> conversion = model.getConversionByClass(BigDecimal.class);
+    assertEquals(Conversions.DecimalConversion.class, conversion.getClass());
+  }
+
+  @Test
+  public void testGetModelAvro1_10() {
+    BDDMockito.given(AvroRecordConverter.getRuntimeAvroVersion()).willReturn("1.10.2");
+
+    // Test that model is generated correctly
+    final SpecificData model = AvroRecordConverter.getModelForSchema(Avro110GeneratedClass.SCHEMA$);
+    Conversion<?> conversion = model.getConversionByClass(BigDecimal.class);
+    assertEquals(Conversions.DecimalConversion.class, conversion.getClass());
+  }
+
+  @Test
+  public void testGetModelAvro1_11() {
+    SpecificData model = AvroRecordConverter.getModelForSchema(LogicalTypesTest.SCHEMA$);
+
+    // Test that model is generated correctly
+    Conversion<?> conversion = model.getConversionByClass(Instant.class);
+    assertEquals(TimeConversions.TimestampMillisConversion.class, conversion.getClass());
+  }
+
+  // Test Avro record class stubs, generated using different versions of the Avro compiler
+  public abstract static class Avro110GeneratedClass extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
+    private static final long serialVersionUID = 5558880508010468207L;
+    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro110GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"Record for testing logical types - generated with Avro 1.10.2\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
+
+    public static org.apache.avro.Schema getClassSchema() {
+      return SCHEMA$;
+    }
+
+    private static SpecificData MODEL$ = new SpecificData();
+
+    static {
+      MODEL$.addLogicalTypeConversion(new org.apache.avro.Conversions.DecimalConversion());
+    }
+  }
+
+  public abstract static class Avro19GeneratedClass extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
+    private static final long serialVersionUID = 5558880508010468207L;
+    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro19GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"Record for testing logical types - generated with Avro 1.10.2\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
+
+    public static org.apache.avro.Schema getClassSchema() {
+      return SCHEMA$;
+    }
+
+    private static SpecificData MODEL$ = new SpecificData();
+
+    static {
+      MODEL$.addLogicalTypeConversion(new org.apache.avro.Conversions.DecimalConversion());
+    }
+  }
+
+  public abstract static class Avro18GeneratedClass extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
+    private static final long serialVersionUID = 5558880508010468207L;
+    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro18GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"Record for testing logical types - generated with Avro 1.10.2\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
+
+    public static org.apache.avro.Schema getClassSchema() {
+      return SCHEMA$;
+    }
+
+    private static SpecificData MODEL$ = new SpecificData();
+
+    protected static final org.apache.avro.Conversions.DecimalConversion DECIMAL_CONVERSION = new org.apache.avro.Conversions.DecimalConversion();
+
+    private static final org.apache.avro.Conversion<?>[] conversions =
+      new org.apache.avro.Conversion<?>[] {
+        DECIMAL_CONVERSION,
+        null
+      };
+
+    @Override
+    public org.apache.avro.Conversion<?> getConversion(int field) {
+      return conversions[field];
+    }
+  }
+
+  public abstract static class Avro17GeneratedClass extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
+    private static final long serialVersionUID = 5558880508010468207L;
+    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro17GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"Record for testing logical types - generated with Avro 1.10.2\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
+
+    public static org.apache.avro.Schema getClassSchema() {
+      return SCHEMA$;
+    }
+
+    private static SpecificData MODEL$ = new SpecificData();
+
+    protected static final org.apache.avro.Conversions.DecimalConversion DECIMAL_CONVERSION = new org.apache.avro.Conversions.DecimalConversion();
+
+    private static final org.apache.avro.Conversion<?>[] conversions =
+      new org.apache.avro.Conversion<?>[] {
+        DECIMAL_CONVERSION,
+        null
+      };
+
+    @Override
+    public org.apache.avro.Conversion<?> getConversion(int field) {
+      return conversions[field];
+    }
+  }
+}

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
@@ -35,7 +35,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.math.BigDecimal;
 import java.time.Instant;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 
 @RunWith(PowerMockRunner.class)

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
     <guava.version>27.0.1-jre</guava.version>
     <brotli-codec.version>0.1.1</brotli-codec.version>
     <mockito.version>1.10.19</mockito.version>
+    <powermock.version>2.0.2</powermock.version>
     <net.openhft.version>0.9</net.openhft.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <yetus.audience-annotations.version>0.13.0</yetus.audience-annotations.version>


### PR DESCRIPTION
Context:

AvroWriteSupport/AvroReadSupport can improve the precision of their default `model` selection. Currently they default to new SpecificDataSupplier().get()[0]. This means that SpecificRecord classes that contain logical types will fail out-of-the-box unless a specific DATA_SUPPLIER is configured that contains logical type conversions.

This PR attempts to derive a `model` by reflecting the `MODEL$` field from the SpecificRecordBase implementation, which in Avro 1.11 comes pre-loaded with all necessary logical type conversions for that Specific Avro class. (For Avro 1.8 compatibility, we have to add the conversions manually from the `conversions` field.)

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
