### PR TITLE
PARQUET-2356: Fix typo like bitwith in DeltaBinaryPackingValuesWriter

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriter.java
@@ -73,7 +73,7 @@ public abstract class DeltaBinaryPackingValuesWriter extends ValuesWriter {
 
   /**
    * bytes buffer for a mini block, it is reused for each mini block.
-   * Therefore the size of biggest miniblock with bitwith of MAX_BITWITH is allocated
+   * Therefore the size of biggest miniblock with bitwidth of MAX_BITWIDTH is allocated
    */
   protected byte[] miniBlockByteBuffer;
 
@@ -97,7 +97,7 @@ public abstract class DeltaBinaryPackingValuesWriter extends ValuesWriter {
     try {
       BytesUtils.writeIntLittleEndianOnOneByte(baos, bitWidths[i]);
     } catch (IOException e) {
-      throw new ParquetEncodingException("can not write bitwith for miniblock", e);
+      throw new ParquetEncodingException("can not write bitwidth for miniblock", e);
     }
   }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).


https://issues.apache.org/jira/browse/PARQUET-2356

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
