### PR TITLE
PARQUET-2384: Mark `toOriginalType` as deprecated

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
@@ -151,8 +151,11 @@ public abstract class LogicalTypeAnnotation {
    *
    * API should be considered private
    *
+   * Deprecated: Please use the LogicalTypeAnnotation itself
+   *
    * @return the OriginalType representation of the new logical type, or null if there's none
    */
+  @Deprecated
   public abstract OriginalType toOriginalType();
 
   /**
@@ -314,9 +317,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       return OriginalType.UTF8;
     }
@@ -357,9 +363,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       return OriginalType.MAP;
     }
@@ -395,9 +404,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       return OriginalType.LIST;
     }
@@ -433,9 +445,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       return OriginalType.ENUM;
     }
@@ -489,9 +504,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       return OriginalType.DECIMAL;
     }
@@ -546,9 +564,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       return OriginalType.DATE;
     }
@@ -598,9 +619,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       switch (unit) {
         case MILLIS:
@@ -681,9 +705,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       switch (unit) {
         case MILLIS:
@@ -771,9 +798,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       switch (bitWidth) {
         case 8:
@@ -847,9 +877,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       return OriginalType.JSON;
     }
@@ -890,9 +923,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       return OriginalType.BSON;
     }
@@ -934,9 +970,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       // No OriginalType for UUID
       return null;
@@ -974,9 +1013,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       return OriginalType.INTERVAL;
     }
@@ -1029,9 +1071,12 @@ public abstract class LogicalTypeAnnotation {
     /**
      * API Should be considered private
      *
+     * Deprecated: Please use the LogicalTypeAnnotation itself
+     *
      * @return the original type
      */
     @Override
+    @Deprecated
     public OriginalType toOriginalType() {
       return OriginalType.MAP_KEY_VALUE;
     }


### PR DESCRIPTION
The OriginalType itself has been marked as deprecated for a long time, would be good to mark these as deprecated as well.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
