### PR TITLE
PARQUET-2410: Use row count instead of value count to get row count from OffsetIndex

### DIFF
--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
@@ -882,6 +882,8 @@ public class ParquetRewriterTest {
         BlockMetaData inBlockMetaData = inMetaData.getBlocks().get(inBlockId);
         BlockMetaData outBlockMetaData = outMetaData.getBlocks().get(outBlockId);
 
+        assertEquals(inBlockMetaData.getRowCount(), outBlockMetaData.getRowCount());
+
         for (int j = 0; j < outBlockMetaData.getColumns().size(); j++) {
           if (!outFileColumnMapping.containsKey(j)) {
             continue;
@@ -908,8 +910,8 @@ public class ParquetRewriterTest {
             for (int k = 0; k < inOffsetIndex.getPageCount(); k++) {
               assertEquals(inOffsetIndex.getFirstRowIndex(k), outOffsetIndex.getFirstRowIndex(k));
               assertEquals(
-                  inOffsetIndex.getLastRowIndex(k, inChunk.getValueCount()),
-                  outOffsetIndex.getLastRowIndex(k, outChunk.getValueCount()));
+                  inOffsetIndex.getLastRowIndex(k, inBlockMetaData.getRowCount()),
+                  outOffsetIndex.getLastRowIndex(k, outBlockMetaData.getRowCount()));
               assertEquals(inOffsetIndex.getOffset(k), (long) inOffsets.get(k));
               assertEquals(outOffsetIndex.getOffset(k), (long) outOffsets.get(k));
             }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-XXX
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does

We should use row count instead of value count to get row count from OffsetIndex in rewriter. Even this only influences the last row count and does not influence the result. It would be better to correct it.