### PR TITLE
PARQUET-2396: Refactor `ColumnIndexBuilder`

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/ColumnIndexBuilder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/ColumnIndexBuilder.java
@@ -33,7 +33,6 @@ import it.unimi.dsi.fastutil.longs.LongLists;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Formatter;
-import java.util.Iterator;
 import java.util.List;
 import java.util.PrimitiveIterator;
 import java.util.Set;
@@ -299,9 +298,7 @@ public abstract class ColumnIndexBuilder {
     public <T extends Comparable<T>> PrimitiveIterator.OfInt visit(In<T> in) {
       Set<T> values = in.getValues();
       IntSet matchingIndexesForNull = new IntOpenHashSet(); // for null
-      Iterator<T> it = values.iterator();
-      while (it.hasNext()) {
-        T value = it.next();
+      for (T value : values) {
         if (value == null) {
           if (nullCounts == null) {
             // Searching for nulls so if we don't have null related statistics we have to return all pages
@@ -313,8 +310,7 @@ public abstract class ColumnIndexBuilder {
               }
             }
             if (values.size() == 1) {
-              return IndexIterator.filter(
-                  getPageCount(), pageIndex -> matchingIndexesForNull.contains(pageIndex));
+              return IndexIterator.filter(getPageCount(), matchingIndexesForNull::contains);
             }
           }
         }
@@ -343,7 +339,7 @@ public abstract class ColumnIndexBuilder {
       matchingIndexesLessThanMax.retainAll(matchingIndexesGreaterThanMin);
       IntSet matchingIndex = matchingIndexesLessThanMax;
       matchingIndex.addAll(matchingIndexesForNull); // add the matching null pages
-      return IndexIterator.filter(getPageCount(), pageIndex -> matchingIndex.contains(pageIndex));
+      return IndexIterator.filter(getPageCount(), matchingIndex::contains);
     }
 
     @Override


### PR DESCRIPTION
Small refactor to improve readability

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
