### PR TITLE
PARQUET-2374: Add metrics support for parquet file reader

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
@@ -29,6 +29,7 @@ import org.apache.parquet.crypto.DecryptionPropertiesFactory;
 import org.apache.parquet.crypto.FileDecryptionProperties;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.format.converter.ParquetMetadataConverter.MetadataFilter;
+import org.apache.parquet.hadoop.ParquetMetricsCallback;
 
 public class HadoopReadOptions extends ParquetReadOptions {
   private final Configuration conf;
@@ -49,7 +50,8 @@ public class HadoopReadOptions extends ParquetReadOptions {
       int maxAllocationSize,
       Map<String, String> properties,
       Configuration conf,
-      FileDecryptionProperties fileDecryptionProperties) {
+      FileDecryptionProperties fileDecryptionProperties,
+      ParquetMetricsCallback metricsCallback) {
     super(
         useSignedStringMinMax,
         useStatsFilter,
@@ -66,6 +68,7 @@ public class HadoopReadOptions extends ParquetReadOptions {
         maxAllocationSize,
         properties,
         fileDecryptionProperties,
+        metricsCallback,
         new HadoopParquetConfiguration(conf));
     this.conf = conf;
   }
@@ -127,7 +130,8 @@ public class HadoopReadOptions extends ParquetReadOptions {
           maxAllocationSize,
           properties,
           conf,
-          fileDecryptionProperties);
+          fileDecryptionProperties,
+          metricsCallback);
     }
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
@@ -306,7 +306,7 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
 
     private void setDecompressMetrics(BytesInput bytes, long start) {
       if (metricsCallback != null) {
-        long time = System.nanoTime() - start;
+        long time = Math.max(System.nanoTime() - start, 0);
         long len = bytes.size();
         double throughput = ((double) len / time) * ((double) 1000_000_000L) / (1024 * 1024);
         LOG.debug(
@@ -314,7 +314,7 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
             len / (1024 * 1024),
             time / 1000_000L,
             throughput);
-        metricsCallback.setValueLong(ParquetFileReaderMetrics.DecompressTime.name(), time);
+        metricsCallback.setDuration(ParquetFileReaderMetrics.DecompressTime.name(), time);
         metricsCallback.setValueLong(ParquetFileReaderMetrics.DecompressSize.name(), len);
         metricsCallback.setValueDouble(ParquetFileReaderMetrics.DecompressThroughput.name(), throughput);
       }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
@@ -77,7 +77,7 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
     private final BlockCipher.Decryptor blockDecryptor;
     private final byte[] dataPageAAD;
     private final byte[] dictionaryPageAAD;
-    ParquetMetricsCallback metricsCallback;
+    private final ParquetMetricsCallback metricsCallback;
 
     ColumnChunkPageReader(
         BytesInputDecompressor decompressor,

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
@@ -77,7 +77,6 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
     private final BlockCipher.Decryptor blockDecryptor;
     private final byte[] dataPageAAD;
     private final byte[] dictionaryPageAAD;
-//     private final ParquetMetricsCallback metricsCallback;
 
     ColumnChunkPageReader(
         BytesInputDecompressor decompressor,

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
@@ -77,7 +77,7 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
     private final BlockCipher.Decryptor blockDecryptor;
     private final byte[] dataPageAAD;
     private final byte[] dictionaryPageAAD;
-    private final ParquetMetricsCallback metricsCallback;
+//     private final ParquetMetricsCallback metricsCallback;
 
     ColumnChunkPageReader(
         BytesInputDecompressor decompressor,
@@ -89,8 +89,7 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
         byte[] fileAAD,
         int rowGroupOrdinal,
         int columnOrdinal,
-        ParquetReadOptions options,
-        ParquetMetricsCallback callback) {
+        ParquetReadOptions options) {
       this.decompressor = decompressor;
       this.compressedPages = new ArrayDeque<DataPage>(compressedPages);
       this.compressedDictionaryPage = compressedDictionaryPage;
@@ -112,7 +111,6 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
         dataPageAAD = null;
         dictionaryPageAAD = null;
       }
-      this.metricsCallback = callback;
     }
 
     private int getPageOrdinal(int currentPageIndex) {
@@ -305,6 +303,7 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
     }
 
     private void setDecompressMetrics(BytesInput bytes, long start) {
+      final ParquetMetricsCallback metricsCallback = options.getMetricsCallback();
       if (metricsCallback != null) {
         long time = Math.max(System.nanoTime() - start, 0);
         long len = bytes.size();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -2012,7 +2012,7 @@ public class ParquetFileReader implements Closeable {
     private void setReadMetrics(long startNs) {
       ParquetMetricsCallback metricsCallback = options.getMetricsCallback();
       if (metricsCallback != null) {
-        long totalFileReadTimeNs = System.nanoTime() - startNs;
+        long totalFileReadTimeNs = Math.max(System.nanoTime() - startNs, 0);
         double sizeInMb = ((double) length) / (1024 * 1024);
         double timeInSec = ((double) totalFileReadTimeNs) / 1000_0000_0000L;
         double throughput = sizeInMb / timeInSec;
@@ -2021,7 +2021,7 @@ public class ParquetFileReader implements Closeable {
             sizeInMb,
             timeInSec,
             throughput);
-        metricsCallback.setValueLong(ParquetFileReaderMetrics.ReadTime.name(), totalFileReadTimeNs);
+        metricsCallback.setDuration(ParquetFileReaderMetrics.ReadTime.name(), totalFileReadTimeNs);
         metricsCallback.setValueLong(ParquetFileReaderMetrics.ReadSize.name(), length);
         metricsCallback.setValueDouble(ParquetFileReaderMetrics.ReadThroughput.name(), throughput);
       }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -1809,8 +1809,7 @@ public class ParquetFileReader implements Closeable {
           aadPrefix,
           rowGroupOrdinal,
           columnOrdinal,
-          options,
-          options.getMetricsCallback());
+          options);
     }
 
     private boolean hasMorePages(long valuesCountReadSoFar, int dataPageCountReadSoFar) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -827,8 +827,8 @@ public class ParquetFileReader implements Closeable {
    * @param conf   the Hadoop Configuration
    * @param file   Path to a parquet file
    * @param footer a {@link ParquetMetadata} footer already read from the file
+   * @param options {@link ParquetReadOptions}
    * @throws IOException if the file can not be opened
-   * @deprecated will be removed in 2.0.0.
    */
   public ParquetFileReader(Configuration conf, Path file, ParquetMetadata footer, ParquetReadOptions options)
       throws IOException {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReaderMetrics.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReaderMetrics.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+public enum ParquetFileReaderMetrics {
+
+  // metrics
+  ReadTime("time spent in reading Parquet file from storage"),
+  SeekTime("time spent in seek when reading Parquet file from storage"),
+  ReadSize("read size when reading Parquet file from storage (MB)"),
+  ReadThroughput("read throughput when reading Parquet file from storage (MB/sec)"),
+  DecompressTime("time spent in block decompression"),
+  DecompressSize("decompressed data size (MB)"),
+  DecompressThroughput("block decompression throughput (MB/sec)");
+
+  private final String desc;
+
+  ParquetFileReaderMetrics(String desc) {
+    this.desc = desc;
+  }
+
+  public String description() {
+    return desc;
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetMetricsCallback.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetMetricsCallback.java
@@ -18,11 +18,21 @@
  */
 package org.apache.parquet.hadoop;
 
+import org.apache.hadoop.classification.InterfaceStability;
+
 /**
- *  a simple interface to pass basic metric values by name to any implementation. Typically an
+ *  A simple interface to pass basic metric values by name to any implementation. Typically, an
  *  implementation of this interface will serve as a bridge to pass metric values on
  *  to the metrics system of a distributed engine (hadoop, spark, etc).
+ *  <br/>
+ *  Development Note: This interface should provide a default implementation for any new metric tracker
+ *  added to allow for backward compatibility
+ *  <br/>
+ *   e.g.
+ *  <br/>
+ *  <code>default addMaximum(key, value) { } ; </code>
  */
+@InterfaceStability.Unstable
 public interface ParquetMetricsCallback {
   void setValueInt(String name, int value);
 
@@ -31,4 +41,6 @@ public interface ParquetMetricsCallback {
   void setValueFloat(String name, float value);
 
   void setValueDouble(String name, double value);
+
+  void setDuration(String name, long value);
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetMetricsCallback.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetMetricsCallback.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+/**
+ *  a simple interface to pass basic metric values by name to any implementation. Typically an
+ *  implementation of this interface will serve as a bridge to pass metric values on
+ *  to the metrics system of a distributed engine (hadoop, spark, etc).
+ */
+public interface ParquetMetricsCallback {
+  void setValueInt(String name, int value);
+
+  void setValueLong(String name, long value);
+
+  void setValueFloat(String name, float value);
+
+  void setValueDouble(String name, double value);
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetMetricsCallback.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetMetricsCallback.java
@@ -24,12 +24,12 @@ import org.apache.hadoop.classification.InterfaceStability;
  *  A simple interface to pass basic metric values by name to any implementation. Typically, an
  *  implementation of this interface will serve as a bridge to pass metric values on
  *  to the metrics system of a distributed engine (hadoop, spark, etc).
- *  <br/>
+ *  <br>
  *  Development Note: This interface should provide a default implementation for any new metric tracker
  *  added to allow for backward compatibility
- *  <br/>
+ *  <br>
  *   e.g.
- *  <br/>
+ *  <br>
  *  <code>default addMaximum(key, value) { } ; </code>
  */
 @InterfaceStability.Unstable


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

This PR addresses the following: [PARQUET-2374](https://issues.apache.org/jira/browse/PARQUET-2374)
Add metrics support for parquet file reader
### Tests
No new tests. Adds a new public interface for reporting metrics from the parquet file reader
