### PR TITLE
PARQUET-2330: Fix convert-csv to show the correct position of the invalid record

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ConvertCSVCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ConvertCSVCommand.java
@@ -181,6 +181,7 @@ public class ConvertCSVCommand extends BaseCommand {
           .build()) {
         for (Record record : reader) {
           writer.write(record);
+          count++;
         }
       } catch (RuntimeException e) {
         throw new RuntimeException("Failed on record " + count, e);


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2330
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I think this fix is so simple and explicit that it doesn't need an additional test. Instead, I ran the fixed version of this command manually and ensured that it showed the correct position of the invalid record.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
