### PR TITLE
PARQUET-2420 : ThriftParquetWriter Convert byte to LogicalType int32 bitWidth 8 instead of primitive int32

### DIFF
--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ThriftSchemaConvertVisitor.java
@@ -362,7 +362,7 @@ class ThriftSchemaConvertVisitor implements ThriftType.StateVisitor<ConvertedFie
 
   @Override
   public ConvertedField visit(ByteType byteType, State state) {
-    return visitPrimitiveType(INT32, state);
+    return visitPrimitiveType(INT32, LogicalTypeAnnotation.intType(8, true), state);
   }
 
   @Override

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConverter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConverter.java
@@ -376,7 +376,9 @@ public class TestThriftSchemaConverter {
 
   @Test
   public void testLogicalTypeConvertion() throws Exception {
-    String expected = "message ParquetSchema {\n" + "  required int32 test_i16 (INTEGER(16,true)) = 1;" + "}";
+    String expected = "message ParquetSchema {\n" + "  required int32 test_i16 (INTEGER(16,true)) = 1;\n"
+        + "  required int32 test_i8 (INTEGER(8,true)) = 2;\n"
+        + "}\n";
     ThriftSchemaConverter schemaConverter = new ThriftSchemaConverter();
     final MessageType converted = schemaConverter.convert(TestLogicalType.class);
     assertEquals(MessageTypeParser.parseMessageType(expected), converted);

--- a/parquet-thrift/src/test/thrift/test.thrift
+++ b/parquet-thrift/src/test/thrift/test.thrift
@@ -100,4 +100,3 @@ struct TestLogicalType {
   1: required i16 test_i16,
   2: required i8 test_i8
 }
-

--- a/parquet-thrift/src/test/thrift/test.thrift
+++ b/parquet-thrift/src/test/thrift/test.thrift
@@ -97,5 +97,7 @@ struct StructWithExtraField {
 }
 
 struct TestLogicalType {
-  1: required i16 test_i16
+  1: required i16 test_i16,
+  2: required i8 test_i8
 }
+

--- a/parquet-thrift/src/test/thrift/test.thrift
+++ b/parquet-thrift/src/test/thrift/test.thrift
@@ -98,5 +98,5 @@ struct StructWithExtraField {
 
 struct TestLogicalType {
   1: required i16 test_i16,
-  2: required i8 test_i8
+  2: required byte test_i8
 }


### PR DESCRIPTION
The current implementation of Parquet serialisation from Thrift Definitions results in the incorrect conversion of Thrift byte fields into INT32 without preserving the required LogicalType Metadata in the Parquet file. The correct conversion should result in INT32 with LogicalType of bitWidth 8 and signed = true.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. 
    - https://issues.apache.org/jira/browse/PARQUET-2420

### Tests

- [x] My PR adds the following unit tests

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
