### PR TITLE
PARQUET-2425: Support non-grouped repeated fields in AvroSchemaConverter

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
@@ -300,9 +300,8 @@ public class AvroSchemaConverter {
     Integer nameCount = names.merge(name, 1, (oldValue, value) -> oldValue + 1);
     for (Type parquetType : parquetFields) {
       Schema fieldSchema = convertField(parquetType, names);
-      if (parquetType.isRepetition(REPEATED)) {
-        throw new UnsupportedOperationException(
-            "REPEATED not supported outside LIST or MAP. Type: " + parquetType);
+      if (parquetType.isRepetition(REPEATED)) { // If a repeated field is ungrouped, treat as REQUIRED per spec
+        fields.add(new Schema.Field(parquetType.getName(), Schema.createArray(fieldSchema)));
       } else if (parquetType.isRepetition(Type.Repetition.OPTIONAL)) {
         fields.add(new Schema.Field(parquetType.getName(), optional(fieldSchema), null, NULL_VALUE));
       } else { // REQUIRED

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
@@ -423,6 +423,21 @@ public class TestAvroSchemaConverter {
   }
 
   @Test
+  public void testConvertUngroupedRepeatedField() throws Exception {
+    testParquetToAvroConversion(
+        NEW_BEHAVIOR,
+        new Schema.Parser()
+            .parse("{\"type\": \"record\","
+                + "  \"name\": \"SchemaWithRepeatedField\","
+                + "  \"fields\": [{"
+                + "    \"name\": \"repeatedField\","
+                + "    \"type\": {\"type\": \"array\",\"items\": \"int\"}"
+                + "  }]"
+                + "}"),
+        "message SchemaWithRepeatedField { repeated int32 repeatedField; }");
+  }
+
+  @Test
   public void testOldThriftListOfLists() throws Exception {
     Schema listOfLists = optional(Schema.createArray(Schema.createArray(Schema.create(INT))));
     Schema schema = Schema.createRecord("ThriftCompatListInList", null, null, false);


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-2425
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
