### PR TITLE
PARQUET-2361: Reduce failure rate of unit test testParquetFileWithBlo…

### DIFF
--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
@@ -288,12 +288,13 @@ public class TestParquetWriter {
 
   @Test
   public void testParquetFileWithBloomFilterWithFpp() throws IOException {
-    int totalCount = 100000;
+    int buildBloomFilterCount = 100000;
     double[] testFpp = {0.01, 0.05, 0.10, 0.15, 0.20, 0.25};
     int randomStrLen = 12;
+    int testBloomFilterCount = 200000;
 
     Set<String> distinctStrings = new HashSet<>();
-    while (distinctStrings.size() < totalCount) {
+    while (distinctStrings.size() < buildBloomFilterCount) {
       String str = RandomStringUtils.randomAlphabetic(randomStrLen);
       distinctStrings.add(str);
     }
@@ -314,7 +315,7 @@ public class TestParquetWriter {
         .withConf(conf)
         .withDictionaryEncoding(false)
         .withBloomFilterEnabled("name", true)
-        .withBloomFilterNDV("name", totalCount)
+        .withBloomFilterNDV("name", buildBloomFilterCount)
         .withBloomFilterFPP("name", testFpp[i])
         .build()) {
         java.util.Iterator<String> iterator = distinctStrings.iterator();
@@ -331,7 +332,7 @@ public class TestParquetWriter {
 
         // The exist counts the number of times FindHash returns true.
         int exist = 0;
-        while (distinctStrings.size() < totalCount) {
+        while (distinctStrings.size() < testBloomFilterCount) {
           String str = RandomStringUtils.randomAlphabetic(randomStrLen - 2);
           if (distinctStrings.add(str) &&
             bloomFilter.findHash(LongHashFunction.xx(0).hashBytes(Binary.fromString(str).toByteBuffer()))) {
@@ -339,7 +340,7 @@ public class TestParquetWriter {
           }
         }
         // The exist should be less than totalCount * fpp. Add 10% here for error space.
-        assertTrue(exist < totalCount * (testFpp[i] * 1.1) && exist > 0);
+        assertTrue(exist < testBloomFilterCount * (testFpp[i] * 1.1) && exist > 0);
       }
     }
   }


### PR DESCRIPTION
…omFilterWithFpp

Change-Id: Ic230f197b0996333a082bb05bd201963d05d862e

```
[INFO] Results:
[INFO] 
Error:  Failures: 
Error:    TestParquetWriter.testParquetFileWithBloomFilterWithFpp:342
[INFO]  
```

Multiple different PR triggered this failure:

1. https://github.com/apache/parquet-mr/pull/1062
2. https://github.com/apache/parquet-mr/actions/runs/5420924489/job/14680382407
3. https://github.com/apache/parquet-mr/actions/runs/6336014897
4. https://github.com/apache/parquet-mr/actions/runs/6381223319
5. https://github.com/apache/parquet-mr/actions/runs/6394826826/job/17357106390

The unit test utilizes random string generation for test data without using a fixed seed. The expectation of a unit test is that the number of false positives in the Bloom filter should match the set probability. Therefore, a simple fix is to increase the number of tests on the Bloom filter. The reason for not using a fixed seed with random numbers is to avoid making the tests effective only in specific scenarios. If it is necessary to use a fixed seed, I can also modify the PR accordingly.


Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-2361: Reduce failure rate of unit test testParquetFileWithBlo…"
  - https://issues.apache.org/jira/browse/PARQUET-2361
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
