### PR TITLE
PARQUET-2276: Bring back support for Hadoop 2.7.3

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopStreams.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopStreams.java
@@ -67,7 +67,7 @@ public class HadoopStreams {
       }
     }
 
-    return isWrappedStreamByteBufferReadableLegacy(stream);
+    return unwrapByteBufferReadableLegacy(stream);
   }
 
   /**
@@ -80,11 +80,11 @@ public class HadoopStreams {
    * @param stream stream to probe
    * @return A H2SeekableInputStream to access, or H1SeekableInputStream if the stream is not seekable
    */
-  private static SeekableInputStream isWrappedStreamByteBufferReadableLegacy(FSDataInputStream stream) {
+  private static SeekableInputStream unwrapByteBufferReadableLegacy(FSDataInputStream stream) {
     InputStream wrapped = stream.getWrappedStream();
     if (wrapped instanceof FSDataInputStream) {
       LOG.debug("Checking on wrapped stream {} of {} whether is ByteBufferReadable", wrapped, stream);
-      return isWrappedStreamByteBufferReadableLegacy(((FSDataInputStream) wrapped));
+      return unwrapByteBufferReadableLegacy(((FSDataInputStream) wrapped));
     }
     if (stream.getWrappedStream() instanceof ByteBufferReadable) {
       return new H2SeekableInputStream(stream);
@@ -117,9 +117,9 @@ public class HadoopStreams {
       return null;
     }
 
-    Boolean hasCapabilities = hasCapabilitiesMethod.invoke(stream, "in:readbytebuffer");
+    boolean isByteBufferReadable = hasCapabilitiesMethod.invoke(stream, "in:readbytebuffer");
 
-    if (hasCapabilities) {
+    if (isByteBufferReadable) {
       // stream is issuing the guarantee that it implements the
       // API. Holds for all implementations in hadoop-*
       // since Hadoop 3.3.0 (HDFS-14111).

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopStreams.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopStreams.java
@@ -20,6 +20,7 @@
 package org.apache.parquet.hadoop.util;
 
 import org.apache.hadoop.fs.ByteBufferReadable;
+import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.parquet.io.PositionOutputStream;
@@ -27,7 +28,10 @@ import org.apache.parquet.io.SeekableInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.util.Objects;
 
 /**
@@ -36,6 +40,39 @@ import java.util.Objects;
 public class HadoopStreams {
 
   private static final Logger LOG = LoggerFactory.getLogger(HadoopStreams.class);
+
+  private static final Class<?> byteBufferReadableClass = getReadableClass();
+  static final Constructor<SeekableInputStream> h2SeekableConstructor = getH2SeekableConstructor();
+
+  private static Class<?> getReadableClass() {
+    try {
+      return Class.forName("org.apache.hadoop.fs.ByteBufferReadable");
+    } catch (ClassNotFoundException | NoClassDefFoundError e) {
+      return null;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Class<SeekableInputStream> getH2SeekableClass() {
+    try {
+      return (Class<SeekableInputStream>) Class.forName(
+        "org.apache.parquet.hadoop.util.H2SeekableInputStream");
+    } catch (ClassNotFoundException | NoClassDefFoundError e) {
+      return null;
+    }
+  }
+
+  private static Constructor<SeekableInputStream> getH2SeekableConstructor() {
+    Class<SeekableInputStream> h2SeekableClass = getH2SeekableClass();
+    if (h2SeekableClass != null) {
+      try {
+        return h2SeekableClass.getConstructor(FSDataInputStream.class);
+      } catch (NoSuchMethodException e) {
+        return null;
+      }
+    }
+    return null;
+  }
 
   /**
    * Wraps a {@link FSDataInputStream} in a {@link SeekableInputStream}
@@ -46,21 +83,60 @@ public class HadoopStreams {
    */
   public static SeekableInputStream wrap(FSDataInputStream stream) {
     Objects.requireNonNull(stream, "Cannot wrap a null input stream");
-    if (isWrappedStreamByteBufferReadable(stream)) {
-      return new H2SeekableInputStream(stream);
-    } else {
-      return new H1SeekableInputStream(stream);
+
+    // Try to check using hasCapabilities(str)
+    Boolean hasCapabilitiesResult = isWrappedStreamByteBufferReadableHasCapabilities(stream);
+
+    // If it is null, then fall back to the old method
+    if (hasCapabilitiesResult != null) {
+      if (hasCapabilitiesResult) {
+        return new H2SeekableInputStream(stream);
+      } else {
+        return new H1SeekableInputStream(stream);
+      }
     }
+
+    return isWrappedStreamByteBufferReadableLegacy(stream);
   }
 
   /**
    * Is the inner stream byte buffer readable?
-   * The test is "the stream is not FSDataInputStream
+   * The test is 'the stream is not FSDataInputStream
+   * and implements ByteBufferReadable'
+   *
+   * This logic is only used for Hadoop <2.9.x, and <3.x.x
+   *
+   * @param stream stream to probe
+   * @return A H2SeekableInputStream to access, or H1SeekableInputStream if the stream is not seekable
+   */
+  private static SeekableInputStream isWrappedStreamByteBufferReadableLegacy(FSDataInputStream stream) {
+    InputStream wrapped = stream.getWrappedStream();
+    if (wrapped instanceof FSDataInputStream) {
+      LOG.debug("Checking on wrapped stream {} of {} whether is ByteBufferReadable", wrapped, stream);
+      return isWrappedStreamByteBufferReadableLegacy(((FSDataInputStream) wrapped));
+    }
+    if (byteBufferReadableClass != null && h2SeekableConstructor != null &&
+      byteBufferReadableClass.isInstance(stream.getWrappedStream())) {
+      try {
+        return h2SeekableConstructor.newInstance(stream);
+      } catch (InstantiationException | IllegalAccessException e) {
+        LOG.warn("Could not instantiate H2SeekableInputStream, falling back to byte array reads", e);
+      } catch (InvocationTargetException e) {
+        throw new ParquetDecodingException(
+          "Could not instantiate H2SeekableInputStream", e.getTargetException());
+      }
+    }
+    return new H1SeekableInputStream(stream);
+  }
+
+  /**
+   * Is the inner stream byte buffer readable?
+   * The test is 'the stream is not FSDataInputStream
    * and implements ByteBufferReadable'
    *
    * That is: all streams which implement ByteBufferReadable
-   * other than FSDataInputStream successfuly support read(ByteBuffer).
-   * This is true for all filesytem clients the hadoop codebase.
+   * other than FSDataInputStream successfully support read(ByteBuffer).
+   * This is true for all filesystem clients the hadoop codebase.
    *
    * In hadoop 3.3.0+, the StreamCapabilities probe can be used to
    * check this: only those streams which provide the read(ByteBuffer)
@@ -68,19 +144,30 @@ public class HadoopStreams {
    * FSDataInputStream will pass the probe down to the underlying stream.
    *
    * @param stream stream to probe
-   * @return true if it is safe to a H2SeekableInputStream to access the data
+   * @return true if it is safe to a H2SeekableInputStream to access
+   *         the data, null when it cannot be determined
    */
-  private static boolean isWrappedStreamByteBufferReadable(FSDataInputStream stream) {
-    if (stream.hasCapability("in:readbytebuffer")) {
-      // stream is issuing the guarantee that it implements the
-      // API. Holds for all implementations in hadoop-*
-      // since Hadoop 3.3.0 (HDFS-14111).
-      return true;
+  private static Boolean isWrappedStreamByteBufferReadableHasCapabilities(FSDataInputStream stream) {
+    Method methodHasCapabilities;
+    try {
+      methodHasCapabilities = stream.getClass().getMethod("hasCapability", String.class);
+    } catch (Exception e) {
+      return null;
+    }
+    try {
+      if ((Boolean) methodHasCapabilities.invoke(stream, "in:readbytebuffer")) {
+        // stream is issuing the guarantee that it implements the
+        // API. Holds for all implementations in hadoop-*
+        // since Hadoop 3.3.0 (HDFS-14111).
+        return true;
+      }
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      return null;
     }
     InputStream wrapped = stream.getWrappedStream();
     if (wrapped instanceof FSDataInputStream) {
       LOG.debug("Checking on wrapped stream {} of {} whether is ByteBufferReadable", wrapped, stream);
-      return isWrappedStreamByteBufferReadable(((FSDataInputStream) wrapped));
+      return isWrappedStreamByteBufferReadableHasCapabilities(((FSDataInputStream) wrapped));
     }
     return wrapped instanceof ByteBufferReadable;
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopStreams.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopStreams.java
@@ -20,18 +20,15 @@
 package org.apache.parquet.hadoop.util;
 
 import org.apache.hadoop.fs.ByteBufferReadable;
-import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.parquet.io.PositionOutputStream;
 import org.apache.parquet.io.SeekableInputStream;
+import org.apache.parquet.util.DynMethods;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.io.InputStream;
-import java.lang.reflect.Method;
 import java.util.Objects;
 
 /**
@@ -41,38 +38,12 @@ public class HadoopStreams {
 
   private static final Logger LOG = LoggerFactory.getLogger(HadoopStreams.class);
 
-  private static final Class<?> byteBufferReadableClass = getReadableClass();
-  static final Constructor<SeekableInputStream> h2SeekableConstructor = getH2SeekableConstructor();
-
-  private static Class<?> getReadableClass() {
-    try {
-      return Class.forName("org.apache.hadoop.fs.ByteBufferReadable");
-    } catch (ClassNotFoundException | NoClassDefFoundError e) {
-      return null;
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Class<SeekableInputStream> getH2SeekableClass() {
-    try {
-      return (Class<SeekableInputStream>) Class.forName(
-        "org.apache.parquet.hadoop.util.H2SeekableInputStream");
-    } catch (ClassNotFoundException | NoClassDefFoundError e) {
-      return null;
-    }
-  }
-
-  private static Constructor<SeekableInputStream> getH2SeekableConstructor() {
-    Class<SeekableInputStream> h2SeekableClass = getH2SeekableClass();
-    if (h2SeekableClass != null) {
-      try {
-        return h2SeekableClass.getConstructor(FSDataInputStream.class);
-      } catch (NoSuchMethodException e) {
-        return null;
-      }
-    }
-    return null;
-  }
+  private static final DynMethods.UnboundMethod hasCapabilitiesMethod =
+    new DynMethods
+      .Builder("hasCapabilities")
+      .impl(FSDataInputStream.class, "hasCapabilities", String.class)
+      .orNoop()
+      .build();
 
   /**
    * Wraps a {@link FSDataInputStream} in a {@link SeekableInputStream}
@@ -115,18 +86,11 @@ public class HadoopStreams {
       LOG.debug("Checking on wrapped stream {} of {} whether is ByteBufferReadable", wrapped, stream);
       return isWrappedStreamByteBufferReadableLegacy(((FSDataInputStream) wrapped));
     }
-    if (byteBufferReadableClass != null && h2SeekableConstructor != null &&
-      byteBufferReadableClass.isInstance(stream.getWrappedStream())) {
-      try {
-        return h2SeekableConstructor.newInstance(stream);
-      } catch (InstantiationException | IllegalAccessException e) {
-        LOG.warn("Could not instantiate H2SeekableInputStream, falling back to byte array reads", e);
-      } catch (InvocationTargetException e) {
-        throw new ParquetDecodingException(
-          "Could not instantiate H2SeekableInputStream", e.getTargetException());
-      }
+    if (stream.getWrappedStream() instanceof ByteBufferReadable) {
+      return new H2SeekableInputStream(stream);
+    } else {
+      return new H1SeekableInputStream(stream);
     }
-    return new H1SeekableInputStream(stream);
   }
 
   /**
@@ -145,24 +109,21 @@ public class HadoopStreams {
    *
    * @param stream stream to probe
    * @return true if it is safe to a H2SeekableInputStream to access
-   *         the data, null when it cannot be determined
+   * the data, null when it cannot be determined because of missing hasCapabilities
    */
   private static Boolean isWrappedStreamByteBufferReadableHasCapabilities(FSDataInputStream stream) {
-    Method methodHasCapabilities;
-    try {
-      methodHasCapabilities = stream.getClass().getMethod("hasCapability", String.class);
-    } catch (Exception e) {
+    if (hasCapabilitiesMethod.isNoop()) {
+      // When the method is not available, just return a null
       return null;
     }
-    try {
-      if ((Boolean) methodHasCapabilities.invoke(stream, "in:readbytebuffer")) {
-        // stream is issuing the guarantee that it implements the
-        // API. Holds for all implementations in hadoop-*
-        // since Hadoop 3.3.0 (HDFS-14111).
-        return true;
-      }
-    } catch (IllegalAccessException | InvocationTargetException e) {
-      return null;
+
+    Boolean hasCapabilities = hasCapabilitiesMethod.invoke(stream, "in:readbytebuffer");
+
+    if (hasCapabilities) {
+      // stream is issuing the guarantee that it implements the
+      // API. Holds for all implementations in hadoop-*
+      // since Hadoop 3.3.0 (HDFS-14111).
+      return true;
     }
     InputStream wrapped = stream.getWrappedStream();
     if (wrapped instanceof FSDataInputStream) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopStreams.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopStreams.java
@@ -56,7 +56,7 @@ public class HadoopStreams {
     Objects.requireNonNull(stream, "Cannot wrap a null input stream");
 
     // Try to check using hasCapabilities(str)
-    Boolean hasCapabilitiesResult = isWrappedStreamByteBufferReadableHasCapabilities(stream);
+    Boolean hasCapabilitiesResult = isWrappedStreamByteBufferReadable(stream);
 
     // If it is null, then fall back to the old method
     if (hasCapabilitiesResult != null) {
@@ -111,7 +111,7 @@ public class HadoopStreams {
    * @return true if it is safe to a H2SeekableInputStream to access
    * the data, null when it cannot be determined because of missing hasCapabilities
    */
-  private static Boolean isWrappedStreamByteBufferReadableHasCapabilities(FSDataInputStream stream) {
+  private static Boolean isWrappedStreamByteBufferReadable(FSDataInputStream stream) {
     if (hasCapabilitiesMethod.isNoop()) {
       // When the method is not available, just return a null
       return null;
@@ -128,7 +128,7 @@ public class HadoopStreams {
     InputStream wrapped = stream.getWrappedStream();
     if (wrapped instanceof FSDataInputStream) {
       LOG.debug("Checking on wrapped stream {} of {} whether is ByteBufferReadable", wrapped, stream);
-      return isWrappedStreamByteBufferReadableHasCapabilities(((FSDataInputStream) wrapped));
+      return isWrappedStreamByteBufferReadable(((FSDataInputStream) wrapped));
     }
     return wrapped instanceof ByteBufferReadable;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -592,7 +592,7 @@
     <profile>
       <id>hadoop2</id>
       <properties>
-        <hadoop.version>2.9.2</hadoop.version>
+        <hadoop.version>2.7.3</hadoop.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

Complements the work of https://github.com/apache/parquet-mr/pull/951. This PR removes the breaking change that caused Parquet to be incompatible with Hadoop <2.9. In this change, we dynamically check if the `hasCapabilities` method is available, and if this is the case, it will use it. Otherwise, it will fall back to the previous implementation, with the addition that it will also check the wrapped streams.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2276
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
