### PR TITLE
PARQUET-2366: Optimize random seek during rewriting

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/IndexCache.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/IndexCache.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import org.apache.parquet.column.values.bloomfilter.BloomFilter;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * A cache for caching indexes(including: ColumnIndex, OffsetIndex and BloomFilter)
+ */
+public interface IndexCache {
+
+  enum CacheStrategy {
+    NONE, /* No cache */
+    PRECACHE_BLOCK /* Precache for block indexes */
+  }
+
+  /**
+   * Create an index cache for the given file reader
+   *
+   * @param fileReader the file reader
+   * @param columns the columns that need to do cache
+   * @param cacheStrategy the cache strategy, supports NONE and PRECACHE_BLOCK
+   * @return the index cache
+   */
+  static IndexCache create(
+      ParquetFileReader fileReader,
+      Set<ColumnPath> columns,
+      CacheStrategy cacheStrategy) {
+    if (cacheStrategy == CacheStrategy.NONE) {
+      return new NoneIndexCache(fileReader);
+    } else if (cacheStrategy == CacheStrategy.PRECACHE_BLOCK) {
+      return new PrefetchIndexCache(fileReader, columns);
+    } else {
+      throw new UnsupportedOperationException("Unknown cache strategy: " + cacheStrategy);
+    }
+  }
+
+  /**
+   * Set the current BlockMetadata
+   */
+  void setBlockMetadata(BlockMetaData currentBlockMetadata) throws IOException;
+
+  /**
+   * Get the ColumnIndex for the given column in the set row group.
+   *
+   * @param chunk the given column chunk
+   * @return the ColumnIndex for the given column
+   * @throws IOException if any I/O error occurs during get the ColumnIndex
+   */
+  ColumnIndex getColumnIndex(ColumnChunkMetaData chunk) throws IOException;
+
+  /**
+   * Get the OffsetIndex for the given column in the set row group.
+   *
+   * @param chunk the given column chunk
+   * @return the OffsetIndex for the given column
+   * @throws IOException if any I/O error occurs during get the OffsetIndex
+   */
+  OffsetIndex getOffsetIndex(ColumnChunkMetaData chunk) throws IOException;
+
+  /**
+   * Get the BloomFilter for the given column in the set row group.
+   *
+   * @param chunk the given column chunk
+   * @return the BloomFilter for the given column
+   * @throws IOException if any I/O error occurs during get the BloomFilter
+   */
+  BloomFilter getBloomFilter(ColumnChunkMetaData chunk) throws IOException;
+
+  /**
+   * Clean the cache
+   */
+  void clean();
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/IndexCache.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/IndexCache.java
@@ -35,7 +35,7 @@ public interface IndexCache {
 
   enum CacheStrategy {
     NONE, /* No cache */
-    PRECACHE_BLOCK /* Precache for block indexes */
+    PREFETCH_BLOCK /* Prefetch block indexes */
   }
 
   /**
@@ -43,7 +43,7 @@ public interface IndexCache {
    *
    * @param fileReader the file reader
    * @param columns the columns that need to do cache
-   * @param cacheStrategy the cache strategy, supports NONE and PRECACHE_BLOCK
+   * @param cacheStrategy the cache strategy, supports NONE and PREFETCH_BLOCK
    * @param freeCacheAfterGet whether free the given index cache after calling the given get method
    * @return the index cache
    */
@@ -54,7 +54,7 @@ public interface IndexCache {
       boolean freeCacheAfterGet) {
     if (cacheStrategy == CacheStrategy.NONE) {
       return new NoneIndexCache(fileReader);
-    } else if (cacheStrategy == CacheStrategy.PRECACHE_BLOCK) {
+    } else if (cacheStrategy == CacheStrategy.PREFETCH_BLOCK) {
       return new PrefetchIndexCache(fileReader, columns, freeCacheAfterGet);
     } else {
       throw new UnsupportedOperationException("Unknown cache strategy: " + cacheStrategy);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/IndexCache.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/IndexCache.java
@@ -44,16 +44,18 @@ public interface IndexCache {
    * @param fileReader the file reader
    * @param columns the columns that need to do cache
    * @param cacheStrategy the cache strategy, supports NONE and PRECACHE_BLOCK
+   * @param freeCacheAfterGet whether free the given index cache after calling the given get method
    * @return the index cache
    */
   static IndexCache create(
       ParquetFileReader fileReader,
       Set<ColumnPath> columns,
-      CacheStrategy cacheStrategy) {
+      CacheStrategy cacheStrategy,
+      boolean freeCacheAfterGet) {
     if (cacheStrategy == CacheStrategy.NONE) {
       return new NoneIndexCache(fileReader);
     } else if (cacheStrategy == CacheStrategy.PRECACHE_BLOCK) {
-      return new PrefetchIndexCache(fileReader, columns);
+      return new PrefetchIndexCache(fileReader, columns, freeCacheAfterGet);
     } else {
       throw new UnsupportedOperationException("Unknown cache strategy: " + cacheStrategy);
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/NoneIndexCache.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/NoneIndexCache.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import org.apache.parquet.column.values.bloomfilter.BloomFilter;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+
+import java.io.IOException;
+
+/**
+ * Cache nothing. All the get methods are pushed to ParquetFileReader to read the given index.
+ */
+class NoneIndexCache implements IndexCache {
+  private final ParquetFileReader fileReader;
+
+  NoneIndexCache(ParquetFileReader fileReader) {
+    this.fileReader = fileReader;
+  }
+
+  @Override
+  public void setBlockMetadata(BlockMetaData currentBlockMetadata) throws IOException {
+    // Do nothing
+  }
+
+  @Override
+  public ColumnIndex getColumnIndex(ColumnChunkMetaData chunk) throws IOException {
+    return fileReader.readColumnIndex(chunk);
+  }
+
+  @Override
+  public OffsetIndex getOffsetIndex(ColumnChunkMetaData chunk) throws IOException {
+    return fileReader.readOffsetIndex(chunk);
+  }
+
+  @Override
+  public BloomFilter getBloomFilter(ColumnChunkMetaData chunk) throws IOException {
+    return fileReader.readBloomFilter(chunk);
+  }
+
+  @Override
+  public void clean() {
+    // Do nothing
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/PrefetchIndexCache.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/PrefetchIndexCache.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * This index cache will prefetch those columns' indexes when calling {@link #setBlockMetadata(BlockMetaData)}.
+ * This index cache will prefetch indexes of all columns when calling {@link #setBlockMetadata(BlockMetaData)}.
  * <p>
  *
  * Note: the given index will be freed from the cache after calling the related get method.

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/PrefetchIndexCache.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/PrefetchIndexCache.java
@@ -75,7 +75,7 @@ class PrefetchIndexCache implements IndexCache {
         columnIndexCache.containsKey(columnPath),
         "Not found cached ColumnIndex for column: %s with cache strategy: %s",
         columnPath.toDotString(),
-        CacheStrategy.PRECACHE_BLOCK);
+        CacheStrategy.PREFETCH_BLOCK);
     }
 
     if (freeCacheAfterGet) {
@@ -94,7 +94,7 @@ class PrefetchIndexCache implements IndexCache {
         offsetIndexCache.containsKey(columnPath),
         "Not found cached OffsetIndex for column: %s with cache strategy: %s",
         columnPath.toDotString(),
-        CacheStrategy.PRECACHE_BLOCK);
+        CacheStrategy.PREFETCH_BLOCK);
     }
 
     if (freeCacheAfterGet) {
@@ -113,7 +113,7 @@ class PrefetchIndexCache implements IndexCache {
         bloomIndexCache.containsKey(columnPath),
         "Not found cached BloomFilter for column: %s with cache strategy: %s",
         columnPath.toDotString(),
-        CacheStrategy.PRECACHE_BLOCK);
+        CacheStrategy.PREFETCH_BLOCK);
     }
 
     if (freeCacheAfterGet) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/IndexCacher.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/IndexCacher.java
@@ -50,7 +50,7 @@ class IndexCacher {
       boolean prefetchBlockAllIndexes) {
     this.fileReader = fileReader;
     this.columnPathSet = columnPathSet;
-    this.prefetchBlockAllIndexes = prefetchBlockAllIndexes;g
+    this.prefetchBlockAllIndexes = prefetchBlockAllIndexes;
   }
 
   void setCurrentBlockMetadata(BlockMetaData blockMetaData) throws IOException {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/IndexCacher.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/IndexCacher.java
@@ -73,7 +73,7 @@ class IndexCacher {
 
   ColumnIndex getColumnIndex(ColumnChunkMetaData chunk) throws IOException {
     if (prefetchBlockAllIndexes) {
-      return columnIndexCache.get(chunk.getPath());
+      return columnIndexCache.remove(chunk.getPath());
     }
 
     return fileReader.readColumnIndex(chunk);
@@ -81,7 +81,7 @@ class IndexCacher {
 
   OffsetIndex getOffsetIndex(ColumnChunkMetaData chunk) throws IOException {
     if (prefetchBlockAllIndexes) {
-      return offsetIndexCache.get(chunk.getPath());
+      return offsetIndexCache.remove(chunk.getPath());
     }
 
     return fileReader.readOffsetIndex(chunk);
@@ -89,7 +89,7 @@ class IndexCacher {
 
   BloomFilter getBloomFilter(ColumnChunkMetaData chunk) throws IOException {
     if (prefetchBlockAllIndexes) {
-      return bloomIndexCache.get(chunk.getPath());
+      return bloomIndexCache.remove(chunk.getPath());
     }
 
     return fileReader.readBloomFilter(chunk);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/IndexCacher.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/IndexCacher.java
@@ -39,7 +39,7 @@ class IndexCacher {
   private final Set<ColumnPath> columnPathSet;
   private final boolean prefetchBlockAllIndexes;
 
-  // Only used when cacheBlockIndexInOnce is true
+  // Only used when prefetchBlockAllIndexes is true
   private Map<ColumnPath, ColumnIndex> columnIndexCache;
   private Map<ColumnPath, OffsetIndex> offsetIndexCache;
   private Map<ColumnPath, BloomFilter> bloomIndexCache;
@@ -50,16 +50,7 @@ class IndexCacher {
       boolean prefetchBlockAllIndexes) {
     this.fileReader = fileReader;
     this.columnPathSet = columnPathSet;
-    this.prefetchBlockAllIndexes = prefetchBlockAllIndexes;
-    if (prefetchBlockAllIndexes) {
-      this.columnIndexCache = new HashMap<>();
-      this.offsetIndexCache = new HashMap<>();
-      this.bloomIndexCache = new HashMap<>();
-    } else {
-      this.columnIndexCache = null;
-      this.offsetIndexCache = null;
-      this.bloomIndexCache = null;
-    }
+    this.prefetchBlockAllIndexes = prefetchBlockAllIndexes;g
   }
 
   void setCurrentBlockMetadata(BlockMetaData blockMetaData) throws IOException {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/IndexCacher.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/IndexCacher.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop.rewrite;
+
+import org.apache.parquet.column.values.bloomfilter.BloomFilter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A cacher for caching file indexes(ColumnIndex, OffsetIndex, BloomFilter)
+ */
+class IndexCacher {
+  private final ParquetFileReader fileReader;
+  private final Set<ColumnPath> columnPathSet;
+  private final boolean prefetchBlockAllIndexes;
+
+  // Only used when cacheBlockIndexInOnce is true
+  private Map<ColumnPath, ColumnIndex> columnIndexCache;
+  private Map<ColumnPath, OffsetIndex> offsetIndexCache;
+  private Map<ColumnPath, BloomFilter> bloomIndexCache;
+
+  IndexCacher(
+      ParquetFileReader fileReader,
+      Set<ColumnPath> columnPathSet,
+      boolean prefetchBlockAllIndexes) {
+    this.fileReader = fileReader;
+    this.columnPathSet = columnPathSet;
+    this.prefetchBlockAllIndexes = prefetchBlockAllIndexes;
+    if (prefetchBlockAllIndexes) {
+      this.columnIndexCache = new HashMap<>();
+      this.offsetIndexCache = new HashMap<>();
+      this.bloomIndexCache = new HashMap<>();
+    } else {
+      this.columnIndexCache = null;
+      this.offsetIndexCache = null;
+      this.bloomIndexCache = null;
+    }
+  }
+
+  void setCurrentBlockMetadata(BlockMetaData blockMetaData) throws IOException {
+    if (prefetchBlockAllIndexes) {
+      free();
+      this.columnIndexCache = readAllColumnIndexes(blockMetaData);
+      this.offsetIndexCache = readAllOffsetIndexes(blockMetaData);
+      this.bloomIndexCache = readAllBloomFilters(blockMetaData);
+    }
+  }
+
+  ColumnIndex getColumnIndex(ColumnChunkMetaData chunk) throws IOException {
+    if (prefetchBlockAllIndexes) {
+      return columnIndexCache.get(chunk.getPath());
+    }
+
+    return fileReader.readColumnIndex(chunk);
+  }
+
+  OffsetIndex getOffsetIndex(ColumnChunkMetaData chunk) throws IOException {
+    if (prefetchBlockAllIndexes) {
+      return offsetIndexCache.get(chunk.getPath());
+    }
+
+    return fileReader.readOffsetIndex(chunk);
+  }
+
+  BloomFilter getBloomFilter(ColumnChunkMetaData chunk) throws IOException {
+    if (prefetchBlockAllIndexes) {
+      return bloomIndexCache.get(chunk.getPath());
+    }
+
+    return fileReader.readBloomFilter(chunk);
+  }
+
+  void free() {
+    if (columnIndexCache != null) {
+      columnIndexCache.clear();
+      columnIndexCache = null;
+    }
+
+    if (offsetIndexCache != null) {
+      offsetIndexCache.clear();
+      offsetIndexCache = null;
+    }
+
+    if (bloomIndexCache != null) {
+      bloomIndexCache.clear();
+      bloomIndexCache = null;
+    }
+  }
+
+  private Map<ColumnPath, ColumnIndex> readAllColumnIndexes(BlockMetaData blockMetaData) throws IOException {
+    Map<ColumnPath, ColumnIndex> columnIndexMap = new HashMap<>(columnPathSet.size());
+    for (ColumnChunkMetaData chunk : blockMetaData.getColumns()) {
+      if (columnPathSet.contains(chunk.getPath())) {
+        columnIndexMap.put(chunk.getPath(), fileReader.readColumnIndex(chunk));
+      }
+    }
+
+    return columnIndexMap;
+  }
+
+  private Map<ColumnPath, OffsetIndex> readAllOffsetIndexes(BlockMetaData blockMetaData) throws IOException {
+    Map<ColumnPath, OffsetIndex> offsetIndexMap = new HashMap<>(columnPathSet.size());
+    for (ColumnChunkMetaData chunk : blockMetaData.getColumns()) {
+      if (columnPathSet.contains(chunk.getPath())) {
+        offsetIndexMap.put(chunk.getPath(), fileReader.readOffsetIndex(chunk));
+      }
+    }
+
+    return offsetIndexMap;
+  }
+
+  private Map<ColumnPath, BloomFilter> readAllBloomFilters(BlockMetaData blockMetaData) throws IOException {
+    Map<ColumnPath, BloomFilter> bloomFilterMap = new HashMap<>(columnPathSet.size());
+    for (ColumnChunkMetaData chunk : blockMetaData.getColumns()) {
+      if (columnPathSet.contains(chunk.getPath())) {
+        bloomFilterMap.put(chunk.getPath(), fileReader.readBloomFilter(chunk));
+      }
+    }
+
+    return bloomFilterMap;
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -96,19 +96,19 @@ public class ParquetRewriter implements Closeable {
   private final byte[] pageBuffer = new byte[pageBufferSize];
   // Configurations for the new file
   private CompressionCodecName newCodecName = null;
-  private List<String> pruneColumns = null;
   private Map<ColumnPath, MaskMode> maskColumns = null;
   private Set<ColumnPath> encryptColumns = null;
   private boolean encryptMode = false;
-  private Map<String, String> extraMetaData = new HashMap<>();
+  private final Map<String, String> extraMetaData = new HashMap<>();
   // Writer to rewrite the input files
-  private ParquetFileWriter writer;
+  private final ParquetFileWriter writer;
   // Number of blocks written which is used to keep track of the actual row group ordinal
   private int numBlocksRewritten = 0;
   // Reader and relevant states of the in-processing input file
-  private Queue<TransParquetFileReader> inputFiles = new LinkedList<>();
+  private final Queue<TransParquetFileReader> inputFiles = new LinkedList<>();
   // Schema of input files (should be the same) and to write to the output file
   private MessageType schema = null;
+  private final Map<ColumnPath, ColumnDescriptor> descriptorsMap;
   // The reader for the current input file
   private TransParquetFileReader reader = null;
   // The metadata of current reader being processed
@@ -116,7 +116,9 @@ public class ParquetRewriter implements Closeable {
   // created_by information of current reader being processed
   private String originalCreatedBy = "";
   // Unique created_by information from all input files
-  private Set<String> allOriginalCreatedBys = new HashSet<>();
+  private final Set<String> allOriginalCreatedBys = new HashSet<>();
+  // Whether prefetch all block indexes
+  private final boolean prefetchBlockAllIndexes;
 
   public ParquetRewriter(RewriteOptions options) throws IOException {
     Configuration conf = options.getConf();
@@ -129,8 +131,7 @@ public class ParquetRewriter implements Closeable {
     initNextReader();
 
     newCodecName = options.getNewCodecName();
-    pruneColumns = options.getPruneColumns();
-
+    List<String> pruneColumns = options.getPruneColumns();
     // Prune columns if specified
     if (pruneColumns != null && !pruneColumns.isEmpty()) {
       List<String> paths = new ArrayList<>();
@@ -145,6 +146,9 @@ public class ParquetRewriter implements Closeable {
       schema = pruneColumnsInSchema(schema, prunePaths);
     }
 
+    this.descriptorsMap =
+      schema.getColumns().stream().collect(Collectors.toMap(x -> ColumnPath.get(x.getPath()), x -> x));
+
     if (options.getMaskColumns() != null) {
       this.maskColumns = new HashMap<>();
       for (Map.Entry<String, MaskMode> col : options.getMaskColumns().entrySet()) {
@@ -156,6 +160,8 @@ public class ParquetRewriter implements Closeable {
       this.encryptColumns = convertToColumnPaths(options.getEncryptColumns());
       this.encryptMode = true;
     }
+
+    this.prefetchBlockAllIndexes = options.prefetchBlockAllIndexes();
 
     ParquetFileWriter.Mode writerMode = ParquetFileWriter.Mode.CREATE;
     writer = new ParquetFileWriter(HadoopOutputFile.fromPath(outPath, conf), schema, writerMode,
@@ -178,6 +184,8 @@ public class ParquetRewriter implements Closeable {
     this.writer = writer;
     this.meta = meta;
     this.schema = schema;
+    this.descriptorsMap =
+      schema.getColumns().stream().collect(Collectors.toMap(x -> ColumnPath.get(x.getPath()), x -> x));
     this.newCodecName = codecName;
     originalCreatedBy = originalCreatedBy == null ? meta.getFileMetaData().getCreatedBy() : originalCreatedBy;
     extraMetaData.putAll(meta.getFileMetaData().getKeyValueMetaData());
@@ -188,6 +196,7 @@ public class ParquetRewriter implements Closeable {
         this.maskColumns.put(ColumnPath.fromDotString(col), maskMode);
       }
     }
+    this.prefetchBlockAllIndexes = false;
   }
 
   // Open all input files to validate their schemas are compatible to merge
@@ -247,28 +256,24 @@ public class ParquetRewriter implements Closeable {
 
   public void processBlocks() throws IOException {
     while (reader != null) {
-      processBlocksFromReader();
+      IndexCacher indexCacher = new IndexCacher(reader, descriptorsMap.keySet(), prefetchBlockAllIndexes);
+      processBlocksFromReader(indexCacher);
+      indexCacher.free();
       initNextReader();
     }
   }
 
-  private void processBlocksFromReader() throws IOException {
+  private void processBlocksFromReader(IndexCacher indexCacher) throws IOException {
     PageReadStore store = reader.readNextRowGroup();
     ColumnReadStoreImpl crStore = new ColumnReadStoreImpl(store, new DummyGroupConverter(), schema, originalCreatedBy);
-    Map<ColumnPath, ColumnDescriptor> descriptorsMap = schema.getColumns().stream().collect(
-            Collectors.toMap(x -> ColumnPath.get(x.getPath()), x -> x));
 
     int blockId = 0;
     while (store != null) {
       writer.startBlock(store.getRowCount());
 
       BlockMetaData blockMetaData = meta.getBlocks().get(blockId);
+      indexCacher.setCurrentBlockMetadata(blockMetaData);
       List<ColumnChunkMetaData> columnsInOrder = blockMetaData.getColumns();
-
-      List<ColumnIndex> columnIndexes = readAllColumnIndexes(reader, columnsInOrder, descriptorsMap);
-      List<OffsetIndex> offsetIndexes = readAllOffsetIndexes(reader, columnsInOrder, descriptorsMap);
-      List<BloomFilter> bloomFilters = readAllBloomFilters(reader, columnsInOrder, descriptorsMap);
-
       for (int i = 0, columnId = 0; i < columnsInOrder.size(); i++) {
         ColumnChunkMetaData chunk = columnsInOrder.get(i);
         ColumnDescriptor descriptor = descriptorsMap.get(chunk.getPath());
@@ -323,15 +328,15 @@ public class ParquetRewriter implements Closeable {
                   newCodecName,
                   columnChunkEncryptorRunTime,
                   encryptColumn,
-                  bloomFilters.get(i),
-                  columnIndexes.get(i),
-                  offsetIndexes.get(i));
+                  indexCacher.getBloomFilter(chunk),
+                  indexCacher.getColumnIndex(chunk),
+                  indexCacher.getOffsetIndex(chunk));
           writer.endColumn();
         } else {
           // Nothing changed, simply copy the binary data.
-          BloomFilter bloomFilter = bloomFilters.get(i);
-          ColumnIndex columnIndex = columnIndexes.get(i);
-          OffsetIndex offsetIndex = offsetIndexes.get(i);
+          BloomFilter bloomFilter = indexCacher.getBloomFilter(chunk);
+          ColumnIndex columnIndex = indexCacher.getColumnIndex(chunk);
+          OffsetIndex offsetIndex = indexCacher.getOffsetIndex(chunk);
           writer.appendColumnChunk(descriptor, reader.getStream(), chunk, bloomFilter, columnIndex, offsetIndex);
         }
 
@@ -745,54 +750,6 @@ public class ParquetRewriter implements Closeable {
     }
 
     return null;
-  }
-
-  private static List<ColumnIndex> readAllColumnIndexes(
-      TransParquetFileReader reader,
-      List<ColumnChunkMetaData> chunks,
-      Map<ColumnPath, ColumnDescriptor> descriptorsMap) throws IOException {
-    List<ColumnIndex> columnIndexList = new ArrayList<>(chunks.size());
-    for (ColumnChunkMetaData chunk : chunks) {
-      if (descriptorsMap.containsKey(chunk.getPath())) {
-        columnIndexList.add(reader.readColumnIndex(chunk));
-      } else {
-        columnIndexList.add(null);
-      }
-    }
-
-    return columnIndexList;
-  }
-
-  private static List<OffsetIndex> readAllOffsetIndexes(
-      TransParquetFileReader reader,
-      List<ColumnChunkMetaData> chunks,
-      Map<ColumnPath, ColumnDescriptor> descriptorsMap) throws IOException {
-    List<OffsetIndex> offsetIndexList = new ArrayList<>(chunks.size());
-    for (ColumnChunkMetaData chunk : chunks) {
-      if (descriptorsMap.containsKey(chunk.getPath())) {
-        offsetIndexList.add(reader.readOffsetIndex(chunk));
-      } else {
-        offsetIndexList.add(null);
-      }
-    }
-
-    return offsetIndexList;
-  }
-
-  private static List<BloomFilter> readAllBloomFilters(
-      TransParquetFileReader reader,
-      List<ColumnChunkMetaData> chunks,
-      Map<ColumnPath, ColumnDescriptor> descriptorsMap) throws IOException {
-    List<BloomFilter> bloomFilterList = new ArrayList<>(chunks.size());
-    for (ColumnChunkMetaData chunk : chunks) {
-      if (descriptorsMap.containsKey(chunk.getPath())) {
-        bloomFilterList.add(reader.readBloomFilter(chunk));
-      } else {
-        bloomFilterList.add(null);
-      }
-    }
-
-    return bloomFilterList;
   }
 
   private static final class DummyGroupConverter extends GroupConverter {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -257,7 +257,7 @@ public class ParquetRewriter implements Closeable {
 
   public void processBlocks() throws IOException {
     while (reader != null) {
-      IndexCache indexCache = IndexCache.create(reader, descriptorsMap.keySet(), indexCacheStrategy);
+      IndexCache indexCache = IndexCache.create(reader, descriptorsMap.keySet(), indexCacheStrategy, true);
       processBlocksFromReader(indexCache);
       indexCache.clean();
       initNextReader();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -795,7 +795,6 @@ public class ParquetRewriter implements Closeable {
     return bloomFilterList;
   }
 
-
   private static final class DummyGroupConverter extends GroupConverter {
     @Override
     public void start() {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.Preconditions;
 import org.apache.parquet.crypto.FileEncryptionProperties;
+import org.apache.parquet.hadoop.IndexCache;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 import java.util.Arrays;
@@ -41,7 +42,7 @@ public class RewriteOptions {
   private final Map<String, MaskMode> maskColumns;
   private final List<String> encryptColumns;
   private final FileEncryptionProperties fileEncryptionProperties;
-  private final boolean prefetchBlockAllIndexes;
+  private final IndexCache.CacheStrategy indexCacheStrategy;
 
   private RewriteOptions(Configuration conf,
                          List<Path> inputFiles,
@@ -51,7 +52,7 @@ public class RewriteOptions {
                          Map<String, MaskMode> maskColumns,
                          List<String> encryptColumns,
                          FileEncryptionProperties fileEncryptionProperties,
-                         boolean prefetchBlockAllIndexes) {
+                         IndexCache.CacheStrategy indexCacheStrategy) {
     this.conf = conf;
     this.inputFiles = inputFiles;
     this.outputFile = outputFile;
@@ -60,7 +61,7 @@ public class RewriteOptions {
     this.maskColumns = maskColumns;
     this.encryptColumns = encryptColumns;
     this.fileEncryptionProperties = fileEncryptionProperties;
-    this.prefetchBlockAllIndexes = prefetchBlockAllIndexes;
+    this.indexCacheStrategy = indexCacheStrategy;
   }
 
   public Configuration getConf() {
@@ -95,8 +96,8 @@ public class RewriteOptions {
     return fileEncryptionProperties;
   }
 
-  public boolean prefetchBlockAllIndexes() {
-    return prefetchBlockAllIndexes;
+  public IndexCache.CacheStrategy getIndexCacheStrategy() {
+    return indexCacheStrategy;
   }
 
   // Builder to create a RewriterOptions.
@@ -109,7 +110,7 @@ public class RewriteOptions {
     private Map<String, MaskMode> maskColumns;
     private List<String> encryptColumns;
     private FileEncryptionProperties fileEncryptionProperties;
-    private boolean prefetchBlockAllIndexes;
+    private IndexCache.CacheStrategy indexCacheStrategy = IndexCache.CacheStrategy.NONE;
 
     /**
      * Create a builder to create a RewriterOptions.
@@ -222,15 +223,16 @@ public class RewriteOptions {
     }
 
     /**
-     * Whether enable prefetch block indexes into cache.
+     * Set the index(ColumnIndex, Offset and BloomFilter) cache strategy.
      * <p>
-     * This could reduce the random seek while rewriting, disabled by default.
+     * This could reduce the random seek while rewriting with PRECACHE_BLOCK strategy, NONE by default.
      *
-     * @param prefetchBlockAllIndexes enable or not
+     * @param cacheStrategy the index cache strategy, supports: {@link IndexCache.CacheStrategy#NONE} or
+     *        {@link IndexCache.CacheStrategy#PRECACHE_BLOCK}
      * @return self
      */
-    public Builder prefetchBlockAllIndex(boolean prefetchBlockAllIndexes) {
-      this.prefetchBlockAllIndexes = prefetchBlockAllIndexes;
+    public Builder indexCacheStrategy(IndexCache.CacheStrategy cacheStrategy) {
+      this.indexCacheStrategy = cacheStrategy;
       return this;
     }
 
@@ -277,7 +279,7 @@ public class RewriteOptions {
               maskColumns,
               encryptColumns,
               fileEncryptionProperties,
-              prefetchBlockAllIndexes);
+              indexCacheStrategy);
     }
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
@@ -33,14 +33,15 @@ import java.util.Map;
  */
 public class RewriteOptions {
 
-  final Configuration conf;
-  final List<Path> inputFiles;
-  final Path outputFile;
-  final List<String> pruneColumns;
-  final CompressionCodecName newCodecName;
-  final Map<String, MaskMode> maskColumns;
-  final List<String> encryptColumns;
-  final FileEncryptionProperties fileEncryptionProperties;
+  private final Configuration conf;
+  private final List<Path> inputFiles;
+  private final Path outputFile;
+  private final List<String> pruneColumns;
+  private final CompressionCodecName newCodecName;
+  private final Map<String, MaskMode> maskColumns;
+  private final List<String> encryptColumns;
+  private final FileEncryptionProperties fileEncryptionProperties;
+  private final boolean prefetchBlockAllIndexes;
 
   private RewriteOptions(Configuration conf,
                          List<Path> inputFiles,
@@ -49,7 +50,8 @@ public class RewriteOptions {
                          CompressionCodecName newCodecName,
                          Map<String, MaskMode> maskColumns,
                          List<String> encryptColumns,
-                         FileEncryptionProperties fileEncryptionProperties) {
+                         FileEncryptionProperties fileEncryptionProperties,
+                         boolean prefetchBlockAllIndexes) {
     this.conf = conf;
     this.inputFiles = inputFiles;
     this.outputFile = outputFile;
@@ -58,6 +60,7 @@ public class RewriteOptions {
     this.maskColumns = maskColumns;
     this.encryptColumns = encryptColumns;
     this.fileEncryptionProperties = fileEncryptionProperties;
+    this.prefetchBlockAllIndexes = prefetchBlockAllIndexes;
   }
 
   public Configuration getConf() {
@@ -92,16 +95,21 @@ public class RewriteOptions {
     return fileEncryptionProperties;
   }
 
+  public boolean prefetchBlockAllIndexes() {
+    return prefetchBlockAllIndexes;
+  }
+
   // Builder to create a RewriterOptions.
   public static class Builder {
-    private Configuration conf;
-    private List<Path> inputFiles;
-    private Path outputFile;
+    private final Configuration conf;
+    private final List<Path> inputFiles;
+    private final Path outputFile;
     private List<String> pruneColumns;
     private CompressionCodecName newCodecName;
     private Map<String, MaskMode> maskColumns;
     private List<String> encryptColumns;
     private FileEncryptionProperties fileEncryptionProperties;
+    private boolean prefetchBlockAllIndexes;
 
     /**
      * Create a builder to create a RewriterOptions.
@@ -214,6 +222,19 @@ public class RewriteOptions {
     }
 
     /**
+     * Whether enable prefetch block indexes into cache.
+     * <p>
+     * This could reduce the random seek while rewriting, disabled by default.
+     *
+     * @param prefetchBlockAllIndexes enable or not
+     * @return self
+     */
+    public Builder prefetchBlockAllIndex(boolean prefetchBlockAllIndexes) {
+      this.prefetchBlockAllIndexes = prefetchBlockAllIndexes;
+      return this;
+    }
+
+    /**
      * Build the RewriterOptions.
      *
      * @return a RewriterOptions
@@ -255,7 +276,8 @@ public class RewriteOptions {
               newCodecName,
               maskColumns,
               encryptColumns,
-              fileEncryptionProperties);
+              fileEncryptionProperties,
+              prefetchBlockAllIndexes);
     }
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
@@ -225,10 +225,10 @@ public class RewriteOptions {
     /**
      * Set the index(ColumnIndex, Offset and BloomFilter) cache strategy.
      * <p>
-     * This could reduce the random seek while rewriting with PRECACHE_BLOCK strategy, NONE by default.
+     * This could reduce the random seek while rewriting with PREFETCH_BLOCK strategy, NONE by default.
      *
      * @param cacheStrategy the index cache strategy, supports: {@link IndexCache.CacheStrategy#NONE} or
-     *        {@link IndexCache.CacheStrategy#PRECACHE_BLOCK}
+     *        {@link IndexCache.CacheStrategy#PREFETCH_BLOCK}
      * @return self
      */
     public Builder indexCacheStrategy(IndexCache.CacheStrategy cacheStrategy) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestIndexCache.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestIndexCache.java
@@ -109,11 +109,11 @@ public class TestIndexCache {
     columns.add(ColumnPath.fromDotString("Links.Backward"));
     columns.add(ColumnPath.fromDotString("Links.Forward"));
 
-    IndexCache indexCache = IndexCache.create(fileReader, columns, IndexCache.CacheStrategy.PRECACHE_BLOCK, false);
+    IndexCache indexCache = IndexCache.create(fileReader, columns, IndexCache.CacheStrategy.PREFETCH_BLOCK, false);
     Assert.assertTrue(indexCache instanceof PrefetchIndexCache);
     validPrecacheIndexCache(fileReader, indexCache, columns, false);
 
-    indexCache = IndexCache.create(fileReader, columns, IndexCache.CacheStrategy.PRECACHE_BLOCK, true);
+    indexCache = IndexCache.create(fileReader, columns, IndexCache.CacheStrategy.PREFETCH_BLOCK, true);
     Assert.assertTrue(indexCache instanceof PrefetchIndexCache);
     validPrecacheIndexCache(fileReader, indexCache, columns, true);
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestIndexCache.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestIndexCache.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.util.TestFileBuilder;
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+import org.apache.parquet.io.LocalInputFile;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
+import static org.apache.parquet.schema.Type.Repetition.REPEATED;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+
+@RunWith(Parameterized.class)
+public class TestIndexCache {
+  private final Configuration conf = new Configuration();
+  private final int numRecords = 100000;
+  private final MessageType schema = new MessageType("schema",
+    new PrimitiveType(OPTIONAL, INT64, "DocId"),
+    new PrimitiveType(REQUIRED, BINARY, "Name"),
+    new PrimitiveType(OPTIONAL, BINARY, "Gender"),
+    new GroupType(OPTIONAL, "Links",
+      new PrimitiveType(REPEATED, BINARY, "Backward"),
+      new PrimitiveType(REPEATED, BINARY, "Forward")));
+
+  private final ParquetProperties.WriterVersion writerVersion;
+
+  @Parameterized.Parameters(name = "WriterVersion = {0}, IndexCacheStrategy = {1}")
+  public static Object[] parameters() {
+    return new Object[] {"v1", "v2"};
+  }
+
+  public TestIndexCache(String writerVersion) {
+    this.writerVersion = ParquetProperties.WriterVersion.fromString(writerVersion);
+  }
+
+  @Test
+  public void testNoneCacheStrategy() throws IOException {
+    String file = createTestFile("DocID");
+
+    ParquetReadOptions options = ParquetReadOptions.builder().build();
+    ParquetFileReader fileReader = new ParquetFileReader(
+      new LocalInputFile(Paths.get(file)), options);
+    IndexCache indexCache = IndexCache.create(fileReader, new HashSet<>(), IndexCache.CacheStrategy.NONE);
+    Assert.assertTrue(indexCache instanceof NoneIndexCache);
+    List<BlockMetaData> blocks = fileReader.getFooter().getBlocks();
+    for (BlockMetaData blockMetaData : blocks) {
+      indexCache.setBlockMetadata(blockMetaData);
+      for (ColumnChunkMetaData chunk : blockMetaData.getColumns()) {
+        validateColumnIndex(fileReader.readColumnIndex(chunk), indexCache.getColumnIndex(chunk));
+        validateOffsetIndex(fileReader.readOffsetIndex(chunk), indexCache.getOffsetIndex(chunk));
+
+        Assert.assertEquals(
+          "BloomFilter should match",
+          fileReader.readBloomFilter(chunk),
+          indexCache.getBloomFilter(chunk));
+      }
+    }
+  }
+
+  @Test
+  public void testPrefetchCacheStrategy() throws IOException {
+    String file = createTestFile("DocID", "Name");
+
+    ParquetReadOptions options = ParquetReadOptions.builder().build();
+    ParquetFileReader fileReader = new ParquetFileReader(
+      new LocalInputFile(Paths.get(file)), options);
+    Set<ColumnPath> columns = new HashSet<>();
+    columns.add(ColumnPath.fromDotString("DocId"));
+    columns.add(ColumnPath.fromDotString("Name"));
+    columns.add(ColumnPath.fromDotString("Gender"));
+    columns.add(ColumnPath.fromDotString("Links.Backward"));
+    columns.add(ColumnPath.fromDotString("Links.Forward"));
+    IndexCache indexCache = IndexCache.create(fileReader, columns, IndexCache.CacheStrategy.PRECACHE_BLOCK);
+    Assert.assertTrue(indexCache instanceof PrefetchIndexCache);
+    List<BlockMetaData> blocks = fileReader.getFooter().getBlocks();
+    for (BlockMetaData blockMetaData : blocks) {
+      indexCache.setBlockMetadata(blockMetaData);
+      for (ColumnChunkMetaData chunk : blockMetaData.getColumns()) {
+        validateColumnIndex(fileReader.readColumnIndex(chunk), indexCache.getColumnIndex(chunk));
+        validateOffsetIndex(fileReader.readOffsetIndex(chunk), indexCache.getOffsetIndex(chunk));
+
+        Assert.assertEquals(
+          "BloomFilter should match",
+          fileReader.readBloomFilter(chunk),
+          indexCache.getBloomFilter(chunk));
+
+        Assert.assertThrows(IllegalStateException.class, () -> indexCache.getColumnIndex(chunk));
+        Assert.assertThrows(IllegalStateException.class, () -> indexCache.getOffsetIndex(chunk));
+        if (columns.contains(chunk.getPath())) {
+          Assert.assertThrows(IllegalStateException.class, () -> indexCache.getBloomFilter(chunk));
+        }
+      }
+    }
+  }
+
+  private String createTestFile(String... bloomFilterEnabledColumns) throws IOException {
+    return new TestFileBuilder(conf, schema)
+      .withNumRecord(numRecords)
+      .withCodec("UNCOMPRESSED")
+      .withRowGroupSize(1024L)
+      .withBloomFilterEnabled(bloomFilterEnabledColumns)
+      .withWriterVersion(writerVersion)
+      .build()
+      .getFileName();
+  }
+
+  private void validateColumnIndex(ColumnIndex expected, ColumnIndex target) {
+    if (expected == null) {
+      Assert.assertEquals("ColumnIndex should should equal", expected, target);
+    } else {
+      Assert.assertNotNull("ColumnIndex should not be null", target);
+      Assert.assertEquals(expected.getClass(), target.getClass());
+      Assert.assertEquals(expected.getMinValues(), target.getMinValues());
+      Assert.assertEquals(expected.getMaxValues(), target.getMaxValues());
+      Assert.assertEquals(expected.getBoundaryOrder(), target.getBoundaryOrder());
+      Assert.assertEquals(expected.getNullCounts(), target.getNullCounts());
+      Assert.assertEquals(expected.getNullPages(), target.getNullPages());
+    }
+  }
+
+  private void validateOffsetIndex(OffsetIndex expected, OffsetIndex target) {
+    if (expected == null) {
+      Assert.assertEquals("OffsetIndex should should equal", expected, target);
+    } else {
+      Assert.assertNotNull("OffsetIndex should not be null", target);
+      Assert.assertEquals(expected.getClass(), target.getClass());
+      Assert.assertEquals(expected.toString(), target.toString());
+    }
+  }
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
@@ -106,7 +106,7 @@ public class ParquetRewriterTest {
 
   @Parameterized.Parameters(name = "WriterVersion = {0}, IndexCacheStrategy = {1}")
   public static Object[][] parameters() {
-    return new Object[][] {{"v1", "NONE"}, {"v1", "PRECACHE_BLOCK"}, {"v2", "NONE"}, {"v2", "PRECACHE_BLOCK"}};
+    return new Object[][] {{"v1", "NONE"}, {"v1", "PREFETCH_BLOCK"}, {"v2", "NONE"}, {"v2", "PREFETCH_BLOCK"}};
   }
 
   public ParquetRewriterTest(String writerVersion, String indexCacheStrategy) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does

The `ColunIndex`, `OffsetIndex`, and `BloomFilter` are stored at the end of the file. We need to randomly seek 4 times when rewriting a column chunk. We found this could impact the rewrite performance heavily for files with a number of columns(~1000). In this PR, we read the `ColumnIndex`, `OffsetIndex`, and `BloomFilter` into a cache to avoid the random seek. We got about 60 times performance improvement in production environments for the files with about one thousand columns.
