### PR TITLE
PARQUET-2329: Fix wrong help messages of parquet-cli subcommands

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ConvertCSVCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ConvertCSVCommand.java
@@ -194,11 +194,9 @@ public class ConvertCSVCommand extends BaseCommand {
   public List<String> getExamples() {
     return Lists.newArrayList(
         "# Create a Parquet file from a CSV file",
-        "sample.csv sample.parquet --schema schema.avsc",
+        "sample.csv -o sample.parquet --schema schema.avsc",
         "# Create a Parquet file in HDFS from local CSV",
-        "path/to/sample.csv hdfs:/user/me/sample.parquet --schema schema.avsc",
-        "# Create an Avro file from CSV data in S3",
-        "s3:/data/path/sample.csv sample.avro --format avro --schema s3:/schemas/schema.avsc"
+        "path/to/sample.csv -o hdfs:/user/me/sample.parquet --schema schema.avsc"
     );
   }
 }

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/RewriteCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/RewriteCommand.java
@@ -62,7 +62,7 @@ public class RewriteCommand extends BaseCommand {
 
   @Parameter(
           names = {"--prune-columns"},
-          description = "<columns to be replaced with masked value>",
+          description = "<columns to be removed>",
           required = false)
   List<String> pruneColumns;
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2329
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

No additional test, since it's just a fix for the help messages. Instead, I manually ensured that parquet-cli was successfully built and it printed out the help messages expected with this PR.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
