### PR TITLE
PARQUET-2171. Implement vectored IO in parquet file format

### DIFF
--- a/parquet-common/src/main/java/org/apache/parquet/io/ParquetFileRange.java
+++ b/parquet-common/src/main/java/org/apache/parquet/io/ParquetFileRange.java
@@ -1,0 +1,71 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.io;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Class to define a file range for a parquet file and to
+ * hold future data for any ongoing read for that range.
+ */
+public class ParquetFileRange {
+
+  /**
+   * Start position in file.
+   */
+  private final long offset;
+
+  /**
+   * Length of data to be read from position.
+   */
+  private final int length;
+
+  /**
+   * A future object to hold future for ongoing read.
+   */
+  private CompletableFuture<ByteBuffer> dataReadFuture;
+
+  public ParquetFileRange(long offset, int length) {
+    this.offset = offset;
+    this.length = length;
+  }
+
+  public long getOffset() {
+    return offset;
+  }
+
+  public int getLength() {
+    return length;
+  }
+
+  public CompletableFuture<ByteBuffer> getDataReadFuture() {
+    return dataReadFuture;
+  }
+
+  public void setDataReadFuture(CompletableFuture<ByteBuffer> dataReadFuture) {
+    this.dataReadFuture = dataReadFuture;
+  }
+
+  @Override
+  public String toString() {
+    return "range[" + this.offset + "," + (this.offset + (long)this.length) + ")";
+  }
+}

--- a/parquet-common/src/main/java/org/apache/parquet/io/SeekableInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/io/SeekableInputStream.java
@@ -23,6 +23,8 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.IntFunction;
 
 /**
  * {@code SeekableInputStream} is an interface with the methods needed by
@@ -104,5 +106,14 @@ public abstract class SeekableInputStream extends InputStream {
    *                      fill the buffer, {@code buf.remaining()}
    */
   public abstract void readFully(ByteBuffer buf) throws IOException;
+
+  /**
+   * Read a set of file ranges in a vectored manner.
+   */
+  public void readVectored(List<ParquetFileRange> ranges,
+                                    IntFunction<ByteBuffer> allocate) throws IOException {
+    throw new IOException(String.format("Vectored io is not supported for %s .",
+      this.getClass().getCanonicalName()));
+  }
 
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
@@ -27,6 +27,7 @@ import org.apache.parquet.crypto.DecryptionPropertiesFactory;
 import org.apache.parquet.crypto.FileDecryptionProperties;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.format.converter.ParquetMetadataConverter.MetadataFilter;
+import org.apache.parquet.hadoop.ParquetInputFormat;
 import org.apache.parquet.hadoop.util.HadoopCodecs;
 
 import java.util.Map;
@@ -37,6 +38,7 @@ import static org.apache.parquet.hadoop.ParquetInputFormat.BLOOM_FILTERING_ENABL
 import static org.apache.parquet.hadoop.ParquetInputFormat.OFF_HEAP_DECRYPT_BUFFER_ENABLED;
 import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
 import static org.apache.parquet.hadoop.ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.HADOOP_VECTORED_IO_ENABLED;
 import static org.apache.parquet.hadoop.ParquetInputFormat.RECORD_FILTERING_ENABLED;
 import static org.apache.parquet.hadoop.ParquetInputFormat.STATS_FILTERING_ENABLED;
 import static org.apache.parquet.hadoop.UnmaterializableRecordCounter.BAD_RECORD_THRESHOLD_CONF_KEY;
@@ -54,6 +56,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
                             boolean usePageChecksumVerification,
                             boolean useBloomFilter,
                             boolean useOffHeapDecryptBuffer,
+                            boolean useHadoopVectoredIO,
                             FilterCompat.Filter recordFilter,
                             MetadataFilter metadataFilter,
                             CompressionCodecFactory codecFactory,
@@ -64,7 +67,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
                             FileDecryptionProperties fileDecryptionProperties) {
     super(
         useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter, useColumnIndexFilter,
-        usePageChecksumVerification, useBloomFilter, useOffHeapDecryptBuffer, recordFilter, metadataFilter, codecFactory, allocator,
+        usePageChecksumVerification, useBloomFilter, useOffHeapDecryptBuffer, useHadoopVectoredIO, recordFilter, metadataFilter, codecFactory, allocator,
         maxAllocationSize, properties, fileDecryptionProperties
     );
     this.conf = conf;
@@ -111,6 +114,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
         usePageChecksumVerification));
       useBloomFilter(conf.getBoolean(BLOOM_FILTERING_ENABLED, true));
       useOffHeapDecryptBuffer(conf.getBoolean(OFF_HEAP_DECRYPT_BUFFER_ENABLED, false));
+      useHadoopVectoredIo(conf.getBoolean(HADOOP_VECTORED_IO_ENABLED, ParquetInputFormat.HADOOP_VECTORED_IO_DEFAULT));
       withCodecFactory(HadoopCodecs.newFactory(conf, 0));
       withRecordFilter(getFilter(conf));
       withMaxAllocationInBytes(conf.getInt(ALLOCATION_SIZE, 8388608));
@@ -128,7 +132,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
       }
       return new HadoopReadOptions(
         useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter,
-        useColumnIndexFilter, usePageChecksumVerification, useBloomFilter, useOffHeapDecryptBuffer, recordFilter, metadataFilter,
+        useColumnIndexFilter, usePageChecksumVerification, useBloomFilter, useOffHeapDecryptBuffer, useHadoopVectoredIo, recordFilter, metadataFilter,
         codecFactory, allocator, maxAllocationSize, properties, conf, fileDecryptionProperties);
     }
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
@@ -41,6 +41,7 @@ public class ParquetReadOptions {
   private static final boolean STATS_FILTERING_ENABLED_DEFAULT = true;
   private static final boolean DICTIONARY_FILTERING_ENABLED_DEFAULT = true;
   private static final boolean COLUMN_INDEX_FILTERING_ENABLED_DEFAULT = true;
+  private static final boolean HADOOP_VECTORED_IO_ENABLED_DEFAULT = false;
   private static final int ALLOCATION_SIZE_DEFAULT = 8388608; // 8MB
   private static final boolean PAGE_VERIFY_CHECKSUM_ENABLED_DEFAULT = false;
   private static final boolean BLOOM_FILTER_ENABLED_DEFAULT = true;
@@ -54,6 +55,7 @@ public class ParquetReadOptions {
   private final boolean usePageChecksumVerification;
   private final boolean useBloomFilter;
   private final boolean useOffHeapDecryptBuffer;
+  private final boolean useHadoopVectoredIO;
   private final FilterCompat.Filter recordFilter;
   private final ParquetMetadataConverter.MetadataFilter metadataFilter;
   private final CompressionCodecFactory codecFactory;
@@ -70,6 +72,7 @@ public class ParquetReadOptions {
                      boolean usePageChecksumVerification,
                      boolean useBloomFilter,
                      boolean useOffHeapDecryptBuffer,
+                     boolean useHadoopVectoredIO,
                      FilterCompat.Filter recordFilter,
                      ParquetMetadataConverter.MetadataFilter metadataFilter,
                      CompressionCodecFactory codecFactory,
@@ -85,6 +88,7 @@ public class ParquetReadOptions {
     this.usePageChecksumVerification = usePageChecksumVerification;
     this.useBloomFilter = useBloomFilter;
     this.useOffHeapDecryptBuffer = useOffHeapDecryptBuffer;
+    this.useHadoopVectoredIO = useHadoopVectoredIO;
     this.recordFilter = recordFilter;
     this.metadataFilter = metadataFilter;
     this.codecFactory = codecFactory;
@@ -124,6 +128,10 @@ public class ParquetReadOptions {
 
   public boolean usePageChecksumVerification() {
     return usePageChecksumVerification;
+  }
+
+  public boolean useHadoopVectoredIO() {
+    return useHadoopVectoredIO;
   }
 
   public FilterCompat.Filter getRecordFilter() {
@@ -173,6 +181,7 @@ public class ParquetReadOptions {
     protected boolean useStatsFilter = STATS_FILTERING_ENABLED_DEFAULT;
     protected boolean useDictionaryFilter = DICTIONARY_FILTERING_ENABLED_DEFAULT;
     protected boolean useRecordFilter = RECORD_FILTERING_ENABLED_DEFAULT;
+    protected boolean useHadoopVectoredIo = HADOOP_VECTORED_IO_ENABLED_DEFAULT;
     protected boolean useColumnIndexFilter = COLUMN_INDEX_FILTERING_ENABLED_DEFAULT;
     protected boolean usePageChecksumVerification = PAGE_VERIFY_CHECKSUM_ENABLED_DEFAULT;
     protected boolean useBloomFilter = BLOOM_FILTER_ENABLED_DEFAULT;
@@ -223,6 +232,11 @@ public class ParquetReadOptions {
 
     public Builder useRecordFilter() {
       this.useRecordFilter = true;
+      return this;
+    }
+
+    public Builder useHadoopVectoredIo(boolean useHadoopVectoredIo) {
+      this.useHadoopVectoredIo = useHadoopVectoredIo;
       return this;
     }
 
@@ -320,6 +334,7 @@ public class ParquetReadOptions {
       useDictionaryFilter(options.useDictionaryFilter);
       useRecordFilter(options.useRecordFilter);
       withRecordFilter(options.recordFilter);
+      useHadoopVectoredIo(options.useHadoopVectoredIO);
       withMetadataFilter(options.metadataFilter);
       withCodecFactory(options.codecFactory);
       withAllocator(options.allocator);
@@ -338,7 +353,7 @@ public class ParquetReadOptions {
 
       return new ParquetReadOptions(
         useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter,
-        useColumnIndexFilter, usePageChecksumVerification, useBloomFilter, useOffHeapDecryptBuffer, recordFilter, metadataFilter,
+        useColumnIndexFilter, usePageChecksumVerification, useBloomFilter, useOffHeapDecryptBuffer, useHadoopVectoredIo, recordFilter, metadataFilter,
         codecFactory, allocator, maxAllocationSize, properties, fileDecryptionProperties);
     }
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -125,6 +125,16 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
   public static final String STATS_FILTERING_ENABLED = "parquet.filter.stats.enabled";
 
   /**
+   * Key to enable/disable vectored io while reading parquet files.
+   */
+  public static final String HADOOP_VECTORED_IO_ENABLED = "parquet.hadoop.vectored.io.enabled";
+
+  /**
+   * Default value of parquet.hadoop.vectored.io.enabled is false.
+   */
+  public static final boolean HADOOP_VECTORED_IO_DEFAULT = false;
+
+  /**
    * key to configure whether row group dictionary filtering is enabled
    */
   public static final String DICTIONARY_FILTERING_ENABLED = "parquet.filter.dictionary.enabled";

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/H1SeekableInputStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/H1SeekableInputStream.java
@@ -21,7 +21,14 @@ package org.apache.parquet.hadoop.util;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.parquet.io.DelegatingSeekableInputStream;
+import org.apache.parquet.io.ParquetFileRange;
+
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.IntFunction;
+
+import static org.apache.parquet.hadoop.util.ParquetVectoredIOUtil.readVectoredAndPopulate;
 
 /**
  * SeekableInputStream implementation that implements read(ByteBuffer) for
@@ -56,4 +63,8 @@ class H1SeekableInputStream extends DelegatingSeekableInputStream {
     stream.readFully(bytes, start, len);
   }
 
+  @Override
+  public void readVectored(List<ParquetFileRange> ranges, IntFunction<ByteBuffer> allocate) throws IOException {
+    readVectoredAndPopulate(ranges, allocate, stream);
+  }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/H2SeekableInputStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/H2SeekableInputStream.java
@@ -21,10 +21,15 @@ package org.apache.parquet.hadoop.util;
 
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.parquet.io.DelegatingSeekableInputStream;
+import org.apache.parquet.io.ParquetFileRange;
 
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.IntFunction;
+
+import static org.apache.parquet.hadoop.util.ParquetVectoredIOUtil.readVectoredAndPopulate;
 
 /**
  * SeekableInputStream implementation for FSDataInputStream that implements
@@ -81,6 +86,11 @@ class H2SeekableInputStream extends DelegatingSeekableInputStream {
     public int read(ByteBuffer buf) throws IOException {
       return stream.read(buf);
     }
+  }
+
+  @Override
+  public void readVectored(List<ParquetFileRange> ranges, IntFunction<ByteBuffer> allocate) throws IOException {
+    readVectoredAndPopulate(ranges, allocate, stream);
   }
 
   public static void readFully(Reader reader, ByteBuffer buf) throws IOException {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/ParquetVectoredIOUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/ParquetVectoredIOUtil.java
@@ -1,0 +1,60 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.hadoop.util;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileRange;
+import org.apache.parquet.io.ParquetFileRange;
+
+/**
+ * Utility class to perform vectored IO reads.
+ */
+public class ParquetVectoredIOUtil {
+
+  /**
+   * Read data in a list of file ranges.
+   * @param ranges parquet file ranges.
+   * @param allocate allocate function to allocate memory to hold data.
+   * @param stream stream from where the data has to be read.
+   * @throws IOException any IOE.
+   */
+  public static void readVectoredAndPopulate(final List<ParquetFileRange> ranges,
+                                             final IntFunction<ByteBuffer> allocate,
+                                             final FSDataInputStream stream) throws IOException {
+    // Setting the parquet range as a reference.
+    List<FileRange> fileRanges = ranges.stream()
+      .map(range -> FileRange.createFileRange(range.getOffset(), range.getLength(), range))
+      .collect(Collectors.toList());
+    stream.readVectored(fileRanges, allocate);
+    // As the range has been set above, there shouldn't be
+    // NPE or class cast issues.
+    fileRanges.forEach(fileRange -> {
+      ParquetFileRange parquetFileRange = (ParquetFileRange) fileRange.getReference();
+      parquetFileRange.setDataReadFuture(fileRange.getData());
+    });
+  }
+}


### PR DESCRIPTION
HADOOP-18103 introduced high-performance vector read API in
Hadoop filesystem. This patch integrates the vectored IO API
in ParquetFileReader. Users can enable this by setting
parquet.hadoop.vectored.io.enabled to true for their workload.


Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Made the TestParquetFileWriter test parameterized such that reads can go via vectored IO API as well. 

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
