### PR TITLE
PARQUET-2428: Make RawPagesReader accpet specificed columns.

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowPagesCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowPagesCommand.java
@@ -83,7 +83,7 @@ public class ShowPagesCommand extends BaseCommand {
     // command.
     if (raw) {
       try (RawPagesReader reader =
-          new RawPagesReader(HadoopInputFile.fromPath(qualifiedPath(targets.get(0)), getConf()))) {
+          new RawPagesReader(HadoopInputFile.fromPath(qualifiedPath(targets.get(0)), getConf()), columns)) {
         reader.listPages(console);
       }
       return 0;


### PR DESCRIPTION
Make RawPagesReader support specified columns as sometimes we only need to print page information from certain columns.

Close [PARQUET-2848](https://issues.apache.org/jira/browse/PARQUET-2428)