### PR TITLE
PARQUET-2326: Bump jcommander from 1.72 to 1.82

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/Help.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/Help.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.cli;
 
+import com.beust.jcommander.DefaultUsageFormatter;
+import com.beust.jcommander.IUsageFormatter;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterDescription;
@@ -33,11 +35,13 @@ public class Help implements Command {
 
   private final JCommander jc;
   private final Logger console;
+  private final IUsageFormatter formatter;
   private String programName;
 
   public Help(JCommander jc, Logger console) {
     this.jc = jc;
     this.console = console;
+    this.formatter = new DefaultUsageFormatter(jc);
   }
 
   public void setProgramName(String programName) {
@@ -67,7 +71,7 @@ public class Help implements Command {
             new Object[] { programName, cmd });
         }
         console.info("\n  Description:");
-        console.info("\n    {}", jc.getCommandDescription(cmd));
+        console.info("\n    {}", formatter.getCommandDescription(cmd));
         if (!commander.getParameters().isEmpty()) {
           console.info("\n  Command options:\n");
           for (ParameterDescription param : commander.getParameters()) {
@@ -112,7 +116,7 @@ public class Help implements Command {
     console.info("\n  Commands:\n");
     for (String command : jc.getCommands().keySet()) {
       console.info("    {}\n\t{}",
-          command, jc.getCommandDescription(command));
+          command, formatter.getCommandDescription(command));
     }
 
     jc.getCommands().keySet().stream().filter(s -> !s.equals("help")).findFirst().ifPresent(command -> {

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 
     <!-- parquet-cli dependencies -->
     <opencsv.version>2.3</opencsv.version>
-    <jcommander.version>1.72</jcommander.version>
+    <jcommander.version>1.82</jcommander.version>
     <zstd-jni.version>1.5.0-1</zstd-jni.version>
     <commons-text.version>1.8</commons-text.version>
     <jsr305.version>3.0.2</jsr305.version>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2326
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

A similar PR already exists (#1086) but it's not sufficient due to the API incompatibilities on the jcommander side.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test since it's just a dependency upgrade. I ensured all of the existing tests succeeded with `mvn clean install -f parquet-cli/pom.xml`.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
