### PR TITLE
PARQUET-2332: Fix unexpectedly disabled tests to be executed

### DIFF
--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
@@ -73,6 +73,7 @@ public class ToAvroCommandTest extends AvroFileTest {
     assert (cmd.run() == 0);
   }
 
+  @Test
   public void testToAvroCommandWithGzipCompression() throws IOException {
     File avroFile = toAvro(parquetFile(), "GZIP");
     Assert.assertTrue(avroFile.exists());

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactoryTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactoryTest.java
@@ -380,6 +380,7 @@ public class DefaultValuesWriterFactoryTest {
       ByteStreamSplitValuesWriter.class);
   }
 
+  @Test
   public void testFloat_V1_WithByteStreamSplitAndDictionary() {
     doTestValueWriter(
       PrimitiveTypeName.FLOAT,
@@ -419,6 +420,7 @@ public class DefaultValuesWriterFactoryTest {
       PlainDoubleDictionaryValuesWriter.class, ByteStreamSplitValuesWriter.class);
   }
 
+  @Test
   public void testColumnWiseDictionaryWithFalseDefault() {
     ValuesWriterFactory factory = getDefaultFactory(WriterVersion.PARQUET_2_0, false,
         "binary_dict",


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2332
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR adds no test, but it enables the following tests by adding `@Test` annotation:

* o.a.parquet.cli.commands.ToAvroCommandTest#testToAvroCommandWithGzipCompression
* o.a.parquet.column.values.factory.DefaultValuesWriterFactoryTest#testFloat_V1_WithByteStreamSplitAndDictionary
* o.a.parquet.column.values.factory.DefaultValuesWriterFactoryTest#testColumnWiseDictionaryWithFalseDefault

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
