### PR TITLE
PARQUET-2336: Add caching key to CodecFactory

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
@@ -239,6 +239,7 @@ public class CodecFactory implements CompressionCodecFactory {
     if (codec != null) {
       return codec;
     }
+
     try {
       Class<?> codecClass;
       try {
@@ -266,10 +267,6 @@ public class CodecFactory implements CompressionCodecFactory {
         break;
       case ZSTD:
         level = configuration.get("parquet.compression.codec.zstd.level");
-        if (level == null) {
-          // keep "io.compression.codec.zstd.level" for backwards compatibility
-          level = configuration.get("io.compression.codec.zstd.level");
-        }
         break;
       default:
         // compression level is not supported; ignore it

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
@@ -173,10 +173,10 @@ public class CodecFactory implements CompressionCodecFactory {
           // null compressor for non-native gzip
           compressor.reset();
         }
-        CompressionOutputStream cos = codec.createOutputStream(compressedOutBuffer, compressor);
-        bytes.writeAllTo(cos);
-        cos.finish();
-        cos.close();
+        try (CompressionOutputStream cos = codec.createOutputStream(compressedOutBuffer, compressor)) {
+          bytes.writeAllTo(cos);
+          cos.finish();
+        }
         compressedBytes = BytesInput.from(compressedOutBuffer);
       }
       return compressedBytes;
@@ -234,11 +234,11 @@ public class CodecFactory implements CompressionCodecFactory {
     if (codecClassName == null) {
       return null;
     }
-    CompressionCodec codec = CODEC_BY_NAME.get(codecClassName);
+    String codecCacheKey = this.cacheKey(codecName);
+    CompressionCodec codec = CODEC_BY_NAME.get(codecCacheKey);
     if (codec != null) {
       return codec;
     }
-
     try {
       Class<?> codecClass;
       try {
@@ -248,11 +248,34 @@ public class CodecFactory implements CompressionCodecFactory {
         codecClass = configuration.getClassLoader().loadClass(codecClassName);
       }
       codec = (CompressionCodec) ReflectionUtils.newInstance(codecClass, configuration);
-      CODEC_BY_NAME.put(codecClassName, codec);
+      CODEC_BY_NAME.put(codecCacheKey, codec);
       return codec;
     } catch (ClassNotFoundException e) {
       throw new BadConfigurationException("Class " + codecClassName + " was not found", e);
     }
+  }
+
+  private String cacheKey(CompressionCodecName codecName) {
+    String level = null;
+    switch (codecName) {
+      case GZIP:
+        level = configuration.get("zlib.compress.level");
+        break;
+      case BROTLI:
+        level = configuration.get("compression.brotli.quality");
+        break;
+      case ZSTD:
+        level = configuration.get("parquet.compression.codec.zstd.level");
+        if (level == null) {
+          // keep "io.compression.codec.zstd.level" for backwards compatibility
+          level = configuration.get("io.compression.codec.zstd.level");
+        }
+        break;
+      default:
+        // compression level is not supported; ignore it
+    }
+    String codecClass = codecName.getHadoopCompressionCodecClassName();
+    return level == null ? codecClass : codecClass + ":" + level;
   }
 
   @Override

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDirectCodecFactory.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDirectCodecFactory.java
@@ -210,10 +210,10 @@ public class TestDirectCodecFactory {
   @Test
   public void cachingKeysZstd() {
     Configuration config_zstd_2 = new Configuration();
-    config_zstd_2.set("io.compression.codec.zstd.level", "2");
+    config_zstd_2.set("parquet.compression.codec.zstd.level", "2");
 
     Configuration config_zstd_5 = new Configuration();
-    config_zstd_5.set("io.compression.codec.zstd.level", "5");
+    config_zstd_5.set("parquet.compression.codec.zstd.level", "5");
 
     final CodecFactory codecFactory_2 = new PublicCodecFactory(config_zstd_2, pageSize);
     final CodecFactory codecFactory_5 = new PublicCodecFactory(config_zstd_5, pageSize);


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

The `CODEC_BY_NAME` is static and may be used across different configurations. If a codec is initialized it will be re-used no matter what the configuration is. This is a problem when there are different compression levels used.

https://github.com/apache/parquet-mr/blob/515734c373f69b5250e8b63eb3d1c973da893b63/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java#L45-L46

Therefore we need to cache per compression level as well.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-2336: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
