### PR TITLE
PARQUET-2347: Add interface layer between Parquet and Hadoop Configuration

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetOutputFormat.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetOutputFormat.java
@@ -19,9 +19,7 @@
 package org.apache.parquet.avro;
 
 import org.apache.avro.Schema;
-import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.mapreduce.Job;
-import org.apache.parquet.avro.AvroWriteSupport;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.hadoop.util.ContextUtil;
 

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetReader.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetReader.java
@@ -26,6 +26,7 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.filter.UnboundRecordFilter;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.api.ReadSupport;
@@ -53,6 +54,10 @@ public class AvroParquetReader<T> extends ParquetReader<T> {
     return new Builder<T>(file);
   }
 
+  public static <T> Builder<T> builder(InputFile file, ParquetConfiguration conf) {
+    return new Builder<T>(file, conf);
+  }
+
   /**
    * Convenience method for creating a ParquetReader which uses Avro
    * {@link GenericData} objects to store data from reads.
@@ -65,6 +70,21 @@ public class AvroParquetReader<T> extends ParquetReader<T> {
    */
   public static ParquetReader<GenericRecord> genericRecordReader(InputFile file) throws IOException {
     return new Builder<GenericRecord>(file).withDataModel(GenericData.get()).build();
+  }
+
+  /**
+   * Convenience method for creating a ParquetReader which uses Avro
+   * {@link GenericData} objects to store data from reads.
+   *
+   * @param file The location to read data from
+   * @param conf The configuration to use
+   * @return A {@code ParquetReader} which reads data as Avro
+   *         {@code GenericData}
+   * @throws IOException if the InputFile has been closed, or if some other I/O
+   *           error occurs
+   */
+  public static ParquetReader<GenericRecord> genericRecordReader(InputFile file, ParquetConfiguration conf) throws IOException {
+    return new Builder<GenericRecord>(file, conf).withDataModel(GenericData.get()).build();
   }
 
   /**
@@ -141,6 +161,10 @@ public class AvroParquetReader<T> extends ParquetReader<T> {
 
     private Builder(InputFile file) {
       super(file);
+    }
+
+    private Builder(InputFile file, ParquetConfiguration conf) {
+      super(file, conf);
     }
 
     public Builder<T> withDataModel(GenericData model) {

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
@@ -25,6 +25,8 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.column.ParquetProperties.WriterVersion;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -154,6 +156,12 @@ public class AvroParquetWriter<T> extends ParquetWriter<T> {
   private static <T> WriteSupport<T> writeSupport(Configuration conf,
                                                   Schema avroSchema,
                                                   GenericData model) {
+    return writeSupport(new HadoopParquetConfiguration(conf), avroSchema, model);
+  }
+
+  private static <T> WriteSupport<T> writeSupport(ParquetConfiguration conf,
+                                                  Schema avroSchema,
+                                                  GenericData model) {
     return new AvroWriteSupport<T>(
         new AvroSchemaConverter(conf).convert(avroSchema), avroSchema, model);
   }
@@ -187,6 +195,11 @@ public class AvroParquetWriter<T> extends ParquetWriter<T> {
 
     @Override
     protected WriteSupport<T> getWriteSupport(Configuration conf) {
+      return AvroParquetWriter.writeSupport(conf, schema, model);
+    }
+
+    @Override
+    protected WriteSupport<T> getWriteSupport(ParquetConfiguration conf) {
       return AvroParquetWriter.writeSupport(conf, schema, model);
     }
   }

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
@@ -170,10 +170,6 @@ public class AvroReadSupport<T> extends ReadSupport<T> {
         parquetSchema, avroSchema, model);
   }
 
-  private GenericData getDataModel(Configuration conf, Schema schema) {
-    return getDataModel(new HadoopParquetConfiguration(conf), schema);
-  }
-
   private GenericData getDataModel(ParquetConfiguration conf, Schema schema) {
     if (model != null) {
       return model;

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroReadSupport.java
@@ -24,7 +24,10 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.hadoop.api.ReadSupport;
+import org.apache.parquet.hadoop.util.ConfigurationUtil;
 import org.apache.parquet.io.api.RecordMaterializer;
 import org.apache.parquet.schema.MessageType;
 import org.slf4j.Logger;
@@ -95,6 +98,13 @@ public class AvroReadSupport<T> extends ReadSupport<T> {
   public ReadContext init(Configuration configuration,
                           Map<String, String> keyValueMetaData,
                           MessageType fileSchema) {
+    return init(new HadoopParquetConfiguration(configuration), keyValueMetaData, fileSchema);
+  }
+
+  @Override
+  public ReadContext init(ParquetConfiguration configuration,
+                          Map<String, String> keyValueMetaData,
+                          MessageType fileSchema) {
     MessageType projection = fileSchema;
     Map<String, String> metadata = new LinkedHashMap<String, String>();
 
@@ -120,6 +130,13 @@ public class AvroReadSupport<T> extends ReadSupport<T> {
   public RecordMaterializer<T> prepareForRead(
       Configuration configuration, Map<String, String> keyValueMetaData,
       MessageType fileSchema, ReadContext readContext) {
+    return prepareForRead(new HadoopParquetConfiguration(configuration), keyValueMetaData, fileSchema, readContext);
+  }
+
+  @Override
+  public RecordMaterializer<T> prepareForRead(
+    ParquetConfiguration configuration, Map<String, String> keyValueMetaData,
+    MessageType fileSchema, ReadContext readContext) {
     Map<String, String> metadata = readContext.getReadSupportMetadata();
     MessageType parquetSchema = readContext.getRequestedSchema();
     Schema avroSchema;
@@ -154,6 +171,10 @@ public class AvroReadSupport<T> extends ReadSupport<T> {
   }
 
   private GenericData getDataModel(Configuration conf, Schema schema) {
+    return getDataModel(new HadoopParquetConfiguration(conf), schema);
+  }
+
+  private GenericData getDataModel(ParquetConfiguration conf, Schema schema) {
     if (model != null) {
       return model;
     }
@@ -175,6 +196,6 @@ public class AvroReadSupport<T> extends ReadSupport<T> {
 
     Class<? extends AvroDataSupplier> suppClass = conf.getClass(
         AVRO_DATA_SUPPLIER, SpecificDataSupplier.class, AvroDataSupplier.class);
-    return ReflectionUtils.newInstance(suppClass, conf).get();
+    return ReflectionUtils.newInstance(suppClass, ConfigurationUtil.createHadoopConfiguration(conf)).get();
   }
 }

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
@@ -23,6 +23,8 @@ import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.schema.ConversionPatterns;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
@@ -102,6 +104,10 @@ public class AvroSchemaConverter {
   }
 
   public AvroSchemaConverter(Configuration conf) {
+    this(new HadoopParquetConfiguration(conf));
+  }
+
+  public AvroSchemaConverter(ParquetConfiguration conf) {
     this.assumeRepeatedIsListElement = conf.getBoolean(
         ADD_LIST_ELEMENT_RECORDS, ADD_LIST_ELEMENT_RECORDS_DEFAULT);
     this.writeOldListStructure = conf.getBoolean(

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
@@ -412,10 +412,6 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
     return Binary.fromCharSequence(value.toString());
   }
 
-  private static GenericData getDataModel(Configuration conf, Schema schema) {
-    return getDataModel(new HadoopParquetConfiguration(conf), schema);
-  }
-
   private static GenericData getDataModel(ParquetConfiguration conf, Schema schema) {
     if (conf.get(AVRO_DATA_SUPPLIER) == null && schema != null) {
       GenericData modelForSchema;

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWriteOldListBehavior.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWriteOldListBehavior.java
@@ -38,6 +38,8 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.util.Utf8;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.io.api.Binary;
@@ -358,6 +360,11 @@ public class TestReadWriteOldListBehavior {
 
       @Override
       public WriteContext init(Configuration configuration) {
+        return init(new HadoopParquetConfiguration(configuration));
+      }
+
+      @Override
+      public WriteContext init(ParquetConfiguration configuration) {
         return new WriteContext(MessageTypeParser.parseMessageType(TestAvroSchemaConverter.ALL_PARQUET_SCHEMA),
             new HashMap<String, String>());
       }

--- a/parquet-common/src/main/java/org/apache/parquet/conf/ParquetConfiguration.java
+++ b/parquet-common/src/main/java/org/apache/parquet/conf/ParquetConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.conf;
+
+import java.util.Map;
+
+/**
+ * Configuration interface with the methods necessary to configure for Parquet applications.
+ */
+public interface ParquetConfiguration extends Iterable<Map.Entry<String,String>> {
+
+  void set(String name, String value);
+
+  void setLong(String name, long value);
+
+  void setInt(String name, int value);
+
+  void setBoolean(String name, boolean value);
+
+  void setStrings(String name, String... value);
+
+  void setClass(String name, Class<?> value, Class<?> xface);
+
+  String get(String name);
+
+  String get(String name, String defaultValue);
+
+  long getLong(String name, long defaultValue);
+
+  int getInt(String name, int defaultValue);
+
+  boolean getBoolean(String name, boolean defaultValue);
+
+  String getTrimmed(String name);
+
+  String getTrimmed(String name, String defaultValue);
+
+  String[] getStrings(String name, String[] defaultValue);
+
+  Class<?> getClass(String name, Class<?> defaultValue);
+
+  <U> Class<? extends U> getClass(String name, Class<? extends U> defaultValue, Class<U> xface);
+
+  Class<?> getClassByName(String name) throws ClassNotFoundException;
+}

--- a/parquet-common/src/main/java/org/apache/parquet/conf/ParquetConfiguration.java
+++ b/parquet-common/src/main/java/org/apache/parquet/conf/ParquetConfiguration.java
@@ -22,41 +22,157 @@ package org.apache.parquet.conf;
 import java.util.Map;
 
 /**
- * Configuration interface with the methods necessary to configure for Parquet applications.
+ * Configuration interface with the methods necessary to configure Parquet applications.
  */
 public interface ParquetConfiguration extends Iterable<Map.Entry<String,String>> {
 
+  /**
+   * Sets the value of the name property.
+   *
+   * @param name the property to set
+   * @param value the value to set the property to
+   */
   void set(String name, String value);
 
+  /**
+   * Sets the value of the name property to a long.
+   *
+   * @param name the property to set
+   * @param value the value to set the property to
+   */
   void setLong(String name, long value);
 
+  /**
+   * Sets the value of the name property to an integer.
+   *
+   * @param name the property to set
+   * @param value the value to set the property to
+   */
   void setInt(String name, int value);
 
+  /**
+   * Sets the value of the name property to a boolean.
+   *
+   * @param name the property to set
+   * @param value the value to set the property to
+   */
   void setBoolean(String name, boolean value);
 
+  /**
+   * Sets the value of the name property to an array of comma delimited values.
+   *
+   * @param name the property to set
+   * @param value the values to set the property to
+   */
   void setStrings(String name, String... value);
 
+  /**
+   * Sets the value of the name property to a class.
+   *
+   * @param name the property to set
+   * @param value the value to set the property to
+   * @param xface the interface implemented by the value
+   */
   void setClass(String name, Class<?> value, Class<?> xface);
 
+  /**
+   * Gets the value of the name property. Returns null if no such value exists.
+   *
+   * @param name the property to retrieve the value of
+   * @return the value of the property, or null if it does not exist
+   */
   String get(String name);
 
+  /**
+   * Gets the value of the name property. Returns the default value if no such value exists.
+   *
+   * @param name the property to retrieve the value of
+   * @param defaultValue the default return if no value is set for the property
+   * @return the value of the property, or the default value if it does not exist
+   */
   String get(String name, String defaultValue);
 
+  /**
+   * Gets the value of the name property as a long. Returns the default value if no such value exists.
+   *
+   * @param name the property to retrieve the value of
+   * @param defaultValue the default return if no value is set for the property
+   * @return the value of the property as a long, or the default value if it does not exist
+   */
   long getLong(String name, long defaultValue);
 
+  /**
+   * Gets the value of the name property as an integer. Returns the default value if no such value exists.
+   *
+   * @param name the property to retrieve the value of
+   * @param defaultValue the default return if no value is set for the property
+   * @return the value of the property as an integer, or the default value if it does not exist
+   */
   int getInt(String name, int defaultValue);
 
+  /**
+   * Gets the value of the name property as a boolean. Returns the default value if no such value exists.
+   *
+   * @param name the property to retrieve the value of
+   * @param defaultValue the default return if no value is set for the property
+   * @return the value of the property as a boolean, or the default value if it does not exist
+   */
   boolean getBoolean(String name, boolean defaultValue);
 
+  /**
+   * Gets the trimmed value of the name property. Returns null if no such value exists.
+   *
+   * @param name the property to retrieve the value of
+   * @return the trimmed value of the property, or null if it does not exist
+   */
   String getTrimmed(String name);
 
+  /**
+   * Gets the trimmed value of the name property as a boolean.
+   * Returns the default value if no such value exists.
+   *
+   * @param name the property to retrieve the value of
+   * @param defaultValue the default return if no value is set for the property
+   * @return the trimmed value of the property, or the default value if it does not exist
+   */
   String getTrimmed(String name, String defaultValue);
 
+  /**
+   * Gets the value of the name property as an array of {@link String}s.
+   * Returns the default value if no such value exists.
+   * Interprets the stored value as a comma delimited array.
+   *
+   * @param name the property to retrieve the value of
+   * @param defaultValue the default return if no value is set for the property
+   * @return the value of the property as an array, or the default value if it does not exist
+   */
   String[] getStrings(String name, String[] defaultValue);
 
+  /**
+   * Gets the value of the name property as a class. Returns the default value if no such value exists.
+   *
+   * @param name the property to retrieve the value of
+   * @param defaultValue the default return if no value is set for the property
+   * @return the value of the property as a class, or the default value if it does not exist
+   */
   Class<?> getClass(String name, Class<?> defaultValue);
 
+  /**
+   * Gets the value of the name property as a class implementing the xface interface.
+   * Returns the default value if no such value exists.
+   *
+   * @param name the property to retrieve the value of
+   * @param defaultValue the default return if no value is set for the property
+   * @return the value of the property as a class, or the default value if it does not exist
+   */
   <U> Class<? extends U> getClass(String name, Class<? extends U> defaultValue, Class<U> xface);
 
+  /**
+   * Load a class by name.
+   *
+   * @param name the name of the {@link Class} to load
+   * @return the loaded class
+   * @throws ClassNotFoundException when the specified class cannot be found
+   */
   Class<?> getClassByName(String name) throws ClassNotFoundException;
 }

--- a/parquet-common/src/main/java/org/apache/parquet/util/Reflection.java
+++ b/parquet-common/src/main/java/org/apache/parquet/util/Reflection.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.util;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Lifted from Hadoop's org.apache.hadoop.util.ReflectionUtils.
+ */
+public class Reflection {
+
+  private static final Class<?>[] EMPTY_ARRAY = new Class[]{};
+  private static final Map<Class<?>, Constructor<?>> CONSTRUCTOR_CACHE = new ConcurrentHashMap<Class<?>, Constructor<?>>();
+
+  @SuppressWarnings("unchecked")
+  public static <T> T newInstance(Class<T> theClass) {
+    T result;
+    try {
+      Constructor<T> meth = (Constructor<T>) CONSTRUCTOR_CACHE.get(theClass);
+      if (meth == null) {
+        meth = theClass.getDeclaredConstructor(EMPTY_ARRAY);
+        meth.setAccessible(true);
+        CONSTRUCTOR_CACHE.put(theClass, meth);
+      }
+      result = meth.newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return result;
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
@@ -23,28 +23,16 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.compression.CompressionCodecFactory;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
 import org.apache.parquet.crypto.DecryptionPropertiesFactory;
 import org.apache.parquet.crypto.FileDecryptionProperties;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.format.converter.ParquetMetadataConverter.MetadataFilter;
-import org.apache.parquet.hadoop.util.HadoopCodecs;
 
 import java.util.Map;
 
-import static org.apache.parquet.hadoop.ParquetInputFormat.COLUMN_INDEX_FILTERING_ENABLED;
-import static org.apache.parquet.hadoop.ParquetInputFormat.DICTIONARY_FILTERING_ENABLED;
-import static org.apache.parquet.hadoop.ParquetInputFormat.BLOOM_FILTERING_ENABLED;
-import static org.apache.parquet.hadoop.ParquetInputFormat.OFF_HEAP_DECRYPT_BUFFER_ENABLED;
-import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
-import static org.apache.parquet.hadoop.ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED;
-import static org.apache.parquet.hadoop.ParquetInputFormat.RECORD_FILTERING_ENABLED;
-import static org.apache.parquet.hadoop.ParquetInputFormat.STATS_FILTERING_ENABLED;
-import static org.apache.parquet.hadoop.UnmaterializableRecordCounter.BAD_RECORD_THRESHOLD_CONF_KEY;
-
 public class HadoopReadOptions extends ParquetReadOptions {
   private final Configuration conf;
-
-  private static final String ALLOCATION_SIZE = "parquet.read.allocation.size";
 
   private HadoopReadOptions(boolean useSignedStringMinMax,
                             boolean useStatsFilter,
@@ -65,7 +53,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
     super(
         useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter, useColumnIndexFilter,
         usePageChecksumVerification, useBloomFilter, useOffHeapDecryptBuffer, recordFilter, metadataFilter, codecFactory, allocator,
-        maxAllocationSize, properties, fileDecryptionProperties
+        maxAllocationSize, properties, fileDecryptionProperties, new HadoopParquetConfiguration(conf)
     );
     this.conf = conf;
   }
@@ -100,24 +88,9 @@ public class HadoopReadOptions extends ParquetReadOptions {
     }
 
     public Builder(Configuration conf, Path filePath) {
+      super(new HadoopParquetConfiguration(conf));
       this.conf = conf;
       this.filePath = filePath;
-      useSignedStringMinMax(conf.getBoolean("parquet.strings.signed-min-max.enabled", false));
-      useDictionaryFilter(conf.getBoolean(DICTIONARY_FILTERING_ENABLED, true));
-      useStatsFilter(conf.getBoolean(STATS_FILTERING_ENABLED, true));
-      useRecordFilter(conf.getBoolean(RECORD_FILTERING_ENABLED, true));
-      useColumnIndexFilter(conf.getBoolean(COLUMN_INDEX_FILTERING_ENABLED, true));
-      usePageChecksumVerification(conf.getBoolean(PAGE_VERIFY_CHECKSUM_ENABLED,
-        usePageChecksumVerification));
-      useBloomFilter(conf.getBoolean(BLOOM_FILTERING_ENABLED, true));
-      useOffHeapDecryptBuffer(conf.getBoolean(OFF_HEAP_DECRYPT_BUFFER_ENABLED, false));
-      withCodecFactory(HadoopCodecs.newFactory(conf, 0));
-      withRecordFilter(getFilter(conf));
-      withMaxAllocationInBytes(conf.getInt(ALLOCATION_SIZE, 8388608));
-      String badRecordThresh = conf.get(BAD_RECORD_THRESHOLD_CONF_KEY);
-      if (badRecordThresh != null) {
-        set(BAD_RECORD_THRESHOLD_CONF_KEY, badRecordThresh);
-      }
     }
 
     @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
@@ -19,9 +19,12 @@
 
 package org.apache.parquet;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.compression.CompressionCodecFactory;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.crypto.FileDecryptionProperties;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.format.converter.ParquetMetadataConverter;
@@ -34,9 +37,21 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
+import static org.apache.parquet.hadoop.ParquetInputFormat.BLOOM_FILTERING_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.COLUMN_INDEX_FILTERING_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.DICTIONARY_FILTERING_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.OFF_HEAP_DECRYPT_BUFFER_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.PAGE_VERIFY_CHECKSUM_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.RECORD_FILTERING_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.STATS_FILTERING_ENABLED;
+import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
+import static org.apache.parquet.hadoop.UnmaterializableRecordCounter.BAD_RECORD_THRESHOLD_CONF_KEY;
 
 // Internal use only
 public class ParquetReadOptions {
+
+  private static final String ALLOCATION_SIZE = "parquet.read.allocation.size";
+
   private static final boolean RECORD_FILTERING_ENABLED_DEFAULT = true;
   private static final boolean STATS_FILTERING_ENABLED_DEFAULT = true;
   private static final boolean DICTIONARY_FILTERING_ENABLED_DEFAULT = true;
@@ -61,6 +76,7 @@ public class ParquetReadOptions {
   private final int maxAllocationSize;
   private final Map<String, String> properties;
   private final FileDecryptionProperties fileDecryptionProperties;
+  private final ParquetConfiguration conf;
 
   ParquetReadOptions(boolean useSignedStringMinMax,
                      boolean useStatsFilter,
@@ -77,6 +93,28 @@ public class ParquetReadOptions {
                      int maxAllocationSize,
                      Map<String, String> properties,
                      FileDecryptionProperties fileDecryptionProperties) {
+    this(useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter, useColumnIndexFilter,
+      usePageChecksumVerification, useBloomFilter, useOffHeapDecryptBuffer, recordFilter, metadataFilter,
+      codecFactory, allocator, maxAllocationSize, properties, fileDecryptionProperties,
+      new HadoopParquetConfiguration());
+  }
+
+  ParquetReadOptions(boolean useSignedStringMinMax,
+                     boolean useStatsFilter,
+                     boolean useDictionaryFilter,
+                     boolean useRecordFilter,
+                     boolean useColumnIndexFilter,
+                     boolean usePageChecksumVerification,
+                     boolean useBloomFilter,
+                     boolean useOffHeapDecryptBuffer,
+                     FilterCompat.Filter recordFilter,
+                     ParquetMetadataConverter.MetadataFilter metadataFilter,
+                     CompressionCodecFactory codecFactory,
+                     ByteBufferAllocator allocator,
+                     int maxAllocationSize,
+                     Map<String, String> properties,
+                     FileDecryptionProperties fileDecryptionProperties,
+                     ParquetConfiguration conf) {
     this.useSignedStringMinMax = useSignedStringMinMax;
     this.useStatsFilter = useStatsFilter;
     this.useDictionaryFilter = useDictionaryFilter;
@@ -92,6 +130,7 @@ public class ParquetReadOptions {
     this.maxAllocationSize = maxAllocationSize;
     this.properties = Collections.unmodifiableMap(properties);
     this.fileDecryptionProperties = fileDecryptionProperties;
+    this.conf = conf;
   }
 
   public boolean useSignedStringMinMax() {
@@ -164,8 +203,16 @@ public class ParquetReadOptions {
         : defaultValue;
   }
 
+  public ParquetConfiguration getConfiguration() {
+    return conf;
+  }
+
   public static Builder builder() {
-    return new Builder();
+    return new Builder(new HadoopParquetConfiguration());
+  }
+
+  public static Builder builder(ParquetConfiguration conf) {
+    return new Builder(conf);
   }
 
   public static class Builder {
@@ -185,6 +232,31 @@ public class ParquetReadOptions {
     protected int maxAllocationSize = ALLOCATION_SIZE_DEFAULT;
     protected Map<String, String> properties = new HashMap<>();
     protected FileDecryptionProperties fileDecryptionProperties = null;
+    protected ParquetConfiguration conf;
+
+    public Builder() {
+      conf = new HadoopParquetConfiguration();
+    }
+
+    public Builder(ParquetConfiguration conf) {
+      this.conf = conf;
+      useSignedStringMinMax(conf.getBoolean("parquet.strings.signed-min-max.enabled", false));
+      useDictionaryFilter(conf.getBoolean(DICTIONARY_FILTERING_ENABLED, true));
+      useStatsFilter(conf.getBoolean(STATS_FILTERING_ENABLED, true));
+      useRecordFilter(conf.getBoolean(RECORD_FILTERING_ENABLED, true));
+      useColumnIndexFilter(conf.getBoolean(COLUMN_INDEX_FILTERING_ENABLED, true));
+      usePageChecksumVerification(conf.getBoolean(PAGE_VERIFY_CHECKSUM_ENABLED,
+        usePageChecksumVerification));
+      useBloomFilter(conf.getBoolean(BLOOM_FILTERING_ENABLED, true));
+      useOffHeapDecryptBuffer(conf.getBoolean(OFF_HEAP_DECRYPT_BUFFER_ENABLED, false));
+      withCodecFactory(HadoopCodecs.newFactory(conf, 0));
+      withRecordFilter(getFilter(conf));
+      withMaxAllocationInBytes(conf.getInt(ALLOCATION_SIZE, 8388608));
+      String badRecordThresh = conf.get(BAD_RECORD_THRESHOLD_CONF_KEY);
+      if (badRecordThresh != null) {
+        set(BAD_RECORD_THRESHOLD_CONF_KEY, badRecordThresh);
+      }
+    }
 
     public Builder useSignedStringMinMax(boolean useSignedStringMinMax) {
       this.useSignedStringMinMax = useSignedStringMinMax;
@@ -325,6 +397,7 @@ public class ParquetReadOptions {
       withAllocator(options.allocator);
       withPageChecksumVerification(options.usePageChecksumVerification);
       withDecryption(options.fileDecryptionProperties);
+      conf = options.conf;
       for (Map.Entry<String, String> keyValue : options.properties.entrySet()) {
         set(keyValue.getKey(), keyValue.getValue());
       }
@@ -333,13 +406,17 @@ public class ParquetReadOptions {
 
     public ParquetReadOptions build() {
       if (codecFactory == null) {
-        codecFactory = HadoopCodecs.newFactory(0);
+        if (conf == null) {
+          codecFactory = HadoopCodecs.newFactory(0);
+        } else {
+          codecFactory = HadoopCodecs.newFactory(conf, 0);
+        }
       }
 
       return new ParquetReadOptions(
         useSignedStringMinMax, useStatsFilter, useDictionaryFilter, useRecordFilter,
         useColumnIndexFilter, usePageChecksumVerification, useBloomFilter, useOffHeapDecryptBuffer, recordFilter, metadataFilter,
-        codecFactory, allocator, maxAllocationSize, properties, fileDecryptionProperties);
+        codecFactory, allocator, maxAllocationSize, properties, fileDecryptionProperties, conf);
     }
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/ParquetReadOptions.java
@@ -19,7 +19,6 @@
 
 package org.apache.parquet;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.compression.CompressionCodecFactory;
@@ -208,7 +207,7 @@ public class ParquetReadOptions {
   }
 
   public static Builder builder() {
-    return new Builder(new HadoopParquetConfiguration());
+    return new Builder();
   }
 
   public static Builder builder(ParquetConfiguration conf) {
@@ -235,7 +234,7 @@ public class ParquetReadOptions {
     protected ParquetConfiguration conf;
 
     public Builder() {
-      conf = new HadoopParquetConfiguration();
+      this(new HadoopParquetConfiguration());
     }
 
     public Builder(ParquetConfiguration conf) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/conf/HadoopParquetConfiguration.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/conf/HadoopParquetConfiguration.java
@@ -1,0 +1,140 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.conf;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Implementation of the Parquet configuration interface relying on Hadoop's
+ * Configuration to aid with interoperability and backwards compatibility.
+ */
+public class HadoopParquetConfiguration implements ParquetConfiguration {
+
+  private final Configuration configuration;
+
+  public HadoopParquetConfiguration() {
+    this(true);
+  }
+
+  public HadoopParquetConfiguration(boolean loadDefaults) {
+    configuration = new Configuration(loadDefaults);
+  }
+
+  public HadoopParquetConfiguration(Configuration conf) {
+    configuration = conf;
+  }
+
+  public Configuration getConfiguration() {
+    return configuration;
+  }
+
+  @Override
+  public void set(String name, String value) {
+    configuration.set(name, value);
+  }
+
+  @Override
+  public void setLong(String name, long value) {
+    configuration.setLong(name, value);
+  }
+
+  @Override
+  public void setInt(String name, int value) {
+    configuration.setInt(name, value);
+  }
+
+  @Override
+  public void setBoolean(String name, boolean value) {
+    configuration.setBoolean(name, value);
+  }
+
+  @Override
+  public void setStrings(String name, String... values) {
+    configuration.setStrings(name, values);
+  }
+
+  @Override
+  public void setClass(String name, Class<?> value, Class<?> xface) {
+    configuration.setClass(name, value, xface);
+  }
+
+  @Override
+  public String get(String name) {
+    return configuration.get(name);
+  }
+
+  @Override
+  public String get(String name, String defaultValue) {
+    return configuration.get(name, defaultValue);
+  }
+
+  @Override
+  public long getLong(String name, long defaultValue) {
+    return configuration.getLong(name, defaultValue);
+  }
+
+  @Override
+  public int getInt(String name, int defaultValue) {
+    return configuration.getInt(name, defaultValue);
+  }
+
+  @Override
+  public boolean getBoolean(String name, boolean defaultValue) {
+    return configuration.getBoolean(name, defaultValue);
+  }
+
+  @Override
+  public String getTrimmed(String name) {
+    return configuration.getTrimmed(name);
+  }
+
+  @Override
+  public String getTrimmed(String name, String defaultValue) {
+    return configuration.getTrimmed(name, defaultValue);
+  }
+
+  @Override
+  public String[] getStrings(String name, String[] defaultValue) {
+    return configuration.getStrings(name, defaultValue);
+  }
+
+  @Override
+  public Class<?> getClass(String name, Class<?> defaultValue) {
+    return configuration.getClass(name, defaultValue);
+  }
+
+  @Override
+  public <U> Class<? extends U> getClass(String name, Class<? extends U> defaultValue, Class<U> xface) {
+    return configuration.getClass(name, defaultValue, xface);
+  }
+
+  @Override
+  public Class<?> getClassByName(String name) throws ClassNotFoundException {
+    return configuration.getClassByName(name);
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, String>> iterator() {
+    return configuration.iterator();
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
@@ -37,8 +37,11 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.compression.CompressionCodecFactory;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.hadoop.codec.ZstandardCodec;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.util.ConfigurationUtil;
 
 public class CodecFactory implements CompressionCodecFactory {
 
@@ -48,7 +51,7 @@ public class CodecFactory implements CompressionCodecFactory {
   private final Map<CompressionCodecName, BytesCompressor> compressors = new HashMap<CompressionCodecName, BytesCompressor>();
   private final Map<CompressionCodecName, BytesDecompressor> decompressors = new HashMap<CompressionCodecName, BytesDecompressor>();
 
-  protected final Configuration configuration;
+  protected final ParquetConfiguration configuration;
   protected final int pageSize;
 
   /**
@@ -61,6 +64,19 @@ public class CodecFactory implements CompressionCodecFactory {
    *                 decompressors this parameter has no impact on the function of the factory
    */
   public CodecFactory(Configuration configuration, int pageSize) {
+    this(new HadoopParquetConfiguration(configuration), pageSize);
+  }
+
+  /**
+   * Create a new codec factory.
+   *
+   * @param configuration used to pass compression codec configuration information
+   * @param pageSize the expected page size, does not set a hard limit, currently just
+   *                 used to set the initial size of the output stream used when
+   *                 compressing a buffer. If this factory is only used to construct
+   *                 decompressors this parameter has no impact on the function of the factory
+   */
+  public CodecFactory(ParquetConfiguration configuration, int pageSize) {
     this.configuration = configuration;
     this.pageSize = pageSize;
   }
@@ -246,9 +262,9 @@ public class CodecFactory implements CompressionCodecFactory {
         codecClass = Class.forName(codecClassName);
       } catch (ClassNotFoundException e) {
         // Try to load the class using the job classloader
-        codecClass = configuration.getClassLoader().loadClass(codecClassName);
+        codecClass = new Configuration(false).getClassLoader().loadClass(codecClassName);
       }
-      codec = (CompressionCodec) ReflectionUtils.newInstance(codecClass, configuration);
+      codec = (CompressionCodec) ReflectionUtils.newInstance(codecClass, ConfigurationUtil.createHadoopConfiguration(configuration));
       CODEC_BY_NAME.put(codecCacheKey, codec);
       return codec;
     } catch (ClassNotFoundException e) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectZstd.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectZstd.java
@@ -143,10 +143,6 @@ class DirectZstd {
     }
   }
 
-  private static BufferPool getPool(Configuration conf) {
-    return getPool(new HadoopParquetConfiguration(conf));
-  }
-
   private static BufferPool getPool(ParquetConfiguration conf) {
     if (conf.getBoolean(PARQUET_COMPRESS_ZSTD_BUFFERPOOL_ENABLED, DEFAULT_PARQUET_COMPRESS_ZSTD_BUFFERPOOL_ENABLED)) {
       return RecyclingBufferPool.INSTANCE;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectZstd.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectZstd.java
@@ -25,6 +25,8 @@ import com.github.luben.zstd.ZstdOutputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.hadoop.codec.ZstdDecompressorStream;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
@@ -51,6 +53,10 @@ import static org.apache.parquet.hadoop.codec.ZstandardCodec.PARQUET_COMPRESS_ZS
 class DirectZstd {
 
   static CodecFactory.BytesCompressor createCompressor(Configuration conf, int pageSize) {
+    return createCompressor(new HadoopParquetConfiguration(conf), pageSize);
+  }
+
+  static CodecFactory.BytesCompressor createCompressor(ParquetConfiguration conf, int pageSize) {
     return new ZstdCompressor(
       getPool(conf),
       conf.getInt(PARQUET_COMPRESS_ZSTD_LEVEL, DEFAULT_PARQUET_COMPRESS_ZSTD_LEVEL),
@@ -59,6 +65,10 @@ class DirectZstd {
   }
 
   static CodecFactory.BytesDecompressor createDecompressor(Configuration conf) {
+    return createDecompressor(new HadoopParquetConfiguration(conf));
+  }
+
+  static CodecFactory.BytesDecompressor createDecompressor(ParquetConfiguration conf) {
     return new ZstdDecompressor(getPool(conf));
   }
 
@@ -135,6 +145,10 @@ class DirectZstd {
   }
 
   private static BufferPool getPool(Configuration conf) {
+    return getPool(new HadoopParquetConfiguration(conf));
+  }
+
+  private static BufferPool getPool(ParquetConfiguration conf) {
     if (conf.getBoolean(PARQUET_COMPRESS_ZSTD_BUFFERPOOL_ENABLED, DEFAULT_PARQUET_COMPRESS_ZSTD_BUFFERPOOL_ENABLED)) {
       return RecyclingBufferPool.INSTANCE;
     } else {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
@@ -173,9 +173,6 @@ class InternalParquetRecordReader<T> {
     for (String property : options.getPropertyNames()) {
       conf.set(property, options.getProperty(property));
     }
-    for (Map.Entry<String, String> property : new Configuration()) {
-      conf.set(property.getKey(), property.getValue());
-    }
 
     // initialize a ReadContext for this file
     this.reader = reader;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
@@ -30,7 +30,6 @@ import java.util.stream.LongStream;
 
 import org.apache.hadoop.conf.Configuration;
 
-import org.apache.parquet.HadoopReadOptions;
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.conf.ParquetConfiguration;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -195,24 +195,6 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
     return ConfigurationUtil.getClassFromConfig(configuration, UNBOUND_RECORD_FILTER, UnboundRecordFilter.class);
   }
 
-  private static UnboundRecordFilter getUnboundRecordFilterInstance(Configuration configuration) {
-    Class<?> clazz = ConfigurationUtil.getClassFromConfig(configuration, UNBOUND_RECORD_FILTER, UnboundRecordFilter.class);
-    if (clazz == null) { return null; }
-
-    try {
-      UnboundRecordFilter unboundRecordFilter = (UnboundRecordFilter) clazz.newInstance();
-
-      if (unboundRecordFilter instanceof Configurable) {
-        ((Configurable)unboundRecordFilter).setConf(configuration);
-      }
-
-      return unboundRecordFilter;
-    } catch (InstantiationException | IllegalAccessException e) {
-      throw new BadConfigurationException(
-          "could not instantiate unbound record filter class", e);
-    }
-  }
-
   private static UnboundRecordFilter getUnboundRecordFilterInstance(ParquetConfiguration configuration) {
     Class<?> clazz = ConfigurationUtil.getClassFromConfig(configuration, UNBOUND_RECORD_FILTER, UnboundRecordFilter.class);
     if (clazz == null) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -293,16 +293,16 @@ public class ParquetWriter<T> implements Closeable {
   }
 
   ParquetWriter(
-    OutputFile file,
-    ParquetFileWriter.Mode mode,
-    WriteSupport<T> writeSupport,
-    CompressionCodecName compressionCodecName,
-    long rowGroupSize,
-    boolean validating,
-    ParquetConfiguration conf,
-    int maxPaddingSize,
-    ParquetProperties encodingProps,
-    FileEncryptionProperties encryptionProperties) throws IOException {
+      OutputFile file,
+      ParquetFileWriter.Mode mode,
+      WriteSupport<T> writeSupport,
+      CompressionCodecName compressionCodecName,
+      long rowGroupSize,
+      boolean validating,
+      ParquetConfiguration conf,
+      int maxPaddingSize,
+      ParquetProperties encodingProps,
+      FileEncryptionProperties encryptionProperties) throws IOException {
 
     WriteSupport.WriteContext writeContext = writeSupport.init(conf);
     MessageType schema = writeContext.getSchema();
@@ -414,7 +414,7 @@ public class ParquetWriter<T> implements Closeable {
      * @return an appropriate WriteSupport for the object model.
      */
     protected WriteSupport<T> getWriteSupport(ParquetConfiguration conf) {
-      throw new UnsupportedOperationException("Override getWriteSupport(ParquetConfiguration)");
+      throw new UnsupportedOperationException("Override ParquetWriter$Builder#getWriteSupport(ParquetConfiguration)");
     }
 
     /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/DelegatingReadSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/DelegatingReadSupport.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.io.api.RecordMaterializer;
 import org.apache.parquet.schema.MessageType;
 
@@ -47,6 +48,15 @@ public class DelegatingReadSupport<T> extends ReadSupport<T> {
   @Override
   public RecordMaterializer<T> prepareForRead(
       Configuration configuration,
+      Map<String, String> keyValueMetaData,
+      MessageType fileSchema,
+      ReadSupport.ReadContext readContext) {
+    return delegate.prepareForRead(configuration, keyValueMetaData, fileSchema, readContext);
+  }
+
+  @Override
+  public RecordMaterializer<T> prepareForRead(
+      ParquetConfiguration configuration,
       Map<String, String> keyValueMetaData,
       MessageType fileSchema,
       ReadSupport.ReadContext readContext) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/DelegatingWriteSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/DelegatingWriteSupport.java
@@ -20,6 +20,7 @@ package org.apache.parquet.hadoop.api;
 
 import org.apache.hadoop.conf.Configuration;
 
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.io.api.RecordConsumer;
 
 /**
@@ -39,6 +40,11 @@ public class DelegatingWriteSupport<T> extends WriteSupport<T> {
 
   @Override
   public WriteSupport.WriteContext init(Configuration configuration) {
+    return delegate.init(configuration);
+  }
+
+  @Override
+  public WriteSupport.WriteContext init(ParquetConfiguration configuration) {
     return delegate.init(configuration);
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/InitContext.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/InitContext.java
@@ -90,7 +90,7 @@ public class InitContext {
     return ConfigurationUtil.createHadoopConfiguration(configuration);
   }
 
-  public ParquetConfiguration getConfig() {
+  public ParquetConfiguration getParquetConfiguration() {
     return configuration;
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/InitContext.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/InitContext.java
@@ -90,6 +90,9 @@ public class InitContext {
     return ConfigurationUtil.createHadoopConfiguration(configuration);
   }
 
+  /**
+   * @return the Parquet configuration for this job
+   */
   public ParquetConfiguration getParquetConfiguration() {
     return configuration;
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/InitContext.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/InitContext.java
@@ -25,6 +25,9 @@ import java.util.Map.Entry;
 
 import org.apache.hadoop.conf.Configuration;
 
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
+import org.apache.parquet.hadoop.util.ConfigurationUtil;
 import org.apache.parquet.schema.MessageType;
 
 /**
@@ -35,7 +38,7 @@ public class InitContext {
 
   private final Map<String,Set<String>> keyValueMetadata;
   private Map<String,String> mergedKeyValueMetadata;
-  private final Configuration configuration;
+  private final ParquetConfiguration configuration;
   private final MessageType fileSchema;
 
   /**
@@ -45,6 +48,13 @@ public class InitContext {
    */
   public InitContext(
       Configuration configuration,
+      Map<String, Set<String>> keyValueMetadata,
+      MessageType fileSchema) {
+    this(new HadoopParquetConfiguration(configuration), keyValueMetadata, fileSchema);
+  }
+
+  public InitContext(
+      ParquetConfiguration configuration,
       Map<String, Set<String>> keyValueMetadata,
       MessageType fileSchema) {
     super();
@@ -77,6 +87,10 @@ public class InitContext {
    * @return the configuration for this job
    */
   public Configuration getConfiguration() {
+    return ConfigurationUtil.createHadoopConfiguration(configuration);
+  }
+
+  public ParquetConfiguration getConfig() {
     return configuration;
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/ReadSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/ReadSupport.java
@@ -101,7 +101,7 @@ abstract public class ReadSupport<T> {
    * @return the readContext that defines how to read the file
    */
   public ReadContext init(InitContext context) {
-    return init(context.getConfig(), context.getMergedKeyValueMetaData(), context.getFileSchema());
+    return init(context.getParquetConfiguration(), context.getMergedKeyValueMetaData(), context.getFileSchema());
   }
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/ReadSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/ReadSupport.java
@@ -70,10 +70,10 @@ abstract public class ReadSupport<T> {
    */
   @Deprecated
   public ReadContext init(
-          Configuration configuration,
-          Map<String, String> keyValueMetaData,
-          MessageType fileSchema) {
-    throw new UnsupportedOperationException("Override init(InitContext)");
+      Configuration configuration,
+      Map<String, String> keyValueMetaData,
+      MessageType fileSchema) {
+    throw new UnsupportedOperationException("Override ReadSupport.init(InitContext)");
   }
 
   /**
@@ -91,7 +91,7 @@ abstract public class ReadSupport<T> {
       ParquetConfiguration configuration,
       Map<String, String> keyValueMetaData,
       MessageType fileSchema) {
-    throw new UnsupportedOperationException("Override init(InitContext)");
+    throw new UnsupportedOperationException("Override ReadSupport.init(InitContext)");
   }
 
   /**
@@ -135,7 +135,7 @@ abstract public class ReadSupport<T> {
       Map<String, String> keyValueMetaData,
       MessageType fileSchema,
       ReadContext readContext) {
-    throw new UnsupportedOperationException("Override prepareForRead(ParquetConfiguration, Map<String, String>, MessageType, ReadContext)");
+    throw new UnsupportedOperationException("Override ReadSupport.prepareForRead(ParquetConfiguration, Map<String, String>, MessageType, ReadContext)");
   }
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/ReadSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/ReadSupport.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.io.api.RecordMaterializer;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
@@ -78,11 +79,29 @@ abstract public class ReadSupport<T> {
   /**
    * called in {@link org.apache.hadoop.mapreduce.InputFormat#getSplits(org.apache.hadoop.mapreduce.JobContext)} in the front end
    *
+   * @param configuration    the configuration
+   * @param keyValueMetaData the app specific metadata from the file
+   * @param fileSchema       the schema of the file
+   * @return the readContext that defines how to read the file
+   *
+   * @deprecated override {@link ReadSupport#init(InitContext)} instead
+   */
+  @Deprecated
+  public ReadContext init(
+      ParquetConfiguration configuration,
+      Map<String, String> keyValueMetaData,
+      MessageType fileSchema) {
+    throw new UnsupportedOperationException("Override init(InitContext)");
+  }
+
+  /**
+   * called in {@link org.apache.hadoop.mapreduce.InputFormat#getSplits(org.apache.hadoop.mapreduce.JobContext)} in the front end
+   *
    * @param context the initialisation context
    * @return the readContext that defines how to read the file
    */
   public ReadContext init(InitContext context) {
-    return init(context.getConfiguration(), context.getMergedKeyValueMetaData(), context.getFileSchema());
+    return init(context.getConfig(), context.getMergedKeyValueMetaData(), context.getFileSchema());
   }
 
   /**
@@ -100,6 +119,24 @@ abstract public class ReadSupport<T> {
           Map<String, String> keyValueMetaData,
           MessageType fileSchema,
           ReadContext readContext);
+
+  /**
+   * called in {@link org.apache.hadoop.mapreduce.RecordReader#initialize(org.apache.hadoop.mapreduce.InputSplit, org.apache.hadoop.mapreduce.TaskAttemptContext)} in the back end
+   * the returned RecordMaterializer will materialize the records and add them to the destination
+   *
+   * @param configuration    the configuration
+   * @param keyValueMetaData the app specific metadata from the file
+   * @param fileSchema       the schema of the file
+   * @param readContext      returned by the init method
+   * @return the recordMaterializer that will materialize the records
+   */
+  public RecordMaterializer<T> prepareForRead(
+      ParquetConfiguration configuration,
+      Map<String, String> keyValueMetaData,
+      MessageType fileSchema,
+      ReadContext readContext) {
+    throw new UnsupportedOperationException("Override prepareForRead(ParquetConfiguration, Map<String, String>, MessageType, ReadContext)");
+  }
 
   /**
    * information to read the file

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/WriteSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/WriteSupport.java
@@ -112,7 +112,7 @@ abstract public class WriteSupport<T> {
    * @return the information needed to write the file
    */
   public WriteContext init(ParquetConfiguration configuration) {
-    throw new UnsupportedOperationException("Override init(ParquetConfiguration)");
+    throw new UnsupportedOperationException("Override WriteSupport#init(ParquetConfiguration)");
   }
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/WriteSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/WriteSupport.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 
 import org.apache.hadoop.conf.Configuration;
 
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.MessageType;
 
@@ -104,6 +105,15 @@ abstract public class WriteSupport<T> {
    * @return the information needed to write the file
    */
   public abstract WriteContext init(Configuration configuration);
+
+  /**
+   * called first in the task
+   * @param configuration the job's configuration
+   * @return the information needed to write the file
+   */
+  public WriteContext init(ParquetConfiguration configuration) {
+    throw new UnsupportedOperationException("Override init(ParquetConfiguration)");
+  }
 
   /**
    * This will be called once per row group

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/example/ExampleParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/example/ExampleParquetWriter.java
@@ -21,6 +21,7 @@ package org.apache.parquet.hadoop.example;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
@@ -111,6 +112,11 @@ public class ExampleParquetWriter extends ParquetWriter<Group> {
 
     @Override
     protected WriteSupport<Group> getWriteSupport(Configuration conf) {
+      return getWriteSupport((ParquetConfiguration) null);
+    }
+
+    @Override
+    protected WriteSupport<Group> getWriteSupport(ParquetConfiguration conf) {
       return new GroupWriteSupport(type, extraMetaData);
     }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/example/GroupReadSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/example/GroupReadSupport.java
@@ -22,6 +22,8 @@ import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.convert.GroupRecordConverter;
 import org.apache.parquet.hadoop.api.ReadSupport;
@@ -34,6 +36,13 @@ public class GroupReadSupport extends ReadSupport<Group> {
   public org.apache.parquet.hadoop.api.ReadSupport.ReadContext init(
       Configuration configuration, Map<String, String> keyValueMetaData,
       MessageType fileSchema) {
+    return init(new HadoopParquetConfiguration(configuration), keyValueMetaData, fileSchema);
+  }
+
+  @Override
+  public org.apache.parquet.hadoop.api.ReadSupport.ReadContext init(
+      ParquetConfiguration configuration, Map<String, String> keyValueMetaData,
+      MessageType fileSchema) {
     String partialSchemaString = configuration.get(ReadSupport.PARQUET_READ_SCHEMA);
     MessageType requestedProjection = getSchemaForRead(fileSchema, partialSchemaString);
     return new ReadContext(requestedProjection);
@@ -43,6 +52,13 @@ public class GroupReadSupport extends ReadSupport<Group> {
   public RecordMaterializer<Group> prepareForRead(Configuration configuration,
       Map<String, String> keyValueMetaData, MessageType fileSchema,
       org.apache.parquet.hadoop.api.ReadSupport.ReadContext readContext) {
+    return new GroupRecordConverter(readContext.getRequestedSchema());
+  }
+
+  @Override
+  public RecordMaterializer<Group> prepareForRead(ParquetConfiguration configuration,
+                                                  Map<String, String> keyValueMetaData, MessageType fileSchema,
+                                                  org.apache.parquet.hadoop.api.ReadSupport.ReadContext readContext) {
     return new GroupRecordConverter(readContext.getRequestedSchema());
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/example/GroupWriteSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/example/GroupWriteSupport.java
@@ -26,6 +26,8 @@ import java.util.Objects;
 
 import org.apache.hadoop.conf.Configuration;
 
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.GroupWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
@@ -41,6 +43,10 @@ public class GroupWriteSupport extends WriteSupport<Group> {
   }
 
   public static MessageType getSchema(Configuration configuration) {
+    return getSchema(new HadoopParquetConfiguration(configuration));
+  }
+
+  public static MessageType getSchema(ParquetConfiguration configuration) {
     return parseMessageType(Objects.requireNonNull(configuration.get(PARQUET_EXAMPLE_SCHEMA), PARQUET_EXAMPLE_SCHEMA));
   }
 
@@ -68,6 +74,11 @@ public class GroupWriteSupport extends WriteSupport<Group> {
 
   @Override
   public org.apache.parquet.hadoop.api.WriteSupport.WriteContext init(Configuration configuration) {
+    return init(new HadoopParquetConfiguration(configuration));
+  }
+
+  @Override
+  public org.apache.parquet.hadoop.api.WriteSupport.WriteContext init(ParquetConfiguration configuration) {
     // if present, prefer the schema passed to the constructor
     if (schema == null) {
       schema = getSchema(configuration);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopCodecs.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopCodecs.java
@@ -22,6 +22,7 @@ package org.apache.parquet.hadoop.util;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.compression.CompressionCodecFactory;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.hadoop.CodecFactory;
 
 public class HadoopCodecs {
@@ -30,6 +31,10 @@ public class HadoopCodecs {
   }
 
   public static CompressionCodecFactory newFactory(Configuration conf, int sizeHint) {
+    return new CodecFactory(conf, sizeHint);
+  }
+
+  public static CompressionCodecFactory newFactory(ParquetConfiguration conf, int sizeHint) {
     return new CodecFactory(conf, sizeHint);
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/SerializationUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/SerializationUtil.java
@@ -29,6 +29,8 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 
 /**
  * Serialization utils copied from:
@@ -70,8 +72,22 @@ public final class SerializationUtil {
    * @return the read object, or null if key is not present in conf
    * @throws IOException if there is an error while reading
    */
-  @SuppressWarnings("unchecked")
   public static <T> T readObjectFromConfAsBase64(String key, Configuration conf) throws IOException {
+    return readObjectFromConfAsBase64(key, new HadoopParquetConfiguration(conf));
+  }
+
+  /**
+   * Reads an object (that was written using
+   * {@link #writeObjectToConfAsBase64}) from a configuration
+   *
+   * @param key for the configuration
+   * @param conf to read from
+   * @param <T> the Java type of the deserialized object
+   * @return the read object, or null if key is not present in conf
+   * @throws IOException if there is an error while reading
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T readObjectFromConfAsBase64(String key, ParquetConfiguration conf) throws IOException {
     String b64 = conf.get(key);
     if (b64 == null) {
       return null;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/DirectWriterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/DirectWriterTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -86,6 +87,11 @@ public class DirectWriterTest {
 
     @Override
     public WriteContext init(Configuration configuration) {
+      return init((ParquetConfiguration) null);
+    }
+
+    @Override
+    public WriteContext init(ParquetConfiguration configuration) {
       return new WriteContext(type, metadata);
     }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/crypto/propertiesfactory/SchemaControlEncryptionTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/crypto/propertiesfactory/SchemaControlEncryptionTest.java
@@ -22,6 +22,8 @@ package org.apache.parquet.crypto.propertiesfactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.crypto.EncryptionPropertiesFactory;
 import org.apache.parquet.crypto.ParquetCipher;
 import org.apache.parquet.example.data.Group;
@@ -203,6 +205,11 @@ public class SchemaControlEncryptionTest {
 
     @Override
     public WriteContext init(Configuration conf) {
+      return init(new HadoopParquetConfiguration(conf));
+    }
+
+    @Override
+    public WriteContext init(ParquetConfiguration conf) {
       WriteContext writeContext = super.init(conf);
       MessageType schema = writeContext.getSchema();
       List<ColumnDescriptor> columns = schema.getColumns();
@@ -219,6 +226,10 @@ public class SchemaControlEncryptionTest {
     }
 
     private void setMetadata(ColumnDescriptor column, Configuration conf) {
+      setMetadata(column, new HadoopParquetConfiguration(conf));
+    }
+
+    private void setMetadata(ColumnDescriptor column, ParquetConfiguration conf) {
       String columnShortName = column.getPath()[column.getPath().length - 1];
       if (cryptoMetadata.containsKey(columnShortName) &&
         cryptoMetadata.get(columnShortName).get("columnKeyMetaData") != null) {
@@ -242,6 +253,11 @@ public class SchemaControlEncryptionTest {
 
     @Override
     protected WriteSupport<Group> getWriteSupport(Configuration conf) {
+      return getWriteSupport((ParquetConfiguration) null);
+    }
+
+    @Override
+    protected WriteSupport<Group> getWriteSupport(ParquetConfiguration conf) {
       return new CryptoGroupWriteSupport();
     }
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestEncryptionOptions.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestEncryptionOptions.java
@@ -316,7 +316,7 @@ public class TestEncryptionOptions {
     Path rootPath = new Path(temporaryFolder.getRoot().getPath());
     LOG.info("======== testWriteReadEncryptedParquetFiles {} ========", rootPath.toString());
     byte[] AADPrefix = AAD_PREFIX_STRING.getBytes(StandardCharsets.UTF_8);
-    // Write using various encryption configuraions
+    // Write using various encryption configurations
     testWriteEncryptedParquetFiles(rootPath, DATA);
     // Read using various decryption configurations.
     testReadEncryptedParquetFiles(rootPath, DATA);

--- a/parquet-pig/src/main/java/org/apache/parquet/pig/TupleReadSupport.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/TupleReadSupport.java
@@ -172,9 +172,9 @@ public class TupleReadSupport extends ReadSupport<Tuple> {
 
   @Override
   public ReadContext init(InitContext initContext) {
-    Schema pigSchema = getPigSchema(initContext.getConfig());
-    RequiredFieldList requiredFields = getRequiredFields(initContext.getConfig());
-    boolean columnIndexAccess = initContext.getConfig().getBoolean(PARQUET_COLUMN_INDEX_ACCESS, false);
+    Schema pigSchema = getPigSchema(initContext.getParquetConfiguration());
+    RequiredFieldList requiredFields = getRequiredFields(initContext.getParquetConfiguration());
+    boolean columnIndexAccess = initContext.getParquetConfiguration().getBoolean(PARQUET_COLUMN_INDEX_ACCESS, false);
 
     if (pigSchema == null) {
       return new ReadContext(initContext.getFileSchema());

--- a/parquet-pig/src/main/java/org/apache/parquet/pig/TupleReadSupport.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/TupleReadSupport.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.pig.LoadPushDown.RequiredFieldList;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.impl.logicalLayer.FrontendException;
@@ -61,6 +63,14 @@ public class TupleReadSupport extends ReadSupport<Tuple> {
    * @return the pig schema requested by the user or null if none.
    */
   static Schema getPigSchema(Configuration configuration) {
+    return getPigSchema(new HadoopParquetConfiguration(configuration));
+  }
+
+  /**
+   * @param configuration the configuration
+   * @return the pig schema requested by the user or null if none.
+   */
+  static Schema getPigSchema(ParquetConfiguration configuration) {
     return parsePigSchema(configuration.get(PARQUET_PIG_SCHEMA));
   }
 
@@ -69,9 +79,17 @@ public class TupleReadSupport extends ReadSupport<Tuple> {
    * @return List of required fields from pushProjection
    */
   static RequiredFieldList getRequiredFields(Configuration configuration) {
+    return getRequiredFields(new HadoopParquetConfiguration(configuration));
+  }
+
+  /**
+   * @param configuration configuration
+   * @return List of required fields from pushProjection
+   */
+  static RequiredFieldList getRequiredFields(ParquetConfiguration configuration) {
     String requiredFieldString = configuration.get(PARQUET_PIG_REQUIRED_FIELDS);
 
-    if(requiredFieldString == null) {
+    if (requiredFieldString == null) {
       return null;
     }
 
@@ -154,9 +172,9 @@ public class TupleReadSupport extends ReadSupport<Tuple> {
 
   @Override
   public ReadContext init(InitContext initContext) {
-    Schema pigSchema = getPigSchema(initContext.getConfiguration());
-    RequiredFieldList requiredFields = getRequiredFields(initContext.getConfiguration());
-    boolean columnIndexAccess = initContext.getConfiguration().getBoolean(PARQUET_COLUMN_INDEX_ACCESS, false);
+    Schema pigSchema = getPigSchema(initContext.getConfig());
+    RequiredFieldList requiredFields = getRequiredFields(initContext.getConfig());
+    boolean columnIndexAccess = initContext.getConfig().getBoolean(PARQUET_COLUMN_INDEX_ACCESS, false);
 
     if (pigSchema == null) {
       return new ReadContext(initContext.getFileSchema());
@@ -174,9 +192,17 @@ public class TupleReadSupport extends ReadSupport<Tuple> {
       Map<String, String> keyValueMetaData,
       MessageType fileSchema,
       ReadContext readContext) {
+    return prepareForRead(new HadoopParquetConfiguration(configuration), keyValueMetaData, fileSchema, readContext);
+  }
+
+  @Override
+  public RecordMaterializer<Tuple> prepareForRead(
+      ParquetConfiguration configuration,
+      Map<String, String> keyValueMetaData,
+      MessageType fileSchema,
+      ReadContext readContext) {
     MessageType requestedSchema = readContext.getRequestedSchema();
     Schema requestedPigSchema = getPigSchema(configuration);
-
     if (requestedPigSchema == null) {
       throw new ParquetDecodingException("Missing Pig schema: ParquetLoader sets the schema in the job conf");
     }

--- a/parquet-pig/src/main/java/org/apache/parquet/pig/TupleWriteSupport.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/TupleWriteSupport.java
@@ -26,6 +26,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.pig.backend.executionengine.ExecException;
 import org.apache.pig.data.DataBag;
 import org.apache.pig.data.DataByteArray;
@@ -82,6 +84,11 @@ public class TupleWriteSupport extends WriteSupport<Tuple> {
 
   @Override
   public WriteContext init(Configuration configuration) {
+    return init(new HadoopParquetConfiguration(configuration));
+  }
+
+  @Override
+  public WriteContext init(ParquetConfiguration configuration) {
     Map<String, String> extraMetaData = new HashMap<String, String>();
     new PigMetaData(rootPigSchema).addToMetaData(extraMetaData);
     return new WriteContext(rootSchema, extraMetaData);

--- a/parquet-pig/src/test/java/org/apache/parquet/pig/TestTupleRecordConsumer.java
+++ b/parquet-pig/src/test/java/org/apache/parquet/pig/TestTupleRecordConsumer.java
@@ -33,6 +33,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.pig.backend.executionengine.ExecException;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
@@ -175,7 +176,7 @@ public class TestTupleRecordConsumer {
 
   private <T> TupleWriteSupport newTupleWriter(String pigSchemaString, RecordMaterializer<T> recordConsumer) throws ParserException {
     TupleWriteSupport tupleWriter = TupleWriteSupport.fromPigSchema(pigSchemaString);
-    tupleWriter.init(null);
+    tupleWriter.init((ParquetConfiguration) null);
     tupleWriter.prepareForWrite(
         new ConverterConsumer(recordConsumer.getRootConverter(), tupleWriter.getParquetSchema())
         );

--- a/parquet-pig/src/test/java/org/apache/parquet/pig/TupleConsumerPerfTest.java
+++ b/parquet-pig/src/test/java/org/apache/parquet/pig/TupleConsumerPerfTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.logging.Level;
 
 import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.pig.backend.executionengine.ExecException;
 import org.apache.pig.data.DataBag;
 import org.apache.pig.data.NonSpillableDataBag;
@@ -130,8 +131,8 @@ public class TupleConsumerPerfTest {
     TupleReadSupport tupleReadSupport = new TupleReadSupport();
     Map<String, String> pigMetaData = pigMetaData(pigSchemaString);
     MessageType schema = new PigSchemaConverter().convert(Utils.getSchemaFromString(pigSchemaString));
-    ReadContext init = tupleReadSupport.init(null, pigMetaData, schema);
-    RecordMaterializer<Tuple> recordConsumer = tupleReadSupport.prepareForRead(null, pigMetaData, schema, init);
+    ReadContext init = tupleReadSupport.init((ParquetConfiguration) null, pigMetaData, schema);
+    RecordMaterializer<Tuple> recordConsumer = tupleReadSupport.prepareForRead((ParquetConfiguration) null, pigMetaData, schema, init);
     RecordReader<Tuple> recordReader = columnIO.getRecordReader(columns, recordConsumer);
     // TODO: put this back
 //  if (DEBUG) {
@@ -156,7 +157,7 @@ public class TupleConsumerPerfTest {
   private static void write(MemPageStore memPageStore, ColumnWriteStoreV1 columns, MessageType schema, String pigSchemaString) throws ExecException, ParserException {
     MessageColumnIO columnIO = newColumnFactory(pigSchemaString);
     TupleWriteSupport tupleWriter = TupleWriteSupport.fromPigSchema(pigSchemaString);
-    tupleWriter.init(null);
+    tupleWriter.init((ParquetConfiguration) null);
     tupleWriter.prepareForWrite(columnIO.getRecordWriter(columns));
     write(memPageStore, tupleWriter, 10000);
     write(memPageStore, tupleWriter, 10000);

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoMessageConverter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoMessageConverter.java
@@ -25,6 +25,8 @@ import com.google.protobuf.Message;
 import com.twitter.elephantbird.util.Protobufs;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.hadoop.BadConfigurationException;
 import org.apache.parquet.io.InvalidRecordException;
 import org.apache.parquet.io.ParquetDecodingException;
@@ -68,7 +70,7 @@ class ProtoMessageConverter extends GroupConverter {
     }
   };
 
-  protected final Configuration conf;
+  protected final ParquetConfiguration conf;
   protected final Converter[] converters;
   protected final ParentValueContainer parent;
   protected final Message.Builder myBuilder;
@@ -88,8 +90,16 @@ class ProtoMessageConverter extends GroupConverter {
     this(conf, pvc, Protobufs.getMessageBuilder(protoClass), parquetSchema, extraMetadata);
   }
 
+  ProtoMessageConverter(ParquetConfiguration conf, ParentValueContainer pvc, Class<? extends Message> protoClass, GroupType parquetSchema, Map<String, String> extraMetadata) {
+    this(conf, pvc, Protobufs.getMessageBuilder(protoClass), parquetSchema, extraMetadata);
+  }
+
   // For usage in message arrays
   ProtoMessageConverter(Configuration conf, ParentValueContainer pvc, Message.Builder builder, GroupType parquetSchema, Map<String, String> extraMetadata) {
+    this(new HadoopParquetConfiguration(conf), pvc, builder, parquetSchema, extraMetadata);
+  }
+
+  ProtoMessageConverter(ParquetConfiguration conf, ParentValueContainer pvc, Message.Builder builder, GroupType parquetSchema, Map<String, String> extraMetadata) {
     if (pvc == null) {
       throw new IllegalStateException("Missing parent value container");
     }
@@ -141,7 +151,12 @@ class ProtoMessageConverter extends GroupConverter {
   private Converter dummyScalarConverter(ParentValueContainer pvc,
                                          Type parquetField, Configuration conf,
                                          Map<String, String> extraMetadata) {
+    return dummyScalarConverter(pvc, parquetField, new HadoopParquetConfiguration(conf), extraMetadata);
+  }
 
+  private Converter dummyScalarConverter(ParentValueContainer pvc,
+                                         Type parquetField, ParquetConfiguration conf,
+                                         Map<String, String> extraMetadata) {
     if (parquetField.isPrimitive()) {
       PrimitiveType primitiveType = parquetField.asPrimitiveType();
       PrimitiveType.PrimitiveTypeName primitiveTypeName = primitiveType.getPrimitiveTypeName();

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
@@ -21,6 +21,7 @@ package org.apache.parquet.proto;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -120,8 +121,15 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
 			return this;
 		}
 
-		protected WriteSupport<T> getWriteSupport(Configuration conf) {
-		    return (WriteSupport<T>) ProtoParquetWriter.writeSupport(protoMessage);
-		}
+    @Override
+    protected WriteSupport<T> getWriteSupport(Configuration conf) {
+      return getWriteSupport((ParquetConfiguration) null);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected WriteSupport<T> getWriteSupport(ParquetConfiguration conf) {
+      return (WriteSupport<T>) ProtoParquetWriter.writeSupport(protoMessage);
+    }
 	}
 }

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoReadSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoReadSupport.java
@@ -21,6 +21,8 @@ package org.apache.parquet.proto;
 import com.google.protobuf.Message;
 import com.twitter.elephantbird.util.Protobufs;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.hadoop.api.InitContext;
 import org.apache.parquet.hadoop.api.ReadSupport;
 import org.apache.parquet.io.api.RecordMaterializer;
@@ -59,7 +61,7 @@ public class ProtoReadSupport<T extends Message> extends ReadSupport<T> {
 
   @Override
   public ReadContext init(InitContext context) {
-    String requestedProjectionString = context.getConfiguration().get(PB_REQUESTED_PROJECTION);
+    String requestedProjectionString = context.getConfig().get(PB_REQUESTED_PROJECTION);
 
     if (requestedProjectionString != null && !requestedProjectionString.trim().isEmpty()) {
       MessageType requestedProjection = getSchemaForRead(context.getFileSchema(), requestedProjectionString);
@@ -74,6 +76,11 @@ public class ProtoReadSupport<T extends Message> extends ReadSupport<T> {
 
   @Override
   public RecordMaterializer<T> prepareForRead(Configuration configuration, Map<String, String> keyValueMetaData, MessageType fileSchema, ReadContext readContext) {
+    return prepareForRead(new HadoopParquetConfiguration(configuration), keyValueMetaData, fileSchema, readContext);
+  }
+
+  @Override
+  public RecordMaterializer<T> prepareForRead(ParquetConfiguration configuration, Map<String, String> keyValueMetaData, MessageType fileSchema, ReadContext readContext) {
     String headerProtoClass = keyValueMetaData.get(PB_CLASS);
     String configuredProtoClass = configuration.get(PB_CLASS);
 

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoReadSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoReadSupport.java
@@ -61,7 +61,7 @@ public class ProtoReadSupport<T extends Message> extends ReadSupport<T> {
 
   @Override
   public ReadContext init(InitContext context) {
-    String requestedProjectionString = context.getConfig().get(PB_REQUESTED_PROJECTION);
+    String requestedProjectionString = context.getParquetConfiguration().get(PB_REQUESTED_PROJECTION);
 
     if (requestedProjectionString != null && !requestedProjectionString.trim().isEmpty()) {
       MessageType requestedProjection = getSchemaForRead(context.getFileSchema(), requestedProjectionString);

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoRecordConverter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoRecordConverter.java
@@ -22,6 +22,7 @@ package org.apache.parquet.proto;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.schema.MessageType;
 
 import java.util.Collections;
@@ -50,6 +51,11 @@ public class ProtoRecordConverter<T extends MessageOrBuilder> extends ProtoMessa
   }
 
   public ProtoRecordConverter(Configuration conf, Class<? extends Message> protoclass, MessageType parquetSchema, Map<String, String> extraMetadata) {
+    super(conf, new SkipParentValueContainer(), protoclass, parquetSchema, extraMetadata);
+    reusedBuilder = getBuilder();
+  }
+
+  public ProtoRecordConverter(ParquetConfiguration conf, Class<? extends Message> protoclass, MessageType parquetSchema, Map<String, String> extraMetadata) {
     super(conf, new SkipParentValueContainer(), protoclass, parquetSchema, extraMetadata);
     reusedBuilder = getBuilder();
   }

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoRecordMaterializer.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoRecordMaterializer.java
@@ -21,6 +21,8 @@ package org.apache.parquet.proto;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.io.api.GroupConverter;
 import org.apache.parquet.io.api.RecordMaterializer;
 import org.apache.parquet.schema.MessageType;
@@ -32,6 +34,10 @@ class ProtoRecordMaterializer<T extends MessageOrBuilder> extends RecordMaterial
   private final ProtoRecordConverter<T> root;
 
   public ProtoRecordMaterializer(Configuration conf, MessageType requestedSchema, Class<? extends Message> protobufClass, Map<String, String> metadata) {
+    this(new HadoopParquetConfiguration(conf), requestedSchema, protobufClass, metadata);
+  }
+
+  public ProtoRecordMaterializer(ParquetConfiguration conf, MessageType requestedSchema, Class<? extends Message> protobufClass, Map<String, String> metadata) {
     this.root = new ProtoRecordConverter<T>(conf, protobufClass, requestedSchema, metadata);
   }
 

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoSchemaConverter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoSchemaConverter.java
@@ -25,6 +25,8 @@ import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 import com.google.protobuf.Message;
 import com.twitter.elephantbird.util.Protobufs;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
@@ -81,9 +83,19 @@ public class ProtoSchemaConverter {
    * Instantiate a schema converter to get the parquet schema corresponding to protobuf classes.
    * Returns instances that are not specs compliant and limited to 5 levels of recursion depth.
    *
-   * @param config   Hadoop configuration object to parrse parquetSpecsCompliant and maxRecursion settings.
+   * @param config   Hadoop configuration object to parse parquetSpecsCompliant and maxRecursion settings.
    */
   public ProtoSchemaConverter(Configuration config) {
+    this(new HadoopParquetConfiguration(config));
+  }
+
+  /**
+   * Instantiate a schema converter to get the parquet schema corresponding to protobuf classes.
+   * Returns instances that are not specs compliant and limited to 5 levels of recursion depth.
+   *
+   * @param config   Parquet configuration object to parse parquetSpecsCompliant and maxRecursion settings.
+   */
+  public ProtoSchemaConverter(ParquetConfiguration config) {
     this(
         config.getBoolean(ProtoWriteSupport.PB_SPECS_COMPLIANT_WRITE, false),
         config.getInt(PB_MAX_RECURSION, 5));

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -23,6 +23,8 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.twitter.elephantbird.util.Protobufs;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.hadoop.BadConfigurationException;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.io.InvalidRecordException;
@@ -118,6 +120,11 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
 
   @Override
   public WriteContext init(Configuration configuration) {
+    return init(new HadoopParquetConfiguration(configuration));
+  }
+
+  @Override
+  public WriteContext init(ParquetConfiguration configuration) {
 
     Map<String, String> extraMetaData = new HashMap<>();
 

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/AbstractThriftWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/AbstractThriftWriteSupport.java
@@ -18,6 +18,8 @@ package org.apache.parquet.hadoop.thrift;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.thrift.TBase;
 
 import com.twitter.elephantbird.pig.util.ThriftToPig;
@@ -40,14 +42,22 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractThriftWriteSupport<T> extends WriteSupport<T> {
   public static final String PARQUET_THRIFT_CLASS = "parquet.thrift.class";
   private static final Logger LOG = LoggerFactory.getLogger(AbstractThriftWriteSupport.class);
-  private static Configuration conf;
+  private static ParquetConfiguration conf;
 
   public static void setGenericThriftClass(Configuration configuration, Class<?> thriftClass) {
+    setGenericThriftClass(new HadoopParquetConfiguration(configuration), thriftClass);
+  }
+
+  public static void setGenericThriftClass(ParquetConfiguration configuration, Class<?> thriftClass) {
     conf = configuration;
     configuration.set(PARQUET_THRIFT_CLASS, thriftClass.getName());
   }
 
   public static Class getGenericThriftClass(Configuration configuration) {
+    return getGenericThriftClass(new HadoopParquetConfiguration(configuration));
+  }
+
+  public static Class<?> getGenericThriftClass(ParquetConfiguration configuration) {
     final String thriftClassName = configuration.get(PARQUET_THRIFT_CLASS);
     if (thriftClassName == null) {
       throw new BadConfigurationException("the thrift class conf is missing in job conf at " + PARQUET_THRIFT_CLASS);
@@ -111,9 +121,14 @@ public abstract class AbstractThriftWriteSupport<T> extends WriteSupport<T> {
 
   @Override
   public WriteContext init(Configuration configuration) {
+    return init(new HadoopParquetConfiguration(configuration));
+  }
+
+  @Override
+  public WriteContext init(ParquetConfiguration configuration) {
     conf = configuration;
     if (writeContext == null) {
-      init(getGenericThriftClass(configuration));
+      init((Class<T>) getGenericThriftClass(configuration));
     }
     return writeContext;
   }

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/AbstractThriftWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/AbstractThriftWriteSupport.java
@@ -53,7 +53,7 @@ public abstract class AbstractThriftWriteSupport<T> extends WriteSupport<T> {
     configuration.set(PARQUET_THRIFT_CLASS, thriftClass.getName());
   }
 
-  public static Class getGenericThriftClass(Configuration configuration) {
+  public static Class<?> getGenericThriftClass(Configuration configuration) {
     return getGenericThriftClass(new HadoopParquetConfiguration(configuration));
   }
 

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/TBaseWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/TBaseWriteSupport.java
@@ -16,6 +16,8 @@
 package org.apache.parquet.hadoop.thrift;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
 
@@ -25,14 +27,22 @@ import org.apache.parquet.thrift.struct.ThriftType.StructType;
 
 public class TBaseWriteSupport<T extends TBase<?, ?>> extends AbstractThriftWriteSupport<T> {
 
-  private static Configuration conf;
+  private static ParquetConfiguration conf;
 
   public static <U extends TBase<?,?>> void setThriftClass(Configuration configuration, Class<U> thriftClass) {
+    setThriftClass(new HadoopParquetConfiguration(configuration), thriftClass);
+  }
+
+  public static <U extends TBase<?,?>> void setThriftClass(ParquetConfiguration configuration, Class<U> thriftClass) {
     conf = configuration;
     AbstractThriftWriteSupport.setGenericThriftClass(configuration, thriftClass);
   }
 
   public static Class<? extends TBase<?,?>> getThriftClass(Configuration configuration) {
+    return getThriftClass(new HadoopParquetConfiguration(configuration));
+  }
+
+  public static Class<? extends TBase<?,?>> getThriftClass(ParquetConfiguration configuration) {
     return (Class<? extends TBase<?,?>>)AbstractThriftWriteSupport.getGenericThriftClass(configuration);
   }
 

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftBytesWriteSupport.java
@@ -24,6 +24,8 @@ import java.lang.reflect.Method;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.BytesWritable;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -57,6 +59,10 @@ public class ThriftBytesWriteSupport extends WriteSupport<BytesWritable> {
   }
 
   public static Class<TProtocolFactory> getTProtocolFactoryClass(Configuration conf) {
+    return getTProtocolFactoryClass(new HadoopParquetConfiguration(conf));
+  }
+
+  public static Class<TProtocolFactory> getTProtocolFactoryClass(ParquetConfiguration conf) {
     final String tProtocolClassName = conf.get(PARQUET_PROTOCOL_CLASS);
     if (tProtocolClassName == null) {
       throw new BadConfigurationException("the protocol class conf is missing in job conf at " + PARQUET_PROTOCOL_CLASS);
@@ -80,7 +86,7 @@ public class ThriftBytesWriteSupport extends WriteSupport<BytesWritable> {
   private StructType thriftStruct;
   private ParquetWriteProtocol parquetWriteProtocol;
   private final FieldIgnoredHandler errorHandler;
-  private Configuration configuration;
+  private ParquetConfiguration configuration;
 
   public ThriftBytesWriteSupport() {
     this.buffered = true;
@@ -106,6 +112,15 @@ public class ThriftBytesWriteSupport extends WriteSupport<BytesWritable> {
       Class<? extends TBase<?, ?>> thriftClass,
       boolean buffered,
       FieldIgnoredHandler errorHandler) {
+    this(new HadoopParquetConfiguration(configuration), protocolFactory, thriftClass, buffered, errorHandler);
+  }
+
+  public ThriftBytesWriteSupport(
+      ParquetConfiguration configuration,
+      TProtocolFactory protocolFactory,
+      Class<? extends TBase<?, ?>> thriftClass,
+      boolean buffered,
+      FieldIgnoredHandler errorHandler) {
     super();
     this.configuration = configuration;
     this.protocolFactory = protocolFactory;
@@ -124,6 +139,11 @@ public class ThriftBytesWriteSupport extends WriteSupport<BytesWritable> {
 
   @Override
   public WriteContext init(Configuration configuration) {
+    return init(new HadoopParquetConfiguration(configuration));
+  }
+
+  @Override
+  public WriteContext init(ParquetConfiguration configuration) {
     this.configuration = configuration;
     if (this.protocolFactory == null) {
       try {

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftReadSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftReadSupport.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.thrift.TBase;
 import org.apache.thrift.protocol.TProtocol;
 
@@ -111,6 +113,10 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
   }
 
   public static FieldProjectionFilter getFieldProjectionFilter(Configuration conf) {
+    return getFieldProjectionFilter(new HadoopParquetConfiguration(conf));
+  }
+
+  public static FieldProjectionFilter getFieldProjectionFilter(ParquetConfiguration conf) {
     String deprecated = conf.get(THRIFT_COLUMN_FILTER_KEY);
     String strict = conf.get(STRICT_THRIFT_COLUMN_FILTER_KEY);
 
@@ -155,7 +161,7 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
 
   @Override
   public org.apache.parquet.hadoop.api.ReadSupport.ReadContext init(InitContext context) {
-    final Configuration configuration = context.getConfiguration();
+    final ParquetConfiguration configuration = context.getConfig();
     final MessageType fileMessageType = context.getFileSchema();
     MessageType requestedProjection = fileMessageType;
     String partialSchemaString = configuration.get(ReadSupport.PARQUET_READ_SCHEMA);
@@ -185,8 +191,13 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
     return new ReadContext(schemaForRead);
   }
 
-  @SuppressWarnings("unchecked")
   protected MessageType getProjectedSchema(Configuration configuration, FieldProjectionFilter
+      fieldProjectionFilter) {
+    return getProjectedSchema(new HadoopParquetConfiguration(configuration), fieldProjectionFilter);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected MessageType getProjectedSchema(ParquetConfiguration configuration, FieldProjectionFilter
       fieldProjectionFilter) {
     return new ThriftSchemaConverter(configuration, fieldProjectionFilter)
         .convert((Class<TBase<?, ?>>)thriftClass);
@@ -200,8 +211,12 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
       .convert((Class<TBase<?, ?>>)thriftClass);
   }
 
-  @SuppressWarnings("unchecked")
   private void initThriftClassFromMultipleFiles(Map<String, Set<String>> fileMetadata, Configuration conf) throws ClassNotFoundException {
+    initThriftClassFromMultipleFiles(fileMetadata, new HadoopParquetConfiguration(conf));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void initThriftClassFromMultipleFiles(Map<String, Set<String>> fileMetadata, ParquetConfiguration conf) throws ClassNotFoundException {
     if (thriftClass != null) {
       return;
     }
@@ -216,8 +231,12 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
     thriftClass = (Class<T>)Class.forName(className);
   }
 
-  @SuppressWarnings("unchecked")
   private void initThriftClass(ThriftMetaData metadata, Configuration conf) throws ClassNotFoundException {
+    initThriftClass(metadata, new HadoopParquetConfiguration(conf));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void initThriftClass(ThriftMetaData metadata, ParquetConfiguration conf) throws ClassNotFoundException {
     if (thriftClass != null) {
       return;
     }
@@ -254,13 +273,48 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
         configuration);
   }
 
-  @SuppressWarnings("unchecked")
+  @Override
+  public RecordMaterializer<T> prepareForRead(ParquetConfiguration configuration,
+                                              Map<String, String> keyValueMetaData, MessageType fileSchema,
+                                              org.apache.parquet.hadoop.api.ReadSupport.ReadContext readContext) {
+    ThriftMetaData thriftMetaData = ThriftMetaData.fromExtraMetaData(keyValueMetaData);
+    try {
+      initThriftClass(thriftMetaData, configuration);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Cannot find Thrift object class for metadata: " + thriftMetaData, e);
+    }
+
+    // if there was not metadata in the file, get it from requested class
+    if (thriftMetaData == null) {
+      thriftMetaData = ThriftMetaData.fromThriftClass(thriftClass);
+    }
+
+    String converterClassName = configuration.get(RECORD_CONVERTER_CLASS_KEY, RECORD_CONVERTER_DEFAULT);
+    return getRecordConverterInstance(converterClassName, thriftClass,
+      readContext.getRequestedSchema(), thriftMetaData.getDescriptor(),
+      configuration);
+  }
+
   private static <T> ThriftRecordConverter<T> getRecordConverterInstance(
       String converterClassName, Class<T> thriftClass,
       MessageType requestedSchema, StructType descriptor, Configuration conf) {
-    Class<ThriftRecordConverter<T>> converterClass;
+    return getRecordConverterInstance(converterClassName, thriftClass, requestedSchema, descriptor, conf, Configuration.class);
+  }
+
+  private static <T> ThriftRecordConverter<T> getRecordConverterInstance(
+      String converterClassName, Class<T> thriftClass,
+      MessageType requestedSchema, StructType descriptor, ParquetConfiguration conf) {
+    return getRecordConverterInstance(converterClassName, thriftClass, requestedSchema, descriptor, conf, ParquetConfiguration.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T1, T2> ThriftRecordConverter<T1> getRecordConverterInstance(
+      String converterClassName, Class<T1> thriftClass,
+      MessageType requestedSchema, StructType descriptor, T2 conf, Class<T2> confClass) {
+
+    Class<ThriftRecordConverter<T1>> converterClass;
     try {
-      converterClass = (Class<ThriftRecordConverter<T>>) Class.forName(converterClassName);
+      converterClass = (Class<ThriftRecordConverter<T1>>) Class.forName(converterClassName);
     } catch (ClassNotFoundException e) {
       throw new RuntimeException("Cannot find Thrift converter class: " + converterClassName, e);
     }
@@ -268,15 +322,15 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
     try {
       // first try the new version that accepts a Configuration
       try {
-        Constructor<ThriftRecordConverter<T>> constructor =
-            converterClass.getConstructor(Class.class, MessageType.class, StructType.class, Configuration.class);
+        Constructor<ThriftRecordConverter<T1>> constructor =
+          converterClass.getConstructor(Class.class, MessageType.class, StructType.class, confClass);
         return constructor.newInstance(thriftClass, requestedSchema, descriptor, conf);
       } catch (IllegalAccessException | NoSuchMethodException e) {
         // try the other constructor pattern
       }
 
-      Constructor<ThriftRecordConverter<T>> constructor =
-          converterClass.getConstructor(Class.class, MessageType.class, StructType.class);
+      Constructor<ThriftRecordConverter<T1>> constructor =
+        converterClass.getConstructor(Class.class, MessageType.class, StructType.class);
       return constructor.newInstance(thriftClass, requestedSchema, descriptor);
     } catch (InstantiationException | InvocationTargetException e) {
       throw new RuntimeException("Failed to construct Thrift converter class: " + converterClassName, e);

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftReadSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftReadSupport.java
@@ -161,7 +161,7 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
 
   @Override
   public org.apache.parquet.hadoop.api.ReadSupport.ReadContext init(InitContext context) {
-    final ParquetConfiguration configuration = context.getConfig();
+    final ParquetConfiguration configuration = context.getParquetConfiguration();
     final MessageType fileMessageType = context.getFileSchema();
     MessageType requestedProjection = fileMessageType;
     String partialSchemaString = configuration.get(ReadSupport.PARQUET_READ_SCHEMA);
@@ -308,13 +308,13 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
   }
 
   @SuppressWarnings("unchecked")
-  private static <T1, T2> ThriftRecordConverter<T1> getRecordConverterInstance(
-      String converterClassName, Class<T1> thriftClass,
-      MessageType requestedSchema, StructType descriptor, T2 conf, Class<T2> confClass) {
+  private static <T, CONF> ThriftRecordConverter<T> getRecordConverterInstance(
+    String converterClassName, Class<T> thriftClass,
+    MessageType requestedSchema, StructType descriptor, CONF conf, Class<CONF> confClass) {
 
-    Class<ThriftRecordConverter<T1>> converterClass;
+    Class<ThriftRecordConverter<T>> converterClass;
     try {
-      converterClass = (Class<ThriftRecordConverter<T1>>) Class.forName(converterClassName);
+      converterClass = (Class<ThriftRecordConverter<T>>) Class.forName(converterClassName);
     } catch (ClassNotFoundException e) {
       throw new RuntimeException("Cannot find Thrift converter class: " + converterClassName, e);
     }
@@ -322,14 +322,14 @@ public class ThriftReadSupport<T> extends ReadSupport<T> {
     try {
       // first try the new version that accepts a Configuration
       try {
-        Constructor<ThriftRecordConverter<T1>> constructor =
+        Constructor<ThriftRecordConverter<T>> constructor =
           converterClass.getConstructor(Class.class, MessageType.class, StructType.class, confClass);
         return constructor.newInstance(thriftClass, requestedSchema, descriptor, conf);
       } catch (IllegalAccessException | NoSuchMethodException e) {
         // try the other constructor pattern
       }
 
-      Constructor<ThriftRecordConverter<T1>> constructor =
+      Constructor<ThriftRecordConverter<T>> constructor =
         converterClass.getConstructor(Class.class, MessageType.class, StructType.class);
       return constructor.newInstance(thriftClass, requestedSchema, descriptor);
     } catch (InstantiationException | InvocationTargetException e) {

--- a/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/hadoop/thrift/ThriftWriteSupport.java
@@ -19,6 +19,7 @@
 package org.apache.parquet.hadoop.thrift;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.thrift.TBase;
 
 import org.apache.parquet.hadoop.api.WriteSupport;
@@ -65,6 +66,11 @@ public class ThriftWriteSupport<T extends TBase<?,?>> extends WriteSupport<T> {
 
   @Override
   public WriteContext init(Configuration configuration) {
+    return this.writeSupport.init(configuration);
+  }
+
+  @Override
+  public WriteContext init(ParquetConfiguration configuration) {
     return this.writeSupport.init(configuration);
   }
 

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ParquetWriteProtocol.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ParquetWriteProtocol.java
@@ -22,6 +22,8 @@ package org.apache.parquet.thrift;
 import java.nio.ByteBuffer;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TField;
 import org.apache.thrift.protocol.TList;
@@ -500,6 +502,11 @@ public class ParquetWriteProtocol extends ParquetProtocol {
 
   public ParquetWriteProtocol(
       Configuration configuration, RecordConsumer recordConsumer, MessageColumnIO schema, StructType thriftType) {
+    this(new HadoopParquetConfiguration(configuration), recordConsumer, schema, thriftType);
+  }
+
+  public ParquetWriteProtocol(
+      ParquetConfiguration configuration, RecordConsumer recordConsumer, MessageColumnIO schema, StructType thriftType) {
     this.recordConsumer = recordConsumer;
     if (configuration != null) {
       this.writeThreeLevelList = configuration.getBoolean(

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/TBaseRecordConverter.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/TBaseRecordConverter.java
@@ -19,6 +19,8 @@
 package org.apache.parquet.thrift;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocol;
@@ -38,10 +40,15 @@ public class TBaseRecordConverter<T extends TBase<?,?>> extends ThriftRecordConv
    */
   @Deprecated
   public TBaseRecordConverter(final Class<T> thriftClass, MessageType requestedParquetSchema, StructType thriftType) {
-    this(thriftClass, requestedParquetSchema, thriftType, null);
+    this(thriftClass, requestedParquetSchema, thriftType, (HadoopParquetConfiguration) null);
   }
 
+  @SuppressWarnings("unused")
   public TBaseRecordConverter(final Class<T> thriftClass, MessageType requestedParquetSchema, StructType thriftType, Configuration conf) {
+    this(thriftClass, requestedParquetSchema, thriftType, new HadoopParquetConfiguration(conf));
+  }
+
+  public TBaseRecordConverter(final Class<T> thriftClass, MessageType requestedParquetSchema, StructType thriftType, ParquetConfiguration conf) {
     super(new ThriftReader<T>() {
       @Override
       public T readOneRecord(TProtocol protocol) throws TException {

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftRecordConverter.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftRecordConverter.java
@@ -861,7 +861,6 @@ public class ThriftRecordConverter<T> extends RecordMaterializer<T> {
   }
 
   /**
-   *
    * @param thriftReader the class responsible for instantiating the final object and read from the protocol
    * @param name the name of that type ( the thrift class simple name)
    * @param requestedParquetSchema the schema for the incoming columnar events

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftRecordConverter.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftRecordConverter.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TField;
 import org.apache.thrift.protocol.TList;
@@ -843,7 +845,7 @@ public class ThriftRecordConverter<T> extends RecordMaterializer<T> {
    */
   @Deprecated
   public ThriftRecordConverter(ThriftReader<T> thriftReader, String name, MessageType requestedParquetSchema, ThriftType.StructType thriftType) {
-    this(thriftReader, name, requestedParquetSchema, thriftType, null);
+    this(thriftReader, name, requestedParquetSchema, thriftType, (ParquetConfiguration) null);
   }
 
   /**
@@ -855,6 +857,18 @@ public class ThriftRecordConverter<T> extends RecordMaterializer<T> {
    * @param conf a Configuration
    */
   public ThriftRecordConverter(ThriftReader<T> thriftReader, String name, MessageType requestedParquetSchema, ThriftType.StructType thriftType, Configuration conf) {
+    this(thriftReader, name, requestedParquetSchema, thriftType, new HadoopParquetConfiguration(conf));
+  }
+
+  /**
+   *
+   * @param thriftReader the class responsible for instantiating the final object and read from the protocol
+   * @param name the name of that type ( the thrift class simple name)
+   * @param requestedParquetSchema the schema for the incoming columnar events
+   * @param thriftType the thrift type descriptor
+   * @param conf a Configuration
+   */
+  public ThriftRecordConverter(ThriftReader<T> thriftReader, String name, MessageType requestedParquetSchema, ThriftType.StructType thriftType, ParquetConfiguration conf) {
     super();
     this.thriftReader = thriftReader;
     this.protocol = new ParquetReadProtocol();

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.ShouldNeverHappenException;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
@@ -80,6 +82,11 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
 
   private ThriftSchemaConvertVisitor(FieldProjectionFilter fieldProjectionFilter, boolean doProjection,
                                      boolean keepOneOfEachUnion, Configuration configuration) {
+    this(fieldProjectionFilter, doProjection, keepOneOfEachUnion, new HadoopParquetConfiguration(configuration));
+  }
+
+  private ThriftSchemaConvertVisitor(FieldProjectionFilter fieldProjectionFilter, boolean doProjection,
+                                     boolean keepOneOfEachUnion, ParquetConfiguration configuration) {
     this.fieldProjectionFilter = Objects.requireNonNull(fieldProjectionFilter,
       "fieldProjectionFilter cannot be null");
     this.doProjection = doProjection;
@@ -105,6 +112,11 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
 
   public static MessageType convert(StructType struct, FieldProjectionFilter filter, boolean keepOneOfEachUnion,
                                     Configuration conf) {
+    return convert(struct, filter, keepOneOfEachUnion, new HadoopParquetConfiguration(conf));
+  }
+
+  public static MessageType convert(StructType struct, FieldProjectionFilter filter, boolean keepOneOfEachUnion,
+                                    ParquetConfiguration conf) {
     State state = new State(new FieldsPath(), REPEATED, "ParquetSchema");
 
     ConvertedField converted = struct.accept(

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConverter.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConverter.java
@@ -24,6 +24,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TEnum;
 import org.apache.thrift.TUnion;
@@ -52,19 +54,28 @@ import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 public class ThriftSchemaConverter {
   private final FieldProjectionFilter fieldProjectionFilter;
 
-  private Configuration conf;
+  private ParquetConfiguration conf;
 
   public ThriftSchemaConverter() {
     this(FieldProjectionFilter.ALL_COLUMNS);
   }
 
   public ThriftSchemaConverter(Configuration configuration) {
+    this(new HadoopParquetConfiguration(configuration));
+  }
+
+  public ThriftSchemaConverter(ParquetConfiguration configuration) {
     this();
     conf = configuration;
   }
 
   public ThriftSchemaConverter(
       Configuration configuration, FieldProjectionFilter fieldProjectionFilter) {
+    this(new HadoopParquetConfiguration(configuration), fieldProjectionFilter);
+  }
+
+  public ThriftSchemaConverter(
+      ParquetConfiguration configuration, FieldProjectionFilter fieldProjectionFilter) {
     this(fieldProjectionFilter);
     conf = configuration;
   }

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/pig/TupleToThriftWriteSupport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/pig/TupleToThriftWriteSupport.java
@@ -19,6 +19,8 @@
 package org.apache.parquet.thrift.pig;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.HadoopParquetConfiguration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.pig.data.Tuple;
 import org.apache.thrift.TBase;
 
@@ -51,9 +53,14 @@ public class TupleToThriftWriteSupport extends WriteSupport<Tuple> {
     return "thrift";
   }
 
-  @SuppressWarnings({"rawtypes", "unchecked"})
   @Override
   public WriteContext init(Configuration configuration) {
+    return init(new HadoopParquetConfiguration(configuration));
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Override
+  public WriteContext init(ParquetConfiguration configuration) {
     try {
       Class<?> clazz = configuration.getClassByName(className).asSubclass(TBase.class);
       thriftWriteSupport = new ThriftWriteSupport(clazz);

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestParquetWriteProtocol.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestParquetWriteProtocol.java
@@ -33,6 +33,7 @@ import java.util.TreeMap;
 import com.twitter.elephantbird.thrift.test.TestMapInList;
 import com.twitter.elephantbird.thrift.test.TestNameSet;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.conf.ParquetConfiguration;
 import org.junit.ComparisonFailure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -708,7 +709,7 @@ public class TestParquetWriteProtocol {
     MessageType schema = new PigSchemaConverter().convert(pigSchema);
     LOG.info("{}", schema);
     TupleWriteSupport tupleWriteSupport = new TupleWriteSupport(pigSchema);
-    tupleWriteSupport.init(null);
+    tupleWriteSupport.init((ParquetConfiguration) null);
     tupleWriteSupport.prepareForWrite(recordConsumer);
     final Tuple pigTuple = thriftToPig.getPigTuple(a);
     LOG.info("{}", pigTuple);

--- a/pom.xml
+++ b/pom.xml
@@ -547,8 +547,8 @@
             </excludeModules>
             <excludes>
               <exclude>${shade.prefix}</exclude>
-              <exclude>org.apache.parquet.hadoop.CodecFactory</exclude>
-              <exclude>org.apache.parquet.hadoop.ParquetReader</exclude>
+              <exclude>org.apache.parquet.hadoop.CodecFactory</exclude> <!-- change field type from Configuration to ParquetConfiguration -->
+              <exclude>org.apache.parquet.hadoop.ParquetReader</exclude> <!-- change field type from Configuration to ParquetConfiguration -->
               <exclude>org.apache.parquet.thrift.projection.deprecated.PathGlobPattern</exclude>
             </excludes>
           </parameter>

--- a/pom.xml
+++ b/pom.xml
@@ -547,6 +547,8 @@
             </excludeModules>
             <excludes>
               <exclude>${shade.prefix}</exclude>
+              <exclude>org.apache.parquet.hadoop.CodecFactory</exclude>
+              <exclude>org.apache.parquet.hadoop.ParquetReader</exclude>
               <exclude>org.apache.parquet.thrift.projection.deprecated.PathGlobPattern</exclude>
             </excludes>
           </parameter>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
       Additional parameters to run the read/write tests using the new interface-using methods.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does

---

jacicmp exclusions have been added for the following classes: `org.apache.parquet.hadoop.CodecFactory`, `org.apache.parquet.hadoop.ParquetReader`. When these exclusions are removed, the following incompatibilities are detected:
```
There is at least one incompatibility: org.apache.parquet.hadoop.CodecFactory.configuration:FIELD_TYPE_CHANGED,org.apache.parquet.hadoop.ParquetReader$Builder.conf:FIELD_TYPE_CHANGED
```

This PR is part of an effort that has been [discussed on the dev mailing list](https://lists.apache.org/thread/4wl0l3d9dkpx4w69jx3rwnjk034dtqr8).
