### PR TITLE
PARQUET-2399: Use deprecated tag in Javadoc

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnMaskingCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ColumnMaskingCommand.java
@@ -40,6 +40,7 @@ import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.schema.MessageType;
 import org.slf4j.Logger;
 
+@Deprecated
 @Parameters(
     commandDescription = "(Deprecated: will be removed in 2.0.0, use rewrite command instead) "
         + "Replace columns with masked values and write to a new Parquet file")

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/PruneColumnsCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/PruneColumnsCommand.java
@@ -29,6 +29,7 @@ import org.apache.parquet.cli.BaseCommand;
 import org.apache.parquet.hadoop.util.ColumnPruner;
 import org.slf4j.Logger;
 
+@Deprecated
 @Parameters(
     commandDescription = "(Deprecated: will be removed in 2.0.0, use rewrite command instead) "
         + "Prune column(s) in a Parquet file and save it to a new file. "

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/TransCompressionCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/TransCompressionCommand.java
@@ -40,6 +40,7 @@ import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.schema.MessageType;
 import org.slf4j.Logger;
 
+@Deprecated
 @Parameters(
     commandDescription = "(Deprecated: will be removed in 2.0.0, use rewrite command instead) "
         + "Translate the compression from one to another (It doesn't support bloom filter feature yet).")

--- a/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
@@ -150,10 +150,9 @@ public abstract class LogicalTypeAnnotation {
    * Those logical type implementations, which don't have a corresponding mapping should return null.
    * <p>
    * API should be considered private
-   * <p>
-   * Deprecated: Please use the LogicalTypeAnnotation itself
    *
    * @return the OriginalType representation of the new logical type, or null if there's none
+   * @deprecated Please use the LogicalTypeAnnotation itself
    */
   @Deprecated
   public abstract OriginalType toOriginalType();
@@ -317,10 +316,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -362,10 +360,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -402,10 +399,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -442,10 +438,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -501,10 +496,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -560,10 +554,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -615,10 +608,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -701,10 +693,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -794,10 +785,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -872,10 +862,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -917,10 +906,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -963,10 +951,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -1005,10 +992,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated
@@ -1062,10 +1048,9 @@ public abstract class LogicalTypeAnnotation {
 
     /**
      * API Should be considered private
-     * <p>
-     * Deprecated: Please use the LogicalTypeAnnotation itself
      *
      * @return the original type
+     * @deprecated Please use the LogicalTypeAnnotation itself
      */
     @Override
     @Deprecated


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-XXX
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [ ] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run the spotless:apply goal in Maven

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
