### PR TITLE
PARQUET-2335: Allow the scan subcommand to take multiple files

### DIFF
--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ScanCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ScanCommandTest.java
@@ -31,8 +31,27 @@ public class ScanCommandTest extends ParquetFileTest {
   public void testScanCommand() throws IOException {
     File file = parquetFile();
     ScanCommand command = new ScanCommand(createLogger());
-    command.sourceFile = file.getAbsolutePath();
+    command.sourceFiles = Arrays.asList(file.getAbsolutePath());
     command.setConf(new Configuration());
     Assert.assertEquals(0, command.run());
+  }
+
+  @Test
+  public void testScanCommandWithMultipleSourceFiles() throws IOException {
+    File file = parquetFile();
+    ScanCommand command = new ScanCommand(createLogger());
+    command.sourceFiles = Arrays.asList(file.getAbsolutePath(), file.getAbsolutePath());
+    command.setConf(new Configuration());
+    Assert.assertEquals(0, command.run());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testScanCommandWithInvalidColumnName() throws IOException {
+    File file = parquetFile();
+    ScanCommand command = new ScanCommand(createLogger());
+    command.sourceFiles = Arrays.asList(file.getAbsolutePath());
+    command.columns = Arrays.asList("invalid_field");
+    command.setConf(new Configuration());
+    command.run();
   }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2335
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This PR adds the following tests to ScanCommandTest:

* testScanCommandWithMultipleSourceFiles
* testScanCommandWithInvalidColumnName

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
