### PR TITLE
PARQUET-2348: Recompression/Re-encrypt should rewrite bloomfilter

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -739,12 +739,12 @@ public class ParquetFileWriter {
   }
 
   /**
-   * Add a Bloom filter that will be written out. This is only used in unit test.
+   * Add a Bloom filter that will be written out.
    *
    * @param column the column name
    * @param bloomFilter the bloom filter of column values
    */
-  void addBloomFilter(String column, BloomFilter bloomFilter)  {
+  public void addBloomFilter(String column, BloomFilter bloomFilter)  {
     currentBloomFilters.put(column , bloomFilter);
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -366,6 +366,10 @@ public class ParquetRewriter implements Closeable {
 
     ColumnIndex columnIndex = reader.readColumnIndex(chunk);
     OffsetIndex offsetIndex = reader.readOffsetIndex(chunk);
+    BloomFilter bloomFilter = reader.readBloomFilter(chunk);
+    if (bloomFilter != null) {
+      writer.addBloomFilter(chunk.getPath().toDotString(), bloomFilter);
+    }
 
     reader.setStreamPosition(chunk.getStartingPos());
     DictionaryPage dictionaryPage = null;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestFileBuilder.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestFileBuilder.java
@@ -52,6 +52,7 @@ public class TestFileBuilder
     private ParquetCipher cipher = ParquetCipher.AES_GCM_V1;
     private Boolean footerEncryption = false;
     private long rowGroupSize = ParquetWriter.DEFAULT_BLOCK_SIZE;
+    private String[] bloomFilterEnabled = {};
 
     public TestFileBuilder(Configuration conf, MessageType schema)
     {
@@ -114,6 +115,12 @@ public class TestFileBuilder
         return this;
     }
 
+    public TestFileBuilder withBloomFilterEnabled(String[] bloomFilterEnabled)
+    {
+        this.bloomFilterEnabled = bloomFilterEnabled;
+        return this;
+    }
+
     public EncryptionTestFile build()
             throws IOException
     {
@@ -129,6 +136,11 @@ public class TestFileBuilder
                 .withRowGroupSize(rowGroupSize)
                 .withEncryption(encryptionProperties)
                 .withCompressionCodec(CompressionCodecName.valueOf(codec));
+
+        for (String columnPath: bloomFilterEnabled) {
+          builder.withBloomFilterEnabled(columnPath, true);
+        }
+
         try (ParquetWriter writer = builder.build()) {
             for (int i = 0; i < fileContent.length; i++) {
                 writer.write(fileContent[i]);


### PR DESCRIPTION
The bloomfilter data is lost after rewriting with recompression or re-encrypt. We should rewrite the bloomfilter data as well.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
