### PR TITLE
PARQUET-2333: Support bzip2 and xz compression in the to-avro subcommand

### DIFF
--- a/parquet-cli/pom.xml
+++ b/parquet-cli/pom.xml
@@ -111,6 +111,12 @@
       <version>${avro.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.tukaani</groupId>
+      <artifactId>xz</artifactId>
+      <version>${tukaani.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>
       <version>${zstd-jni.version}</version>

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
@@ -90,6 +90,18 @@ public class ToAvroCommandTest extends AvroFileTest {
     Assert.assertTrue(avroFile.exists());
   }
 
+  @Test
+  public void testToAvroCommandWithBzip2Compression() throws IOException {
+    File avroFile = toAvro(parquetFile(), "bzip2");
+    Assert.assertTrue(avroFile.exists());
+  }
+
+  @Test
+  public void testToAvroCommandWithXzCompression() throws IOException {
+    File avroFile = toAvro(parquetFile(), "xz");
+    Assert.assertTrue(avroFile.exists());
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testToAvroCommandWithInvalidCompression() throws IOException {
     toAvro(parquetFile(), "FOO");

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
     <!-- parquet-cli dependencies -->
     <opencsv.version>2.3</opencsv.version>
     <jcommander.version>1.82</jcommander.version>
+    <tukaani.version>1.9</tukaani.version>
     <zstd-jni.version>1.5.0-1</zstd-jni.version>
     <commons-text.version>1.8</commons-text.version>
     <jsr305.version>3.0.2</jsr305.version>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2333
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

I've newly added the following tests into ToAvroCommandTest:

* testToAvroCommandWithBzip2Compression
* testToAvroCommandWithXzCompression

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
