### PR TITLE
Remove redundant code

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/MemoryManager.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/MemoryManager.java
@@ -119,11 +119,6 @@ public class MemoryManager {
       }
     }
 
-    int maxColCount = 0;
-    for (InternalParquetRecordWriter<?> w : writerList.keySet()) {
-      maxColCount = Math.max(w.getSchema().getColumns().size(), maxColCount);
-    }
-
     for (Map.Entry<InternalParquetRecordWriter<?>, Long> entry : writerList
         .entrySet()) {
       long newSize = (long) Math.floor(entry.getValue() * scale);


### PR DESCRIPTION
There has redundant code in **org.apache.parquet.hadoop.MemoryManager,** method **updateAllocation** calculate _**maxColCount**_ but not use. So I think we can remove it to improve performance.
