### PR TITLE
PARQUET-2325: Fix parquet-cli's dictionary subcommand to work with FIXED_LEN_BYTE_ARRAY

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowDictionaryCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowDictionaryCommand.java
@@ -98,6 +98,7 @@ public class ShowDictionaryCommand extends BaseCommand {
     for (int i = 0; i <= dict.getMaxId(); i += 1) {
       switch(type.getPrimitiveTypeName()) {
         case BINARY:
+        case FIXED_LEN_BYTE_ARRAY:
           if (type.getLogicalTypeAnnotation() instanceof LogicalTypeAnnotation.StringLogicalTypeAnnotation) {
             console.info("{}: {}", String.format("%6d", i),
                     Util.humanReadable(dict.decodeToBinary(i).toStringUsingUTF8(), 70));

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowDictionaryCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowDictionaryCommandTest.java
@@ -47,4 +47,14 @@ public class ShowDictionaryCommandTest extends ParquetFileTest {
     command.setConf(new Configuration());
     Assert.assertEquals(0, command.run());
   }
+
+  @Test
+  public void testShowDirectoryCommandForFixedLengthByteArray() throws IOException {
+    File file = parquetFile();
+    ShowDictionaryCommand command = new ShowDictionaryCommand(createLogger());
+    command.targets = Arrays.asList(file.getAbsolutePath());
+    command.column = FIXED_LEN_BYTE_ARRAY_FIELD;
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2325
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

o.a.parquet.cli.commands.ShowDictionaryCommandTest#testShowDirectoryCommandForFixedLengthByteArray

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
