### PR TITLE
PARQUET-2301 (parquet-1.13.x branch): Add missing argument in ParquetRewriter logging

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -122,7 +122,8 @@ public class ParquetRewriter implements Closeable {
     Configuration conf = options.getConf();
     Path outPath = options.getOutputFile();
     openInputFiles(options.getInputFiles(), conf);
-    LOG.info("Start rewriting {} input files {} to {}", inputFiles.size(), outPath);
+    LOG.info("Start rewriting {} input file(s) {} to {}",
+      inputFiles.size(), options.getInputFiles(), outPath);
 
     // Init reader of the first input file
     initNextReader();


### PR DESCRIPTION
Cherry-pick #1096 to `parquet-1.13.x` branch.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title: https://issues.apache.org/jira/browse/PARQUET-2301

### Tests

- [x] Already covered by existing tests in `ParquetRewriterTest`

Before this PR, the logging message puts the output path directly after `input files`, which is confusing:
```
2023-05-24 17:25:49 INFO ParquetRewriter - Start rewriting 1 input files /var/folders/60/wk8qzx310fd32b2dp7mhzvdc0000gn/T/test6036085754599645014/test.parquet to {}
```
After this PR, the log is fixed:
```
2023-05-24 17:22:16 INFO ParquetRewriter - Start rewriting 1 input file(s) [/var/folders/60/wk8qzx310fd32b2dp7mhzvdc0000gn/T/test1323432776204209385/test.parquet] to /var/folders/60/wk8qzx310fd32b2dp7mhzvdc0000gn/T/test6904487786327536358/test.parquet
```

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] No documentation needed
