### PR TITLE
PARQUET-2292: Improve default SpecificRecord model selection for Avro{Write,Read}Support

### DIFF
--- a/parquet-avro/pom.xml
+++ b/parquet-avro/pom.xml
@@ -104,6 +104,30 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.23.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-core</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
@@ -160,7 +160,7 @@ public class AvroParquetWriter<T> extends ParquetWriter<T> {
 
   public static class Builder<T> extends ParquetWriter.Builder<T, Builder<T>> {
     private Schema schema = null;
-    private GenericData model = SpecificData.get();
+    private GenericData model = null;
 
     private Builder(Path file) {
       super(file);

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -30,12 +30,15 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.LinkedHashMap;
+import java.util.Objects;
+
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Conversion;
 import org.apache.avro.LogicalType;
@@ -57,6 +60,8 @@ import org.apache.parquet.io.api.GroupConverter;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.avro.SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE;
 import static org.apache.avro.SchemaCompatibility.checkReaderWriterCompatibility;
@@ -72,6 +77,8 @@ import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
  * @param <T> a subclass of Avro's IndexedRecord
  */
 class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AvroRecordConverter.class);
 
   private static final String STRINGABLE_PROP = "avro.java.string";
   private static final String JAVA_CLASS_PROP = "java-class";
@@ -167,6 +174,77 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
       // use this.model because model may be null
       recordDefaults.put(field, this.model.getDefaultValue(field));
     }
+  }
+
+  /**
+   * Returns the specific data model for a given SpecificRecord schema by reflecting the underlying
+   * Avro class's `MODEL$` field, or Null if the class is not on the classpath or reflection fails.
+   */
+  static SpecificData getModelForSchema(Schema schema) {
+    final Class<?> clazz;
+
+    if (schema != null && (schema.getType() == Schema.Type.RECORD || schema.getType() == Schema.Type.UNION)) {
+      clazz = SpecificData.get().getClass(schema);
+    } else {
+      return null;
+    }
+
+    // If clazz == null, the underlying Avro class for the schema is not on the classpath
+    if (clazz == null) {
+      return null;
+    }
+
+    final SpecificData model;
+    try {
+      final Field modelField = clazz.getDeclaredField("MODEL$");
+      modelField.setAccessible(true);
+
+      model = (SpecificData) modelField.get(null);
+    } catch (NoSuchFieldException e) {
+      LOG.info(String.format(
+        "Generated Avro class %s did not contain a MODEL$ field. Parquet will use default SpecificData model for " +
+          "reading and writing.", clazz));
+      return null;
+    } catch (IllegalAccessException e) {
+      LOG.warn(String.format(
+        "Field `MODEL$` in class %s was inaccessible. Parquet will use default SpecificData model for " +
+          "reading and writing.", clazz), e);
+      return null;
+    }
+
+    final String avroVersion = getRuntimeAvroVersion();
+    // Avro 1.7 and 1.8 don't include conversions in the MODEL$ field by default
+    if (avroVersion != null && (avroVersion.startsWith("1.8.") || avroVersion.startsWith("1.7."))) {
+      final Field conversionsField;
+      try {
+        conversionsField = clazz.getDeclaredField("conversions");
+      } catch (NoSuchFieldException e) {
+        // Avro classes without logical types (denoted by the "conversions" field) can be returned as-is
+        return model;
+      }
+
+      final Conversion<?>[] conversions;
+      try {
+        conversionsField.setAccessible(true);
+        conversions = (Conversion<?>[]) conversionsField.get(null);
+      } catch (IllegalAccessException e) {
+        LOG.warn(String.format("Field `conversions` in class %s was inaccessible. Parquet will use default " +
+          "SpecificData model for reading and writing.", clazz));
+        return null;
+      }
+
+      for (int i = 0; i < conversions.length; i++) {
+        if (conversions[i] != null) {
+          model.addLogicalTypeConversion(conversions[i]);
+        }
+      }
+    }
+
+    return model;
+  }
+
+  static String getRuntimeAvroVersion() {
+    return Schema.Parser.class.getPackage().getImplementationVersion();
   }
 
   // this was taken from Avro's ReflectData

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
@@ -43,6 +43,8 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.parquet.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Avro implementation of {@link WriteSupport} for generic, specific, and
@@ -50,6 +52,8 @@ import org.apache.parquet.Preconditions;
  * {@link AvroParquetOutputFormat} rather than using this class directly.
  */
 public class AvroWriteSupport<T> extends WriteSupport<T> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AvroWriteSupport.class);
 
   public static final String AVRO_DATA_SUPPLIER = "parquet.avro.write.data.supplier";
 
@@ -131,7 +135,7 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
     }
 
     if (model == null) {
-      this.model = getDataModel(configuration);
+      this.model = getDataModel(configuration, rootAvroSchema);
     }
 
     boolean writeOldListStructure = configuration.getBoolean(
@@ -400,7 +404,23 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
     return Binary.fromCharSequence(value.toString());
   }
 
-  private static GenericData getDataModel(Configuration conf) {
+  private static GenericData getDataModel(Configuration conf, Schema schema) {
+    if (conf.get(AVRO_DATA_SUPPLIER) == null && schema != null) {
+      GenericData modelForSchema;
+      try {
+        modelForSchema = AvroRecordConverter.getModelForSchema(schema);
+      } catch (Exception e) {
+        LOG.warn(String.format("Failed to derive data model for Avro schema %s. Parquet will use default " +
+          "SpecificData model for writing to sink.", schema), e);
+        modelForSchema = null;
+      }
+
+
+      if (modelForSchema != null) {
+        return modelForSchema;
+      }
+    }
+
     Class<? extends AvroDataSupplier> suppClass = conf.getClass(
         AVRO_DATA_SUPPLIER, SpecificDataSupplier.class, AvroDataSupplier.class);
     return ReflectionUtils.newInstance(suppClass, conf).get();

--- a/parquet-avro/src/test/avro/logicalType.avsc
+++ b/parquet-avro/src/test/avro/logicalType.avsc
@@ -1,0 +1,14 @@
+{
+    "type": "record",
+    "name": "LogicalTypesTest",
+    "namespace": "org.apache.parquet.avro",
+    "doc": "Record for testing logical types",
+    "fields": [
+        {
+          "name": "timestamp",
+          "type": {
+            "type": "long", "logicalType": "timestamp-millis"
+          }
+        }
+    ]
+}

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.avro;
+
+import com.google.common.collect.Lists;
+import org.apache.avro.Conversion;
+import org.apache.avro.Conversions;
+import org.apache.avro.Schema;
+import org.apache.avro.data.TimeConversions;
+import org.apache.avro.specific.SpecificData;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AvroRecordConverter.class)
+public class TestAvroRecordConverter {
+
+  @Before
+  public void setup() {
+    // Default to calling real methods unless overridden in specific test
+    PowerMockito.mockStatic(AvroRecordConverter.class, CALLS_REAL_METHODS);
+  }
+
+  @Test
+  public void testModelForSpecificRecordWithLogicalTypes() {
+    SpecificData model = AvroRecordConverter.getModelForSchema(LogicalTypesTest.SCHEMA$);
+
+    // Test that model is generated correctly
+    Conversion<?> conversion = model.getConversionByClass(Instant.class);
+    assertEquals(TimeConversions.TimestampMillisConversion.class, conversion.getClass());
+  }
+
+  @Test
+  public void testModelForSpecificRecordWithoutLogicalTypes() {
+    SpecificData model = AvroRecordConverter.getModelForSchema(Car.SCHEMA$);
+
+    assertTrue(model.getConversions().isEmpty());
+  }
+
+  @Test
+  public void testModelForGenericRecord() {
+    SpecificData model = AvroRecordConverter.getModelForSchema(
+      Schema.createRecord(
+        "someSchema",
+        "doc",
+        "some.namespace",
+        false,
+        Lists.newArrayList(new Schema.Field("strField", Schema.create(Schema.Type.STRING)))));
+
+    // There is no class "someSchema" on the classpath, so should return null
+    assertNull(model);
+  }
+
+  // Test logical type support for older Avro versions
+  @Test
+  public void testGetModelAvro1_7() {
+    Mockito.when(AvroRecordConverter.getRuntimeAvroVersion()).thenReturn("1.7.7");
+
+    // Test that model is generated correctly
+    final SpecificData model = AvroRecordConverter.getModelForSchema(Avro17GeneratedClass.SCHEMA$);
+    Conversion<?> conversion = model.getConversionByClass(BigDecimal.class);
+    assertEquals(Conversions.DecimalConversion.class, conversion.getClass());
+  }
+
+  @Test
+  public void testGetModelAvro1_8() {
+    Mockito.when(AvroRecordConverter.getRuntimeAvroVersion()).thenReturn("1.8.2");
+
+    // Test that model is generated correctly
+    final SpecificData model = AvroRecordConverter.getModelForSchema(Avro18GeneratedClass.SCHEMA$);
+    Conversion<?> conversion = model.getConversionByClass(BigDecimal.class);
+    assertEquals(Conversions.DecimalConversion.class, conversion.getClass());
+  }
+
+  @Test
+  public void testGetModelAvro1_9() {
+    Mockito.when(AvroRecordConverter.getRuntimeAvroVersion()).thenReturn("1.9.2");
+
+    // Test that model is generated correctly
+    final SpecificData model = AvroRecordConverter.getModelForSchema(Avro19GeneratedClass.SCHEMA$);
+    Conversion<?> conversion = model.getConversionByClass(BigDecimal.class);
+    assertEquals(Conversions.DecimalConversion.class, conversion.getClass());
+  }
+
+  @Test
+  public void testGetModelAvro1_10() {
+    Mockito.when(AvroRecordConverter.getRuntimeAvroVersion()).thenReturn("1.10.2");
+
+    // Test that model is generated correctly
+    final SpecificData model = AvroRecordConverter.getModelForSchema(Avro110GeneratedClass.SCHEMA$);
+    Conversion<?> conversion = model.getConversionByClass(BigDecimal.class);
+    assertEquals(Conversions.DecimalConversion.class, conversion.getClass());
+  }
+
+  // Test Avro record class stubs, generated using different versions of the Avro compiler
+  public abstract static class Avro110GeneratedClass extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
+    private static final long serialVersionUID = 5558880508010468207L;
+    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro110GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
+
+    public static org.apache.avro.Schema getClassSchema() {
+      return SCHEMA$;
+    }
+
+    private static SpecificData MODEL$ = new SpecificData();
+
+    static {
+      MODEL$.addLogicalTypeConversion(new org.apache.avro.Conversions.DecimalConversion());
+    }
+  }
+
+  public abstract static class Avro19GeneratedClass extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
+    private static final long serialVersionUID = 5558880508010468207L;
+    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro19GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
+
+    public static org.apache.avro.Schema getClassSchema() {
+      return SCHEMA$;
+    }
+
+    private static SpecificData MODEL$ = new SpecificData();
+
+    static {
+      MODEL$.addLogicalTypeConversion(new org.apache.avro.Conversions.DecimalConversion());
+    }
+  }
+
+  public abstract static class Avro18GeneratedClass extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
+    private static final long serialVersionUID = 5558880508010468207L;
+    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro18GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
+
+    public static org.apache.avro.Schema getClassSchema() {
+      return SCHEMA$;
+    }
+
+    private static SpecificData MODEL$ = new SpecificData();
+
+    protected static final org.apache.avro.Conversions.DecimalConversion DECIMAL_CONVERSION = new org.apache.avro.Conversions.DecimalConversion();
+
+    private static final org.apache.avro.Conversion<?>[] conversions =
+      new org.apache.avro.Conversion<?>[] {
+        DECIMAL_CONVERSION,
+        null
+      };
+
+    @Override
+    public org.apache.avro.Conversion<?> getConversion(int field) {
+      return conversions[field];
+    }
+  }
+
+  public abstract static class Avro17GeneratedClass extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
+    private static final long serialVersionUID = 5558880508010468207L;
+    public static final org.apache.avro.Schema SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Avro17GeneratedClass\",\"namespace\":\"org.apache.parquet.avro.TestAvroRecordConverter\",\"doc\":\"\",\"fields\":[{\"name\":\"decimal\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}");
+
+    public static org.apache.avro.Schema getClassSchema() {
+      return SCHEMA$;
+    }
+
+    private static SpecificData MODEL$ = new SpecificData();
+
+    protected static final org.apache.avro.Conversions.DecimalConversion DECIMAL_CONVERSION = new org.apache.avro.Conversions.DecimalConversion();
+
+    private static final org.apache.avro.Conversion<?>[] conversions =
+      new org.apache.avro.Conversion<?>[] {
+        DECIMAL_CONVERSION,
+        null
+      };
+
+    @Override
+    public org.apache.avro.Conversion<?> getConversion(int field) {
+      return conversions[field];
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
     <guava.version>27.0.1-jre</guava.version>
     <brotli-codec.version>0.1.1</brotli-codec.version>
     <mockito.version>1.10.19</mockito.version>
+    <powermock.version>2.0.2</powermock.version>
     <net.openhft.version>0.9</net.openhft.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <yetus.audience-annotations.version>0.13.0</yetus.audience-annotations.version>


### PR DESCRIPTION
Per discussion here https://lists.apache.org/thread/0qmwj33vohxymsfc1tw1f3141zrn62yp

### Jira

- [z] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
