### PR TITLE
PARQUET-2318: Implement a tool to list page headers

### DIFF
--- a/parquet-cli/pom.xml
+++ b/parquet-cli/pom.xml
@@ -32,6 +32,53 @@
   <name>Apache Parquet Command-line</name>
   <url>https://parquet.apache.org</url>
 
+  <properties>
+      <deps.scope>provided</deps.scope>
+  </properties>
+
+  <profiles>
+    <!-- Profile to build a standalone uber jar that can be used with "java -jar" without a Hadoop environment -->
+    <profile>
+      <id>local</id>
+      <properties>
+        <deps.scope>compile</deps.scope>
+      </properties>
+      <build>
+        <!-- Required to skip some checking plugins to work. The generated jar will not be part of the distribution anyway. -->
+        <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-banned-dependencies</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>analyze-only</goal>
+                </goals>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.parquet</groupId>
@@ -119,47 +166,47 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>${slf4j.version}</version>
-      <scope>provided</scope>
+      <scope>${deps.scope}</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
-      <scope>provided</scope>
+      <scope>${deps.scope}</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <scope>provided</scope>
+      <scope>${deps.scope}</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <scope>provided</scope>
+      <scope>${deps.scope}</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>${jsr305.version}</version>
-      <scope>provided</scope>
+      <scope>${deps.scope}</scope>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>1.2.17</version>
-      <scope>provided</scope>
+      <scope>${deps.scope}</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.7</version>
-      <scope>provided</scope>
+      <scope>${deps.scope}</scope>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <version>1.1.3</version>
-      <scope>provided</scope>
+      <scope>${deps.scope}</scope>
     </dependency>
   </dependencies>
 
@@ -168,6 +215,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.apache.parquet.cli.Main</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -210,6 +264,10 @@
                   <shadedPattern>${shade.prefix}.org.apache.avro</shadedPattern>
                 </relocation>
               </relocations>
+              <transformers>
+                <!-- Needs to merge Hadoop's FileSystem plugin manifest -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
             </configuration>
           </execution>
         </executions>

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/BaseCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/BaseCommand.java
@@ -250,7 +250,14 @@ public abstract class BaseCommand implements Command, Configurable {
   public Configuration getConf() {
     // In case conf is null, we'll return an empty configuration
     // this can be on a local development machine
-    return null != conf ? conf : new Configuration();
+    return null != conf ? conf : createDefaultConf();
+  }
+
+  private Configuration createDefaultConf() {
+    Configuration conf = new Configuration();
+    // Support reading INT96 by default
+    conf.setBoolean(AvroReadSupport.READ_INT96_AS_FIXED, true);
+    return conf;
   }
 
   /**

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowFooterCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowFooterCommand.java
@@ -19,21 +19,15 @@
 
 package org.apache.parquet.cli.commands;
 
-import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndian;
-import static org.apache.parquet.hadoop.ParquetFileWriter.EFMAGIC;
 import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.cli.BaseCommand;
+import org.apache.parquet.cli.util.RawUtils;
 import org.apache.parquet.format.CliUtils;
-import org.apache.parquet.format.Util;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
@@ -47,7 +41,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
 @Parameters(commandDescription = "Print the Parquet file footer in json format")
 public class ShowFooterCommand extends BaseCommand {
@@ -75,20 +68,12 @@ public class ShowFooterCommand extends BaseCommand {
     String json;
     try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
       ParquetMetadata footer = reader.getFooter();
-      ObjectMapper mapper = createObjectMapper();
+      ObjectMapper mapper = RawUtils.createObjectMapper();
       mapper.setVisibility(PropertyAccessor.ALL, Visibility.NONE);
       mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
       json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(footer);
     }
     return json;
-  }
-
-  private ObjectMapper createObjectMapper() {
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
-    mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
-    mapper.registerModule(new JavaTimeModule());
-    return mapper;
   }
 
   private String readRawFooter(InputFile file) throws IOException {
@@ -100,38 +85,8 @@ public class ShowFooterCommand extends BaseCommand {
     }
 
     try (SeekableInputStream f = file.newStream()) {
-      // Read footer length and magic string - with a single seek
-      byte[] magic = new byte[MAGIC.length];
-      long fileMetadataLengthIndex = fileLen - magic.length - FOOTER_LENGTH_SIZE;
-      f.seek(fileMetadataLengthIndex);
-      int fileMetadataLength = readIntLittleEndian(f);
-      f.readFully(magic);
-
-      if (Arrays.equals(EFMAGIC, magic)) {
-        throw new RuntimeException("Parquet files with encrypted footers are not supported.");
-      } else if (!Arrays.equals(MAGIC, magic)) {
-        throw new RuntimeException(
-            "Not a Parquet file (expected magic number at tail, but found " + Arrays.toString(magic) + ')');
-      }
-
-      long fileMetadataIndex = fileMetadataLengthIndex - fileMetadataLength;
-      if (fileMetadataIndex < magic.length || fileMetadataIndex >= fileMetadataLengthIndex) {
-        throw new RuntimeException("Corrupted file: the footer index is not within the file: " + fileMetadataIndex);
-      }
-      f.seek(fileMetadataIndex);
-
-      ByteBuffer footerBytesBuffer = ByteBuffer.allocate(fileMetadataLength);
-      f.readFully(footerBytesBuffer);
-      footerBytesBuffer.flip();
-      InputStream footerBytesStream = ByteBufferInputStream.wrap(footerBytesBuffer);
-      return prettify(CliUtils.toJson(Util.readFileMetaData(footerBytesStream)));
+      return RawUtils.prettifyJson(CliUtils.toJson(RawUtils.readFooter(f, fileLen)));
     }
-  }
-
-  private String prettify(String json) throws JsonProcessingException {
-    ObjectMapper mapper = createObjectMapper();
-    Object obj = mapper.readValue(json, Object.class);
-    return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
   }
 
   @Override

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/rawpages/RawPagesReader.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/rawpages/RawPagesReader.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.rawpages;
+
+import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
+
+import java.io.IOException;
+
+import org.apache.parquet.cli.util.RawUtils;
+import org.apache.parquet.format.CliUtils;
+import org.apache.parquet.format.ColumnChunk;
+import org.apache.parquet.format.ColumnMetaData;
+import org.apache.parquet.format.FileMetaData;
+import org.apache.parquet.format.PageHeader;
+import org.apache.parquet.format.RowGroup;
+import org.apache.parquet.format.Util;
+import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.SeekableInputStream;
+import org.slf4j.Logger;
+
+public class RawPagesReader implements AutoCloseable {
+
+  private final SeekableInputStream input;
+  private final FileMetaData footer;
+
+  public RawPagesReader(InputFile file) throws IOException {
+    long fileLen = file.getLength();
+
+    if (fileLen < MAGIC.length + 4 + MAGIC.length) {
+      throw new RuntimeException("Not a Parquet file (length is too low: " + fileLen + ")");
+    }
+
+    input = file.newStream();
+    footer = RawUtils.readFooter(input, fileLen);
+  }
+
+  public void listPages(Logger console) throws IOException {
+    for (int i = 0, n = footer.getRow_groupsSize(); i < n; ++i) {
+      RowGroup rowGroup = footer.getRow_groups().get(i);
+      for (ColumnChunk columnChunk : rowGroup.getColumns()) {
+        ColumnMetaData metaData = columnChunk.getMeta_data();
+        String path = String.join(".", metaData.getPath_in_schema());
+        long totalSize = metaData.getTotal_compressed_size();
+        long dictOffset = metaData.getDictionary_page_offset();
+        long seekTo = metaData.getData_page_offset();
+        console.info(
+          "Start of chunk (rowGroup: {}, columnName: {}, dictPageOffset: {}, dataPageOffset: {}, numValues: {}, totalSize: {})",
+          i, path, metaData.isSetDictionary_page_offset() ? dictOffset : "-", seekTo, metaData.getNum_values(),
+          totalSize);
+        if (metaData.isSetDictionary_page_offset() && dictOffset > 0 && dictOffset < seekTo) {
+          seekTo = metaData.getDictionary_page_offset();
+        }
+        input.seek(seekTo);
+        long endPos = seekTo + totalSize;
+        int pageIndex = 0;
+        for (long offset = input.getPos(); offset < endPos; offset = input.getPos()) {
+          PageHeader pageHeader = Util.readPageHeader(input);
+          console.info("Page {}. (offset: {}, headerSize: {})\n{}", pageIndex++, offset, (input.getPos() - offset),
+            RawUtils.prettifyJson(CliUtils.toJson(pageHeader)));
+          input.skip(pageHeader.getCompressed_page_size());
+        }
+        if (input.getPos() != endPos) {
+          console.warn("!!! Current file offset does not match with the total size of the chunk in the footer: {}",
+            input.getPos());
+        } else {
+          console.info("End of chunk (offset: {})", (endPos - 1));
+        }
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    input.close();
+  }
+}

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/util/RawUtils.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/util/RawUtils.java
@@ -41,13 +41,13 @@ public class RawUtils {
 
   private static final ObjectMapper MAPPER = createObjectMapper();
 
-  public static FileMetaData readFooter(SeekableInputStream is, long fileLen) throws IOException {
+  public static FileMetaData readFooter(SeekableInputStream inputStream, long fileLen) throws IOException {
     // Read footer length and magic string - with a single seek
     byte[] magic = new byte[MAGIC.length];
     long fileMetadataLengthIndex = fileLen - magic.length - 4;
-    is.seek(fileMetadataLengthIndex);
-    int fileMetadataLength = readIntLittleEndian(is);
-    is.readFully(magic);
+    inputStream.seek(fileMetadataLengthIndex);
+    int fileMetadataLength = readIntLittleEndian(inputStream);
+    inputStream.readFully(magic);
 
     if (Arrays.equals(EFMAGIC, magic)) {
       throw new RuntimeException("Parquet files with encrypted footers are not supported.");
@@ -58,12 +58,12 @@ public class RawUtils {
 
     long fileMetadataIndex = fileMetadataLengthIndex - fileMetadataLength;
     if (fileMetadataIndex < magic.length || fileMetadataIndex >= fileMetadataLengthIndex) {
-      throw new RuntimeException("Corrupted file: the footer index is not within the file: " + fileMetadataIndex);
+      throw new RuntimeException("Corrupted file: the footer index inputStream not within the file: " + fileMetadataIndex);
     }
-    is.seek(fileMetadataIndex);
+    inputStream.seek(fileMetadataIndex);
 
     ByteBuffer footerBytesBuffer = ByteBuffer.allocate(fileMetadataLength);
-    is.readFully(footerBytesBuffer);
+    inputStream.readFully(footerBytesBuffer);
     footerBytesBuffer.flip();
     InputStream footerBytesStream = ByteBufferInputStream.wrap(footerBytesBuffer);
     return Util.readFileMetaData(footerBytesStream);

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/util/RawUtils.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/util/RawUtils.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.util;
+
+import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndian;
+import static org.apache.parquet.hadoop.ParquetFileWriter.EFMAGIC;
+import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.format.FileMetaData;
+import org.apache.parquet.format.Util;
+import org.apache.parquet.io.SeekableInputStream;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class RawUtils {
+
+  private static final ObjectMapper MAPPER = createObjectMapper();
+
+  public static FileMetaData readFooter(SeekableInputStream is, long fileLen) throws IOException {
+    // Read footer length and magic string - with a single seek
+    byte[] magic = new byte[MAGIC.length];
+    long fileMetadataLengthIndex = fileLen - magic.length - 4;
+    is.seek(fileMetadataLengthIndex);
+    int fileMetadataLength = readIntLittleEndian(is);
+    is.readFully(magic);
+
+    if (Arrays.equals(EFMAGIC, magic)) {
+      throw new RuntimeException("Parquet files with encrypted footers are not supported.");
+    } else if (!Arrays.equals(MAGIC, magic)) {
+      throw new RuntimeException(
+        "Not a Parquet file (expected magic number at tail, but found " + Arrays.toString(magic) + ')');
+    }
+
+    long fileMetadataIndex = fileMetadataLengthIndex - fileMetadataLength;
+    if (fileMetadataIndex < magic.length || fileMetadataIndex >= fileMetadataLengthIndex) {
+      throw new RuntimeException("Corrupted file: the footer index is not within the file: " + fileMetadataIndex);
+    }
+    is.seek(fileMetadataIndex);
+
+    ByteBuffer footerBytesBuffer = ByteBuffer.allocate(fileMetadataLength);
+    is.readFully(footerBytesBuffer);
+    footerBytesBuffer.flip();
+    InputStream footerBytesStream = ByteBufferInputStream.wrap(footerBytesBuffer);
+    return Util.readFileMetaData(footerBytesStream);
+  }
+
+  public static String prettifyJson(String json) throws JsonProcessingException {
+    ObjectMapper mapper = MAPPER;
+    Object obj = mapper.readValue(json, Object.class);
+    return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+  }
+
+  public static ObjectMapper createObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+    mapper.registerModule(new JavaTimeModule());
+    return mapper;
+  }
+}


### PR DESCRIPTION
Implemented a new tool to retrieve the original Thrift page headers (in json format). It is attached to the existing command "pages" with the options "--raw".
Additional changes:
- Added default Hadoop configuration to support reading INT96 values
- Added the profile "local" to parquet-cli so a standalone jar can be generated which does not need a Hadoop environment to be used

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
