### PR TITLE
PARQUET-2342: Fix writing corrupted parquet file by avoiding overflow on page value count

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -53,6 +53,7 @@ public class ParquetProperties {
   public static final boolean DEFAULT_ESTIMATE_ROW_COUNT_FOR_PAGE_SIZE_CHECK = true;
   public static final int DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK = 100;
   public static final int DEFAULT_MAXIMUM_RECORD_COUNT_FOR_CHECK = 10000;
+  public static final int DEFAULT_PAGE_VALUE_COUNT_THRESHOLD = Integer.MAX_VALUE / 2;
   public static final int DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH = 64;
   public static final int DEFAULT_STATISTICS_TRUNCATE_LENGTH = Integer.MAX_VALUE;
   public static final int DEFAULT_PAGE_ROW_COUNT_LIMIT = 20_000;
@@ -91,6 +92,7 @@ public class ParquetProperties {
 
   private final int initialSlabSize;
   private final int pageSizeThreshold;
+  private final int pageValueCountThreshold;
   private final int dictionaryPageSizeThreshold;
   private final WriterVersion writerVersion;
   private final ColumnProperty<Boolean> dictionaryEnabled;
@@ -115,6 +117,7 @@ public class ParquetProperties {
 
   private ParquetProperties(Builder builder) {
     this.pageSizeThreshold = builder.pageSize;
+    this.pageValueCountThreshold = builder.pageValueCountThreshold;
     this.initialSlabSize = CapacityByteArrayOutputStream
       .initialSlabSizeHeuristic(MIN_SLAB_SIZE, pageSizeThreshold, 10);
     this.dictionaryPageSizeThreshold = builder.dictPageSize;
@@ -175,6 +178,10 @@ public class ParquetProperties {
 
   public int getPageSizeThreshold() {
     return pageSizeThreshold;
+  }
+
+  public int getPageValueCountThreshold() {
+    return pageValueCountThreshold;
   }
 
   public int getInitialSlabSize() {
@@ -323,6 +330,7 @@ public class ParquetProperties {
     private WriterVersion writerVersion = DEFAULT_WRITER_VERSION;
     private int minRowCountForPageSizeCheck = DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK;
     private int maxRowCountForPageSizeCheck = DEFAULT_MAXIMUM_RECORD_COUNT_FOR_CHECK;
+    private int pageValueCountThreshold = DEFAULT_PAGE_VALUE_COUNT_THRESHOLD;
     private boolean estimateNextSizeCheck = DEFAULT_ESTIMATE_ROW_COUNT_FOR_PAGE_SIZE_CHECK;
     private ByteBufferAllocator allocator = new HeapByteBufferAllocator();
     private ValuesWriterFactory valuesWriterFactory = DEFAULT_VALUES_WRITER_FACTORY;
@@ -444,6 +452,13 @@ public class ParquetProperties {
       Preconditions.checkArgument(max > 0,
           "Invalid row count for page size check (negative): %s", max);
       this.maxRowCountForPageSizeCheck = max;
+      return this;
+    }
+
+    public Builder withPageValueCountThreshold(int value) {
+      Preconditions.checkArgument(value > 0,
+          "Invalid page value count threshold (negative): %s", value);
+      this.pageValueCountThreshold = value;
       return this;
     }
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreBase.java
@@ -231,7 +231,9 @@ abstract class ColumnWriteStoreBase implements ColumnWriteStore {
       long usedMem = writer.getCurrentPageBufferedSize();
       long rows = rowCount - writer.getRowsWrittenSoFar();
       long remainingMem = props.getPageSizeThreshold() - usedMem;
-      if (remainingMem <= thresholdTolerance || rows >= pageRowCountLimit) {
+      if (remainingMem <= thresholdTolerance ||
+          rows >= pageRowCountLimit ||
+          writer.getValueCount() >= props.getPageValueCountThreshold()) {
         writer.writePage();
         remainingMem = props.getPageSizeThreshold();
       } else {

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterBase.java
@@ -380,6 +380,10 @@ abstract class ColumnWriterBase implements ColumnWriter {
     return this.rowsWrittenSoFar;
   }
 
+  int getValueCount() {
+    return this.valueCount;
+  }
+
   /**
    * Writes the current data to a new page in the page store
    */

--- a/parquet-hadoop/README.md
+++ b/parquet-hadoop/README.md
@@ -175,6 +175,12 @@ If the frequency is low, the performance will be better.
 
 ---
 
+**Property:** `parquet.page.value.count.threshold`  
+**Description:** The value count threshold within a Parquet page used on each page check.
+**Default value:** `Integer.MAX_VALUE / 2`
+
+---
+
 **Property:** `parquet.page.size.check.estimate`  
 **Description:** If it is true, the column writer estimates the size of the next page.  
 It prevents issues with rows that vary significantly in size.  

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -146,6 +146,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static final String MAX_PADDING_BYTES    = "parquet.writer.max-padding";
   public static final String MIN_ROW_COUNT_FOR_PAGE_SIZE_CHECK = "parquet.page.size.row.check.min";
   public static final String MAX_ROW_COUNT_FOR_PAGE_SIZE_CHECK = "parquet.page.size.row.check.max";
+  public static final String PAGE_VALUE_COUNT_THRESHOLD = "parquet.page.value.count.threshold";
   public static final String ESTIMATE_PAGE_SIZE_CHECK = "parquet.page.size.check.estimate";
   public static final String COLUMN_INDEX_TRUNCATE_LENGTH = "parquet.columnindex.truncate.length";
   public static final String STATISTICS_TRUNCATE_LENGTH = "parquet.statistics.truncate.length";
@@ -276,6 +277,11 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static int getMaxRowCountForPageSizeCheck(Configuration configuration) {
     return configuration.getInt(MAX_ROW_COUNT_FOR_PAGE_SIZE_CHECK,
         ParquetProperties.DEFAULT_MAXIMUM_RECORD_COUNT_FOR_CHECK);
+  }
+
+  public static int getValueCountThreshold(Configuration configuration) {
+    return configuration.getInt(PAGE_VALUE_COUNT_THRESHOLD,
+        ParquetProperties.DEFAULT_PAGE_VALUE_COUNT_THRESHOLD);
   }
 
   public static boolean getEstimatePageSizeCheck(Configuration configuration) {
@@ -456,6 +462,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
         .estimateRowCountForPageSizeCheck(getEstimatePageSizeCheck(conf))
         .withMinRowCountForPageSizeCheck(getMinRowCountForPageSizeCheck(conf))
         .withMaxRowCountForPageSizeCheck(getMaxRowCountForPageSizeCheck(conf))
+        .withPageValueCountThreshold(getValueCountThreshold(conf))
         .withColumnIndexTruncateLength(getColumnIndexTruncateLength(conf))
         .withStatisticsTruncateLength(getStatisticsTruncateLength(conf))
         .withMaxBloomFilterBytes(getBloomFilterMaxBytes(conf))


### PR DESCRIPTION
Parquet writer only checks the number of rows and the page size to decide whether it needs to fit content written on a single page. In the case of a composite column (ex: array/map) with many nulls, it is possible to create 2billions+ values under the default page size & row-count threshold (1MB, 20000 rows).

This change is adding an Integer limit threshold to avoid value count overflow to happen within a single page.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET-2342) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2342
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - `testMemColumnBinaryExceedIntMaxValue` on parquet-column/src/test/java/org/apache/parquet/column/mem/TestMemColumn.java

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
