### PR TITLE
PARQUET-2331: Allow convert-csv to take multiple input files

### DIFF
--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVFileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVFileTest.java
@@ -30,11 +30,17 @@ public abstract class CSVFileTest extends FileTest {
   @Before
   public void setUp() throws IOException {
     createTestCSVFile();
+    createTestCSVFileWithDifferentSchema();
   }
 
   protected File csvFile() {
     File tmpDir = getTempFolder();
     return new File(tmpDir, getClass().getSimpleName() + ".csv");
+  }
+
+  protected File csvFileWithDifferentSchema() {
+    File tmpDir = getTempFolder();
+    return new File(tmpDir, getClass().getSimpleName() + "2.csv");
   }
 
   private void createTestCSVFile() throws IOException {
@@ -46,6 +52,18 @@ public abstract class CSVFileTest extends FileTest {
         Integer.MIN_VALUE, Long.MIN_VALUE, COLORS[0]));
       writer.write(String.format("%d,%d,\"%s\"\n",
         Integer.MAX_VALUE, Long.MAX_VALUE, COLORS[1]));
+    }
+  }
+
+  private void createTestCSVFileWithDifferentSchema() throws IOException {
+    File file = csvFileWithDifferentSchema();
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+      writer.write(String.format("%s,%s,%s\n",
+        FLOAT_FIELD, DOUBLE_FIELD, BINARY_FIELD));
+      writer.write(String.format("%f,%f,\"%s\"\n",
+        Float.MIN_VALUE, Double.MIN_VALUE, COLORS[0]));
+      writer.write(String.format("%f,%f,\"%s\"\n",
+        Float.MAX_VALUE, Double.MAX_VALUE, COLORS[1]));
     }
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCSVCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCSVCommandTest.java
@@ -38,4 +38,28 @@ public class ConvertCSVCommandTest extends CSVFileTest {
     Assert.assertEquals(0, command.run());
     Assert.assertTrue(output.exists());
   }
+
+  @Test
+  public void testConvertCSVCommandWithMultipleInput() throws IOException {
+    File file = csvFile();
+    ConvertCSVCommand command = new ConvertCSVCommand(createLogger());
+    command.targets = Arrays.asList(file.getAbsolutePath(), file.getAbsolutePath());
+    File output = new File(getTempFolder(), getClass().getSimpleName() + ".parquet");
+    command.outputPath = output.getAbsolutePath();
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+    Assert.assertTrue(output.exists());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConvertCSVCommandWithDifferentSchemas() throws IOException {
+    File file = csvFile();
+    File fileWithDifferentSchema = csvFileWithDifferentSchema();
+    ConvertCSVCommand command = new ConvertCSVCommand(createLogger());
+    command.targets = Arrays.asList(file.getAbsolutePath(), fileWithDifferentSchema.getAbsolutePath());
+    File output = new File(getTempFolder(), getClass().getSimpleName() + ".parquet");
+    command.outputPath = output.getAbsolutePath();
+    command.setConf(new Configuration());
+    command.run();
+  }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2331
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR adds the following tests in ConvertCSVCommandTest:

* testConvertCSVCommandWithMultipleInput
* testConvertCSVCommandWithDifferentSchemas

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
