### PR TITLE
PARQUET-2343: Fixes NPE when rewriting file with multiple rowgroups

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -254,7 +254,6 @@ public class ParquetRewriter implements Closeable {
 
   private void processBlocksFromReader() throws IOException {
     PageReadStore store = reader.readNextRowGroup();
-    ColumnReadStoreImpl crStore = new ColumnReadStoreImpl(store, new DummyGroupConverter(), schema, originalCreatedBy);
     Map<ColumnPath, ColumnDescriptor> descriptorsMap = schema.getColumns().stream().collect(
             Collectors.toMap(x -> ColumnPath.get(x.getPath()), x -> x));
 
@@ -293,6 +292,8 @@ public class ParquetRewriter implements Closeable {
               throw new IOException(
                       "Required column [" + descriptor.getPrimitiveType().getName() + "] cannot be nullified");
             }
+
+            ColumnReadStoreImpl crStore = new ColumnReadStoreImpl(store, new DummyGroupConverter(), schema, originalCreatedBy);
             nullifyColumn(
                     descriptor,
                     chunk,
@@ -312,6 +313,7 @@ public class ParquetRewriter implements Closeable {
                     new ColumnChunkEncryptorRunTime(writer.getEncryptor(), chunk, numBlocksRewritten, columnId);
           }
 
+          ColumnReadStoreImpl crStore = new ColumnReadStoreImpl(store, new DummyGroupConverter(), schema, originalCreatedBy);
           // Translate compression and/or encryption
           writer.startColumn(descriptor, crStore.getColumnReader(descriptor).getTotalValueCount(), newCodecName);
           processChunk(chunk, newCodecName, columnChunkEncryptorRunTime, encryptColumn);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -254,6 +254,7 @@ public class ParquetRewriter implements Closeable {
 
   private void processBlocksFromReader() throws IOException {
     PageReadStore store = reader.readNextRowGroup();
+    ColumnReadStoreImpl crStore = new ColumnReadStoreImpl(store, new DummyGroupConverter(), schema, originalCreatedBy);
     Map<ColumnPath, ColumnDescriptor> descriptorsMap = schema.getColumns().stream().collect(
             Collectors.toMap(x -> ColumnPath.get(x.getPath()), x -> x));
 
@@ -292,8 +293,6 @@ public class ParquetRewriter implements Closeable {
               throw new IOException(
                       "Required column [" + descriptor.getPrimitiveType().getName() + "] cannot be nullified");
             }
-
-            ColumnReadStoreImpl crStore = new ColumnReadStoreImpl(store, new DummyGroupConverter(), schema, originalCreatedBy);
             nullifyColumn(
                     descriptor,
                     chunk,
@@ -313,7 +312,6 @@ public class ParquetRewriter implements Closeable {
                     new ColumnChunkEncryptorRunTime(writer.getEncryptor(), chunk, numBlocksRewritten, columnId);
           }
 
-          ColumnReadStoreImpl crStore = new ColumnReadStoreImpl(store, new DummyGroupConverter(), schema, originalCreatedBy);
           // Translate compression and/or encryption
           writer.startColumn(descriptor, crStore.getColumnReader(descriptor).getTotalValueCount(), newCodecName);
           processChunk(chunk, newCodecName, columnChunkEncryptorRunTime, encryptColumn);
@@ -331,6 +329,7 @@ public class ParquetRewriter implements Closeable {
 
       writer.endBlock();
       store = reader.readNextRowGroup();
+      crStore = new ColumnReadStoreImpl(store, new DummyGroupConverter(), schema, originalCreatedBy);
       blockId++;
       numBlocksRewritten++;
     }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestFileBuilder.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestFileBuilder.java
@@ -51,6 +51,7 @@ public class TestFileBuilder
     private String[] encryptColumns = {};
     private ParquetCipher cipher = ParquetCipher.AES_GCM_V1;
     private Boolean footerEncryption = false;
+    private long rowGroupSize = ParquetWriter.DEFAULT_BLOCK_SIZE;
 
     public TestFileBuilder(Configuration conf, MessageType schema)
     {
@@ -107,6 +108,12 @@ public class TestFileBuilder
         return this;
     }
 
+    public TestFileBuilder withRowGroupSize(long rowGroupSize)
+    {
+        this.rowGroupSize = rowGroupSize;
+        return this;
+    }
+
     public EncryptionTestFile build()
             throws IOException
     {
@@ -119,6 +126,7 @@ public class TestFileBuilder
                 .withExtraMetaData(extraMeta)
                 .withValidation(true)
                 .withPageSize(pageSize)
+                .withRowGroupSize(rowGroupSize)
                 .withEncryption(encryptionProperties)
                 .withCompressionCodec(CompressionCodecName.valueOf(codec));
         try (ParquetWriter writer = builder.build()) {


### PR DESCRIPTION
Currently, the ParquetRewiter creates the `ColumnReadStoreImpl crStore` and reuses it for all the blocks rewriting. This should be incorrect and we should create the `crStore` for each block that needs to be rewritten. Otherwise, we will fail as the following:
```java
java.lang.NullPointerException
at org.apache.parquet.column.impl.ColumnReaderBase.readPage(ColumnReaderBase.java:620)
at org.apache.parquet.column.impl.ColumnReaderBase.checkRead(ColumnReaderBase.java:594)
at org.apache.parquet.column.impl.ColumnReaderBase.consume(ColumnReaderBase.java:735)
at org.apache.parquet.column.impl.ColumnReaderImpl.consume(ColumnReaderImpl.java:30)
at org.apache.parquet.column.impl.ColumnReaderImpl.<init>(ColumnReaderImpl.java:47)
at org.apache.parquet.column.impl.ColumnReadStoreImpl.getColumnReader(ColumnReadStoreImpl.java:82)
at org.apache.parquet.hadoop.rewrite.ParquetRewriter.processBlocksFromReader(ParquetRewriter.java:316)
at org.apache.parquet.hadoop.rewrite.ParquetRewriter.processBlocks(ParquetRewriter.java:250)
```

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Adds `testRewriteFileWithMultipleBlocks` in `ParquetRewriterTest`.

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
