### PR TITLE
PARQUET-2431: Handle ByteBufferAllocator gracefully

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/CheckParquet251Command.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/CheckParquet251Command.java
@@ -113,6 +113,7 @@ public class CheckParquet251Command extends BaseCommand {
             pages != null;
             pages = reader.readNextRowGroup()) {
           validator.validate(columns, pages);
+          pages.close();
         }
       } catch (BadStatsException e) {
         return e.getMessage();

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowPagesCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowPagesCommand.java
@@ -131,6 +131,7 @@ public class ShowPagesCommand extends BaseCommand {
           }
         }
         rowGroupNum += 1;
+        pageStore.close();
       }
 
       // TODO: Show total column size and overall size per value in the column summary line

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderBase.java
@@ -729,7 +729,7 @@ abstract class ColumnReaderBase implements ColumnReader {
 
     if (CorruptDeltaByteArrays.requiresSequentialReads(writerVersion, dataEncoding)
         && previousReader != null
-        && previousReader instanceof RequiresPreviousReader) {
+        && dataColumn instanceof RequiresPreviousReader) {
       // previous reader can only be set if reading sequentially
       ((RequiresPreviousReader) dataColumn).setPreviousReader(previousReader);
     }

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/PageReadStore.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/PageReadStore.java
@@ -27,7 +27,7 @@ import org.apache.parquet.column.ColumnDescriptor;
  * <p>
  * TODO: rename to RowGroup?
  */
-public interface PageReadStore {
+public interface PageReadStore extends AutoCloseable {
 
   /**
    * @param descriptor the descriptor of the column
@@ -57,5 +57,10 @@ public interface PageReadStore {
    */
   default Optional<PrimitiveIterator.OfLong> getRowIndexes() {
     return Optional.empty();
+  }
+
+  @Override
+  default void close() {
+    // No-op default implementation for compatibility
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/ValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/ValuesWriter.java
@@ -26,7 +26,7 @@ import org.apache.parquet.io.api.Binary;
 /**
  * base class to implement an encoding for a given column
  */
-public abstract class ValuesWriter {
+public abstract class ValuesWriter implements AutoCloseable {
 
   /**
    * used to decide if we want to work to the next page
@@ -58,6 +58,7 @@ public abstract class ValuesWriter {
    * Called to close the values writer. Any output stream is closed and can no longer be used.
    * All resources are released.
    */
+  @Override
   public void close() {}
 
   /**

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/rle/RunLengthBitPackingHybridEncoder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/rle/RunLengthBitPackingHybridEncoder.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Only supports positive values (including 0) // TODO: is that ok? Should we make a signed version?
  */
-public class RunLengthBitPackingHybridEncoder {
+public class RunLengthBitPackingHybridEncoder implements AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(RunLengthBitPackingHybridEncoder.class);
 
   private final BytePacker packer;
@@ -279,6 +279,7 @@ public class RunLengthBitPackingHybridEncoder {
     reset(true);
   }
 
+  @Override
   public void close() {
     reset(false);
     baos.close();

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
+import org.apache.parquet.bytes.TrackingByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.Encoding;
@@ -49,23 +50,36 @@ import org.apache.parquet.column.values.plain.PlainValuesReader;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class TestDictionary {
 
+  private TrackingByteBufferAllocator allocator;
+
+  @Before
+  public void initAllocator() {
+    allocator = TrackingByteBufferAllocator.wrap(new DirectByteBufferAllocator());
+  }
+
+  @After
+  public void closeAllocator() {
+    allocator.close();
+  }
+
   private <I extends DictionaryValuesWriter> FallbackValuesWriter<I, PlainValuesWriter> plainFallBack(
       I dvw, int initialSize) {
-    return FallbackValuesWriter.of(
-        dvw, new PlainValuesWriter(initialSize, initialSize * 5, new DirectByteBufferAllocator()));
+    return FallbackValuesWriter.of(dvw, new PlainValuesWriter(initialSize, initialSize * 5, allocator));
   }
 
   private FallbackValuesWriter<PlainBinaryDictionaryValuesWriter, PlainValuesWriter>
       newPlainBinaryDictionaryValuesWriter(int maxDictionaryByteSize, int initialSize) {
     return plainFallBack(
         new PlainBinaryDictionaryValuesWriter(
-            maxDictionaryByteSize, PLAIN_DICTIONARY, PLAIN_DICTIONARY, new DirectByteBufferAllocator()),
+            maxDictionaryByteSize, PLAIN_DICTIONARY, PLAIN_DICTIONARY, allocator),
         initialSize);
   }
 
@@ -73,7 +87,7 @@ public class TestDictionary {
       int maxDictionaryByteSize, int initialSize) {
     return plainFallBack(
         new PlainLongDictionaryValuesWriter(
-            maxDictionaryByteSize, PLAIN_DICTIONARY, PLAIN_DICTIONARY, new DirectByteBufferAllocator()),
+            maxDictionaryByteSize, PLAIN_DICTIONARY, PLAIN_DICTIONARY, allocator),
         initialSize);
   }
 
@@ -81,7 +95,7 @@ public class TestDictionary {
       newPlainIntegerDictionaryValuesWriter(int maxDictionaryByteSize, int initialSize) {
     return plainFallBack(
         new PlainIntegerDictionaryValuesWriter(
-            maxDictionaryByteSize, PLAIN_DICTIONARY, PLAIN_DICTIONARY, new DirectByteBufferAllocator()),
+            maxDictionaryByteSize, PLAIN_DICTIONARY, PLAIN_DICTIONARY, allocator),
         initialSize);
   }
 
@@ -89,7 +103,7 @@ public class TestDictionary {
       newPlainDoubleDictionaryValuesWriter(int maxDictionaryByteSize, int initialSize) {
     return plainFallBack(
         new PlainDoubleDictionaryValuesWriter(
-            maxDictionaryByteSize, PLAIN_DICTIONARY, PLAIN_DICTIONARY, new DirectByteBufferAllocator()),
+            maxDictionaryByteSize, PLAIN_DICTIONARY, PLAIN_DICTIONARY, allocator),
         initialSize);
   }
 
@@ -97,67 +111,69 @@ public class TestDictionary {
       newPlainFloatDictionaryValuesWriter(int maxDictionaryByteSize, int initialSize) {
     return plainFallBack(
         new PlainFloatDictionaryValuesWriter(
-            maxDictionaryByteSize, PLAIN_DICTIONARY, PLAIN_DICTIONARY, new DirectByteBufferAllocator()),
+            maxDictionaryByteSize, PLAIN_DICTIONARY, PLAIN_DICTIONARY, allocator),
         initialSize);
   }
 
   @Test
   public void testBinaryDictionary() throws IOException {
     int COUNT = 100;
-    ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(200, 10000);
-    writeRepeated(COUNT, cw, "a");
-    BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    writeRepeated(COUNT, cw, "b");
-    BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    // now we will fall back
-    writeDistinct(COUNT, cw, "c");
-    BytesInput bytes3 = getBytesAndCheckEncoding(cw, PLAIN);
+    try (ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(200, 10000)) {
+      writeRepeated(COUNT, cw, "a");
+      BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      writeRepeated(COUNT, cw, "b");
+      BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      // now we will fall back
+      writeDistinct(COUNT, cw, "c");
+      BytesInput bytes3 = getBytesAndCheckEncoding(cw, PLAIN);
 
-    DictionaryValuesReader cr = initDicReader(cw, BINARY);
-    checkRepeated(COUNT, bytes1, cr, "a");
-    checkRepeated(COUNT, bytes2, cr, "b");
-    BinaryPlainValuesReader cr2 = new BinaryPlainValuesReader();
-    checkDistinct(COUNT, bytes3, cr2, "c");
+      DictionaryValuesReader cr = initDicReader(cw, BINARY);
+      checkRepeated(COUNT, bytes1, cr, "a");
+      checkRepeated(COUNT, bytes2, cr, "b");
+      BinaryPlainValuesReader cr2 = new BinaryPlainValuesReader();
+      checkDistinct(COUNT, bytes3, cr2, "c");
+    }
   }
 
   @Test
   public void testSkipInBinaryDictionary() throws Exception {
-    ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(1000, 10000);
-    writeRepeated(100, cw, "a");
-    writeDistinct(100, cw, "b");
-    assertEquals(PLAIN_DICTIONARY, cw.getEncoding());
+    try (ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(1000, 10000)) {
+      writeRepeated(100, cw, "a");
+      writeDistinct(100, cw, "b");
+      assertEquals(PLAIN_DICTIONARY, cw.getEncoding());
 
-    // Test skip and skip-n with dictionary encoding
-    ByteBufferInputStream stream = cw.getBytes().toInputStream();
-    DictionaryValuesReader cr = initDicReader(cw, BINARY);
-    cr.initFromPage(200, stream);
-    for (int i = 0; i < 100; i += 2) {
-      assertEquals(Binary.fromString("a" + i % 10), cr.readBytes());
-      cr.skip();
-    }
-    int skipCount;
-    for (int i = 0; i < 100; i += skipCount + 1) {
-      skipCount = (100 - i) / 2;
-      assertEquals(Binary.fromString("b" + i), cr.readBytes());
-      cr.skip(skipCount);
-    }
+      // Test skip and skip-n with dictionary encoding
+      ByteBufferInputStream stream = cw.getBytes().toInputStream();
+      DictionaryValuesReader cr = initDicReader(cw, BINARY);
+      cr.initFromPage(200, stream);
+      for (int i = 0; i < 100; i += 2) {
+        assertEquals(Binary.fromString("a" + i % 10), cr.readBytes());
+        cr.skip();
+      }
+      int skipCount;
+      for (int i = 0; i < 100; i += skipCount + 1) {
+        skipCount = (100 - i) / 2;
+        assertEquals(Binary.fromString("b" + i), cr.readBytes());
+        cr.skip(skipCount);
+      }
 
-    // Ensure fallback
-    writeDistinct(1000, cw, "c");
-    assertEquals(PLAIN, cw.getEncoding());
+      // Ensure fallback
+      writeDistinct(1000, cw, "c");
+      assertEquals(PLAIN, cw.getEncoding());
 
-    // Test skip and skip-n with plain encoding (after fallback)
-    ValuesReader plainReader = new BinaryPlainValuesReader();
-    plainReader.initFromPage(1200, cw.getBytes().toInputStream());
-    plainReader.skip(200);
-    for (int i = 0; i < 100; i += 2) {
-      assertEquals("c" + i, plainReader.readBytes().toStringUsingUTF8());
-      plainReader.skip();
-    }
-    for (int i = 100; i < 1000; i += skipCount + 1) {
-      skipCount = (1000 - i) / 2;
-      assertEquals(Binary.fromString("c" + i), plainReader.readBytes());
-      plainReader.skip(skipCount);
+      // Test skip and skip-n with plain encoding (after fallback)
+      ValuesReader plainReader = new BinaryPlainValuesReader();
+      plainReader.initFromPage(1200, cw.getBytes().toInputStream());
+      plainReader.skip(200);
+      for (int i = 0; i < 100; i += 2) {
+        assertEquals("c" + i, plainReader.readBytes().toStringUsingUTF8());
+        plainReader.skip();
+      }
+      for (int i = 100; i < 1000; i += skipCount + 1) {
+        skipCount = (1000 - i) / 2;
+        assertEquals(Binary.fromString("c" + i), plainReader.readBytes());
+        plainReader.skip(skipCount);
+      }
     }
   }
 
@@ -165,31 +181,32 @@ public class TestDictionary {
   public void testBinaryDictionaryFallBack() throws IOException {
     int slabSize = 100;
     int maxDictionaryByteSize = 50;
-    final ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(maxDictionaryByteSize, slabSize);
-    int fallBackThreshold = maxDictionaryByteSize;
-    int dataSize = 0;
-    for (long i = 0; i < 100; i++) {
-      Binary binary = Binary.fromString("str" + i);
-      cw.writeBytes(binary);
-      dataSize += (binary.length() + 4);
-      if (dataSize < fallBackThreshold) {
-        assertEquals(PLAIN_DICTIONARY, cw.getEncoding());
-      } else {
-        assertEquals(PLAIN, cw.getEncoding());
+    try (final ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(maxDictionaryByteSize, slabSize)) {
+      int fallBackThreshold = maxDictionaryByteSize;
+      int dataSize = 0;
+      for (long i = 0; i < 100; i++) {
+        Binary binary = Binary.fromString("str" + i);
+        cw.writeBytes(binary);
+        dataSize += (binary.length() + 4);
+        if (dataSize < fallBackThreshold) {
+          assertEquals(PLAIN_DICTIONARY, cw.getEncoding());
+        } else {
+          assertEquals(PLAIN, cw.getEncoding());
+        }
       }
+
+      // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
+      ValuesReader reader = new BinaryPlainValuesReader();
+      reader.initFromPage(100, cw.getBytes().toInputStream());
+
+      for (long i = 0; i < 100; i++) {
+        assertEquals(Binary.fromString("str" + i), reader.readBytes());
+      }
+
+      // simulate cutting the page
+      cw.reset();
+      assertEquals(0, cw.getBufferedSize());
     }
-
-    // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
-    ValuesReader reader = new BinaryPlainValuesReader();
-    reader.initFromPage(100, cw.getBytes().toInputStream());
-
-    for (long i = 0; i < 100; i++) {
-      assertEquals(Binary.fromString("str" + i), reader.readBytes());
-    }
-
-    // simulate cutting the page
-    cw.reset();
-    assertEquals(0, cw.getBufferedSize());
   }
 
   @Test
@@ -199,98 +216,103 @@ public class TestDictionary {
     // make the writer happy
     Mockito.when(mock.copy()).thenReturn(Binary.fromString(" world"));
 
-    final ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(100, 100);
-    cw.writeBytes(Binary.fromString("hello"));
-    cw.writeBytes(mock);
+    try (final ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(100, 100)) {
+      cw.writeBytes(Binary.fromString("hello"));
+      cw.writeBytes(mock);
 
-    assertEquals(PLAIN, cw.getEncoding());
+      assertEquals(PLAIN, cw.getEncoding());
+    }
   }
 
   @Test
   public void testBinaryDictionaryChangedValues() throws IOException {
     int COUNT = 100;
-    ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(200, 10000);
-    writeRepeatedWithReuse(COUNT, cw, "a");
-    BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    writeRepeatedWithReuse(COUNT, cw, "b");
-    BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    // now we will fall back
-    writeDistinct(COUNT, cw, "c");
-    BytesInput bytes3 = getBytesAndCheckEncoding(cw, PLAIN);
+    try (ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(200, 10000)) {
+      writeRepeatedWithReuse(COUNT, cw, "a");
+      BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      writeRepeatedWithReuse(COUNT, cw, "b");
+      BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      // now we will fall back
+      writeDistinct(COUNT, cw, "c");
+      BytesInput bytes3 = getBytesAndCheckEncoding(cw, PLAIN);
 
-    DictionaryValuesReader cr = initDicReader(cw, BINARY);
-    checkRepeated(COUNT, bytes1, cr, "a");
-    checkRepeated(COUNT, bytes2, cr, "b");
-    BinaryPlainValuesReader cr2 = new BinaryPlainValuesReader();
-    checkDistinct(COUNT, bytes3, cr2, "c");
+      DictionaryValuesReader cr = initDicReader(cw, BINARY);
+      checkRepeated(COUNT, bytes1, cr, "a");
+      checkRepeated(COUNT, bytes2, cr, "b");
+      BinaryPlainValuesReader cr2 = new BinaryPlainValuesReader();
+      checkDistinct(COUNT, bytes3, cr2, "c");
+    }
   }
 
   @Test
   public void testFirstPageFallBack() throws IOException {
     int COUNT = 1000;
-    ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(10000, 10000);
-    writeDistinct(COUNT, cw, "a");
-    // not efficient so falls back
-    BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN);
-    writeRepeated(COUNT, cw, "b");
-    // still plain because we fell back on first page
-    BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN);
+    try (ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(10000, 10000)) {
+      writeDistinct(COUNT, cw, "a");
+      // not efficient so falls back
+      BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN);
+      writeRepeated(COUNT, cw, "b");
+      // still plain because we fell back on first page
+      BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN);
 
-    ValuesReader cr = new BinaryPlainValuesReader();
-    checkDistinct(COUNT, bytes1, cr, "a");
-    checkRepeated(COUNT, bytes2, cr, "b");
+      ValuesReader cr = new BinaryPlainValuesReader();
+      checkDistinct(COUNT, bytes1, cr, "a");
+      checkRepeated(COUNT, bytes2, cr, "b");
+    }
   }
 
   @Test
   public void testSecondPageFallBack() throws IOException {
     int COUNT = 1000;
-    ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(1000, 10000);
-    writeRepeated(COUNT, cw, "a");
-    BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    writeDistinct(COUNT, cw, "b");
-    // not efficient so falls back
-    BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN);
-    writeRepeated(COUNT, cw, "a");
-    // still plain because we fell back on previous page
-    BytesInput bytes3 = getBytesAndCheckEncoding(cw, PLAIN);
+    try (ValuesWriter cw = newPlainBinaryDictionaryValuesWriter(1000, 10000)) {
+      writeRepeated(COUNT, cw, "a");
+      BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      writeDistinct(COUNT, cw, "b");
+      // not efficient so falls back
+      BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN);
+      writeRepeated(COUNT, cw, "a");
+      // still plain because we fell back on previous page
+      BytesInput bytes3 = getBytesAndCheckEncoding(cw, PLAIN);
 
-    ValuesReader cr = initDicReader(cw, BINARY);
-    checkRepeated(COUNT, bytes1, cr, "a");
-    cr = new BinaryPlainValuesReader();
-    checkDistinct(COUNT, bytes2, cr, "b");
-    checkRepeated(COUNT, bytes3, cr, "a");
+      ValuesReader cr = initDicReader(cw, BINARY);
+      checkRepeated(COUNT, bytes1, cr, "a");
+      cr = new BinaryPlainValuesReader();
+      checkDistinct(COUNT, bytes2, cr, "b");
+      checkRepeated(COUNT, bytes3, cr, "a");
+    }
   }
 
   @Test
   public void testLongDictionary() throws IOException {
     int COUNT = 1000;
     int COUNT2 = 2000;
-    final FallbackValuesWriter<PlainLongDictionaryValuesWriter, PlainValuesWriter> cw =
-        newPlainLongDictionaryValuesWriter(10000, 10000);
-    for (long i = 0; i < COUNT; i++) {
-      cw.writeLong(i % 50);
-    }
-    BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    assertEquals(50, cw.initialWriter.getDictionarySize());
+    try (final FallbackValuesWriter<PlainLongDictionaryValuesWriter, PlainValuesWriter> cw =
+        newPlainLongDictionaryValuesWriter(10000, 10000)) {
+      for (long i = 0; i < COUNT; i++) {
+        cw.writeLong(i % 50);
+      }
+      BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      assertEquals(50, cw.initialWriter.getDictionarySize());
 
-    for (long i = COUNT2; i > 0; i--) {
-      cw.writeLong(i % 50);
-    }
-    BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    assertEquals(50, cw.initialWriter.getDictionarySize());
+      for (long i = COUNT2; i > 0; i--) {
+        cw.writeLong(i % 50);
+      }
+      BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      assertEquals(50, cw.initialWriter.getDictionarySize());
 
-    DictionaryValuesReader cr = initDicReader(cw, PrimitiveTypeName.INT64);
+      DictionaryValuesReader cr = initDicReader(cw, PrimitiveTypeName.INT64);
 
-    cr.initFromPage(COUNT, bytes1.toInputStream());
-    for (long i = 0; i < COUNT; i++) {
-      long back = cr.readLong();
-      assertEquals(i % 50, back);
-    }
+      cr.initFromPage(COUNT, bytes1.toInputStream());
+      for (long i = 0; i < COUNT; i++) {
+        long back = cr.readLong();
+        assertEquals(i % 50, back);
+      }
 
-    cr.initFromPage(COUNT2, bytes2.toInputStream());
-    for (long i = COUNT2; i > 0; i--) {
-      long back = cr.readLong();
-      assertEquals(i % 50, back);
+      cr.initFromPage(COUNT2, bytes2.toInputStream());
+      for (long i = COUNT2; i > 0; i--) {
+        long back = cr.readLong();
+        assertEquals(i % 50, back);
+      }
     }
   }
 
@@ -336,18 +358,19 @@ public class TestDictionary {
   public void testLongDictionaryFallBack() throws IOException {
     int slabSize = 100;
     int maxDictionaryByteSize = 50;
-    final FallbackValuesWriter<PlainLongDictionaryValuesWriter, PlainValuesWriter> cw =
-        newPlainLongDictionaryValuesWriter(maxDictionaryByteSize, slabSize);
-    // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
-    ValuesReader reader = new PlainValuesReader.LongPlainValuesReader();
+    try (final FallbackValuesWriter<PlainLongDictionaryValuesWriter, PlainValuesWriter> cw =
+        newPlainLongDictionaryValuesWriter(maxDictionaryByteSize, slabSize)) {
+      // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
+      ValuesReader reader = new PlainValuesReader.LongPlainValuesReader();
 
-    roundTripLong(cw, reader, maxDictionaryByteSize);
-    // simulate cutting the page
-    cw.reset();
-    assertEquals(0, cw.getBufferedSize());
-    cw.resetDictionary();
+      roundTripLong(cw, reader, maxDictionaryByteSize);
+      // simulate cutting the page
+      cw.reset();
+      assertEquals(0, cw.getBufferedSize());
+      cw.resetDictionary();
 
-    roundTripLong(cw, reader, maxDictionaryByteSize);
+      roundTripLong(cw, reader, maxDictionaryByteSize);
+    }
   }
 
   @Test
@@ -355,34 +378,35 @@ public class TestDictionary {
 
     int COUNT = 1000;
     int COUNT2 = 2000;
-    final FallbackValuesWriter<PlainDoubleDictionaryValuesWriter, PlainValuesWriter> cw =
-        newPlainDoubleDictionaryValuesWriter(10000, 10000);
+    try (final FallbackValuesWriter<PlainDoubleDictionaryValuesWriter, PlainValuesWriter> cw =
+        newPlainDoubleDictionaryValuesWriter(10000, 10000)) {
 
-    for (double i = 0; i < COUNT; i++) {
-      cw.writeDouble(i % 50);
-    }
+      for (double i = 0; i < COUNT; i++) {
+        cw.writeDouble(i % 50);
+      }
 
-    BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    assertEquals(50, cw.initialWriter.getDictionarySize());
+      BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      assertEquals(50, cw.initialWriter.getDictionarySize());
 
-    for (double i = COUNT2; i > 0; i--) {
-      cw.writeDouble(i % 50);
-    }
-    BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    assertEquals(50, cw.initialWriter.getDictionarySize());
+      for (double i = COUNT2; i > 0; i--) {
+        cw.writeDouble(i % 50);
+      }
+      BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      assertEquals(50, cw.initialWriter.getDictionarySize());
 
-    final DictionaryValuesReader cr = initDicReader(cw, DOUBLE);
+      final DictionaryValuesReader cr = initDicReader(cw, DOUBLE);
 
-    cr.initFromPage(COUNT, bytes1.toInputStream());
-    for (double i = 0; i < COUNT; i++) {
-      double back = cr.readDouble();
-      assertEquals(i % 50, back, 0.0);
-    }
+      cr.initFromPage(COUNT, bytes1.toInputStream());
+      for (double i = 0; i < COUNT; i++) {
+        double back = cr.readDouble();
+        assertEquals(i % 50, back, 0.0);
+      }
 
-    cr.initFromPage(COUNT2, bytes2.toInputStream());
-    for (double i = COUNT2; i > 0; i--) {
-      double back = cr.readDouble();
-      assertEquals(i % 50, back, 0.0);
+      cr.initFromPage(COUNT2, bytes2.toInputStream());
+      for (double i = COUNT2; i > 0; i--) {
+        double back = cr.readDouble();
+        assertEquals(i % 50, back, 0.0);
+      }
     }
   }
 
@@ -428,19 +452,20 @@ public class TestDictionary {
   public void testDoubleDictionaryFallBack() throws IOException {
     int slabSize = 100;
     int maxDictionaryByteSize = 50;
-    final FallbackValuesWriter<PlainDoubleDictionaryValuesWriter, PlainValuesWriter> cw =
-        newPlainDoubleDictionaryValuesWriter(maxDictionaryByteSize, slabSize);
+    try (final FallbackValuesWriter<PlainDoubleDictionaryValuesWriter, PlainValuesWriter> cw =
+        newPlainDoubleDictionaryValuesWriter(maxDictionaryByteSize, slabSize)) {
 
-    // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
-    ValuesReader reader = new PlainValuesReader.DoublePlainValuesReader();
+      // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
+      ValuesReader reader = new PlainValuesReader.DoublePlainValuesReader();
 
-    roundTripDouble(cw, reader, maxDictionaryByteSize);
-    // simulate cutting the page
-    cw.reset();
-    assertEquals(0, cw.getBufferedSize());
-    cw.resetDictionary();
+      roundTripDouble(cw, reader, maxDictionaryByteSize);
+      // simulate cutting the page
+      cw.reset();
+      assertEquals(0, cw.getBufferedSize());
+      cw.resetDictionary();
 
-    roundTripDouble(cw, reader, maxDictionaryByteSize);
+      roundTripDouble(cw, reader, maxDictionaryByteSize);
+    }
   }
 
   @Test
@@ -448,33 +473,34 @@ public class TestDictionary {
 
     int COUNT = 2000;
     int COUNT2 = 4000;
-    final FallbackValuesWriter<PlainIntegerDictionaryValuesWriter, PlainValuesWriter> cw =
-        newPlainIntegerDictionaryValuesWriter(10000, 10000);
+    try (final FallbackValuesWriter<PlainIntegerDictionaryValuesWriter, PlainValuesWriter> cw =
+        newPlainIntegerDictionaryValuesWriter(10000, 10000)) {
 
-    for (int i = 0; i < COUNT; i++) {
-      cw.writeInteger(i % 50);
-    }
-    BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    assertEquals(50, cw.initialWriter.getDictionarySize());
+      for (int i = 0; i < COUNT; i++) {
+        cw.writeInteger(i % 50);
+      }
+      BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      assertEquals(50, cw.initialWriter.getDictionarySize());
 
-    for (int i = COUNT2; i > 0; i--) {
-      cw.writeInteger(i % 50);
-    }
-    BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    assertEquals(50, cw.initialWriter.getDictionarySize());
+      for (int i = COUNT2; i > 0; i--) {
+        cw.writeInteger(i % 50);
+      }
+      BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      assertEquals(50, cw.initialWriter.getDictionarySize());
 
-    DictionaryValuesReader cr = initDicReader(cw, INT32);
+      DictionaryValuesReader cr = initDicReader(cw, INT32);
 
-    cr.initFromPage(COUNT, bytes1.toInputStream());
-    for (int i = 0; i < COUNT; i++) {
-      int back = cr.readInteger();
-      assertEquals(i % 50, back);
-    }
+      cr.initFromPage(COUNT, bytes1.toInputStream());
+      for (int i = 0; i < COUNT; i++) {
+        int back = cr.readInteger();
+        assertEquals(i % 50, back);
+      }
 
-    cr.initFromPage(COUNT2, bytes2.toInputStream());
-    for (int i = COUNT2; i > 0; i--) {
-      int back = cr.readInteger();
-      assertEquals(i % 50, back);
+      cr.initFromPage(COUNT2, bytes2.toInputStream());
+      for (int i = COUNT2; i > 0; i--) {
+        int back = cr.readInteger();
+        assertEquals(i % 50, back);
+      }
     }
   }
 
@@ -520,19 +546,20 @@ public class TestDictionary {
   public void testIntDictionaryFallBack() throws IOException {
     int slabSize = 100;
     int maxDictionaryByteSize = 50;
-    final FallbackValuesWriter<PlainIntegerDictionaryValuesWriter, PlainValuesWriter> cw =
-        newPlainIntegerDictionaryValuesWriter(maxDictionaryByteSize, slabSize);
+    try (final FallbackValuesWriter<PlainIntegerDictionaryValuesWriter, PlainValuesWriter> cw =
+        newPlainIntegerDictionaryValuesWriter(maxDictionaryByteSize, slabSize)) {
 
-    // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
-    ValuesReader reader = new PlainValuesReader.IntegerPlainValuesReader();
+      // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
+      ValuesReader reader = new PlainValuesReader.IntegerPlainValuesReader();
 
-    roundTripInt(cw, reader, maxDictionaryByteSize);
-    // simulate cutting the page
-    cw.reset();
-    assertEquals(0, cw.getBufferedSize());
-    cw.resetDictionary();
+      roundTripInt(cw, reader, maxDictionaryByteSize);
+      // simulate cutting the page
+      cw.reset();
+      assertEquals(0, cw.getBufferedSize());
+      cw.resetDictionary();
 
-    roundTripInt(cw, reader, maxDictionaryByteSize);
+      roundTripInt(cw, reader, maxDictionaryByteSize);
+    }
   }
 
   @Test
@@ -540,33 +567,34 @@ public class TestDictionary {
 
     int COUNT = 2000;
     int COUNT2 = 4000;
-    final FallbackValuesWriter<PlainFloatDictionaryValuesWriter, PlainValuesWriter> cw =
-        newPlainFloatDictionaryValuesWriter(10000, 10000);
+    try (final FallbackValuesWriter<PlainFloatDictionaryValuesWriter, PlainValuesWriter> cw =
+        newPlainFloatDictionaryValuesWriter(10000, 10000)) {
 
-    for (float i = 0; i < COUNT; i++) {
-      cw.writeFloat(i % 50);
-    }
-    BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    assertEquals(50, cw.initialWriter.getDictionarySize());
+      for (float i = 0; i < COUNT; i++) {
+        cw.writeFloat(i % 50);
+      }
+      BytesInput bytes1 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      assertEquals(50, cw.initialWriter.getDictionarySize());
 
-    for (float i = COUNT2; i > 0; i--) {
-      cw.writeFloat(i % 50);
-    }
-    BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    assertEquals(50, cw.initialWriter.getDictionarySize());
+      for (float i = COUNT2; i > 0; i--) {
+        cw.writeFloat(i % 50);
+      }
+      BytesInput bytes2 = getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      assertEquals(50, cw.initialWriter.getDictionarySize());
 
-    DictionaryValuesReader cr = initDicReader(cw, FLOAT);
+      DictionaryValuesReader cr = initDicReader(cw, FLOAT);
 
-    cr.initFromPage(COUNT, bytes1.toInputStream());
-    for (float i = 0; i < COUNT; i++) {
-      float back = cr.readFloat();
-      assertEquals(i % 50, back, 0.0f);
-    }
+      cr.initFromPage(COUNT, bytes1.toInputStream());
+      for (float i = 0; i < COUNT; i++) {
+        float back = cr.readFloat();
+        assertEquals(i % 50, back, 0.0f);
+      }
 
-    cr.initFromPage(COUNT2, bytes2.toInputStream());
-    for (float i = COUNT2; i > 0; i--) {
-      float back = cr.readFloat();
-      assertEquals(i % 50, back, 0.0f);
+      cr.initFromPage(COUNT2, bytes2.toInputStream());
+      for (float i = COUNT2; i > 0; i--) {
+        float back = cr.readFloat();
+        assertEquals(i % 50, back, 0.0f);
+      }
     }
   }
 
@@ -612,40 +640,42 @@ public class TestDictionary {
   public void testFloatDictionaryFallBack() throws IOException {
     int slabSize = 100;
     int maxDictionaryByteSize = 50;
-    final FallbackValuesWriter<PlainFloatDictionaryValuesWriter, PlainValuesWriter> cw =
-        newPlainFloatDictionaryValuesWriter(maxDictionaryByteSize, slabSize);
+    try (final FallbackValuesWriter<PlainFloatDictionaryValuesWriter, PlainValuesWriter> cw =
+        newPlainFloatDictionaryValuesWriter(maxDictionaryByteSize, slabSize)) {
 
-    // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
-    ValuesReader reader = new PlainValuesReader.FloatPlainValuesReader();
+      // Fallbacked to Plain encoding, therefore use PlainValuesReader to read it back
+      ValuesReader reader = new PlainValuesReader.FloatPlainValuesReader();
 
-    roundTripFloat(cw, reader, maxDictionaryByteSize);
-    // simulate cutting the page
-    cw.reset();
-    assertEquals(0, cw.getBufferedSize());
-    cw.resetDictionary();
+      roundTripFloat(cw, reader, maxDictionaryByteSize);
+      // simulate cutting the page
+      cw.reset();
+      assertEquals(0, cw.getBufferedSize());
+      cw.resetDictionary();
 
-    roundTripFloat(cw, reader, maxDictionaryByteSize);
+      roundTripFloat(cw, reader, maxDictionaryByteSize);
+    }
   }
 
   @Test
   public void testZeroValues() throws IOException {
-    FallbackValuesWriter<PlainIntegerDictionaryValuesWriter, PlainValuesWriter> cw =
-        newPlainIntegerDictionaryValuesWriter(100, 100);
-    cw.writeInteger(34);
-    cw.writeInteger(34);
-    getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
-    DictionaryValuesReader reader = initDicReader(cw, INT32);
+    try (FallbackValuesWriter<PlainIntegerDictionaryValuesWriter, PlainValuesWriter> cw =
+        newPlainIntegerDictionaryValuesWriter(100, 100)) {
+      cw.writeInteger(34);
+      cw.writeInteger(34);
+      getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+      DictionaryValuesReader reader = initDicReader(cw, INT32);
 
-    // pretend there are 100 nulls. what matters is offset = bytes.length.
-    ByteBuffer bytes = ByteBuffer.wrap(new byte[] {0x00, 0x01, 0x02, 0x03}); // data doesn't matter
-    ByteBufferInputStream stream = ByteBufferInputStream.wrap(bytes);
-    stream.skipFully(stream.available());
-    reader.initFromPage(100, stream);
+      // pretend there are 100 nulls. what matters is offset = bytes.length.
+      ByteBuffer bytes = ByteBuffer.wrap(new byte[] {0x00, 0x01, 0x02, 0x03}); // data doesn't matter
+      ByteBufferInputStream stream = ByteBufferInputStream.wrap(bytes);
+      stream.skipFully(stream.available());
+      reader.initFromPage(100, stream);
 
-    // Testing the deprecated behavior of using byte arrays directly
-    reader = initDicReader(cw, INT32);
-    int offset = bytes.remaining();
-    reader.initFromPage(100, bytes, offset);
+      // Testing the deprecated behavior of using byte arrays directly
+      reader = initDicReader(cw, INT32);
+      int offset = bytes.remaining();
+      reader.initFromPage(100, bytes, offset);
+    }
   }
 
   private DictionaryValuesReader initDicReader(ValuesWriter cw, PrimitiveTypeName type) throws IOException {

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
@@ -334,6 +334,7 @@ public class CapacityByteArrayOutputStream extends OutputStream {
     for (ByteBuffer slab : slabs) {
       allocator.release(slab);
     }
+    slabs.clear();
     try {
       super.close();
     } catch (IOException e) {

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/MultiBufferInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/MultiBufferInputStream.java
@@ -31,6 +31,7 @@ import java.util.NoSuchElementException;
 class MultiBufferInputStream extends ByteBufferInputStream {
   private static final ByteBuffer EMPTY = ByteBuffer.allocate(0);
 
+  private final List<ByteBuffer> buffers;
   private final long length;
 
   private Iterator<ByteBuffer> iterator;
@@ -42,15 +43,15 @@ class MultiBufferInputStream extends ByteBufferInputStream {
   private List<ByteBuffer> markBuffers = new ArrayList<>();
 
   MultiBufferInputStream(List<ByteBuffer> buffers) {
-    List<ByteBuffer> buffersCopy = new ArrayList<>(buffers);
+    this.buffers = buffers;
 
     long totalLen = 0;
-    for (ByteBuffer buffer : buffersCopy) {
+    for (ByteBuffer buffer : buffers) {
       totalLen += buffer.remaining();
     }
     this.length = totalLen;
 
-    this.iterator = buffersCopy.iterator();
+    this.iterator = buffers.iterator();
 
     nextBuffer();
   }

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/MultiBufferInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/MultiBufferInputStream.java
@@ -31,7 +31,6 @@ import java.util.NoSuchElementException;
 class MultiBufferInputStream extends ByteBufferInputStream {
   private static final ByteBuffer EMPTY = ByteBuffer.allocate(0);
 
-  private final List<ByteBuffer> buffers;
   private final long length;
 
   private Iterator<ByteBuffer> iterator;
@@ -43,15 +42,15 @@ class MultiBufferInputStream extends ByteBufferInputStream {
   private List<ByteBuffer> markBuffers = new ArrayList<>();
 
   MultiBufferInputStream(List<ByteBuffer> buffers) {
-    this.buffers = buffers;
+    List<ByteBuffer> buffersCopy = new ArrayList<>(buffers);
 
     long totalLen = 0;
-    for (ByteBuffer buffer : buffers) {
+    for (ByteBuffer buffer : buffersCopy) {
       totalLen += buffer.remaining();
     }
     this.length = totalLen;
 
-    this.iterator = buffers.iterator();
+    this.iterator = buffersCopy.iterator();
 
     nextBuffer();
   }

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/TrackingByteBufferAllocator.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/TrackingByteBufferAllocator.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.bytes;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A wrapper {@link ByteBufferAllocator} implementation that tracks whether all allocated buffers are released. It
+ * throws the related exception at {@link #close()} if any buffer remains un-released. It also clears the buffers at
+ * release so if they continued being used it'll generate errors.
+ * <p>To be used for testing purposes.
+ */
+public final class TrackingByteBufferAllocator implements ByteBufferAllocator, AutoCloseable {
+
+  /**
+   * The stacktraces of the allocation are not stored by default because it significantly decreases the unit test
+   * execution performance
+   *
+   * @see ByteBufferAllocationStacktraceException
+   */
+  private static final boolean DEBUG = false;
+
+  public static TrackingByteBufferAllocator wrap(ByteBufferAllocator allocator) {
+    return new TrackingByteBufferAllocator(allocator);
+  }
+
+  private static class Key {
+
+    private final int hashCode;
+    private final ByteBuffer buffer;
+
+    Key(ByteBuffer buffer) {
+      hashCode = System.identityHashCode(buffer);
+      this.buffer = buffer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Key key = (Key) o;
+      return this.buffer == key.buffer;
+    }
+
+    @Override
+    public int hashCode() {
+      return hashCode;
+    }
+  }
+
+  public static class LeakDetectorHeapByteBufferAllocatorException extends RuntimeException {
+
+    private LeakDetectorHeapByteBufferAllocatorException(String msg) {
+      super(msg);
+    }
+
+    private LeakDetectorHeapByteBufferAllocatorException(String msg, Throwable cause) {
+      super(msg, cause);
+    }
+
+    private LeakDetectorHeapByteBufferAllocatorException(
+        String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+      super(message, cause, enableSuppression, writableStackTrace);
+    }
+  }
+
+  public static class ByteBufferAllocationStacktraceException extends LeakDetectorHeapByteBufferAllocatorException {
+
+    private static final ByteBufferAllocationStacktraceException WITHOUT_STACKTRACE =
+        new ByteBufferAllocationStacktraceException(false);
+
+    private static ByteBufferAllocationStacktraceException create() {
+      return DEBUG ? new ByteBufferAllocationStacktraceException() : WITHOUT_STACKTRACE;
+    }
+
+    private ByteBufferAllocationStacktraceException() {
+      super("Allocation stacktrace of the first ByteBuffer:");
+    }
+
+    private ByteBufferAllocationStacktraceException(boolean unused) {
+      super(
+          "Set org.apache.parquet.bytes.TrackingByteBufferAllocator.DEBUG = true for more info",
+          null,
+          false,
+          false);
+    }
+  }
+
+  public static class ReleasingUnallocatedByteBufferException extends LeakDetectorHeapByteBufferAllocatorException {
+
+    private ReleasingUnallocatedByteBufferException() {
+      super("Releasing a ByteBuffer instance that is not allocated by this allocator or already been released");
+    }
+  }
+
+  public static class LeakedByteBufferException extends LeakDetectorHeapByteBufferAllocatorException {
+
+    private LeakedByteBufferException(int count, ByteBufferAllocationStacktraceException e) {
+      super(count + " ByteBuffer object(s) is/are remained unreleased after closing this allocator.", e);
+    }
+  }
+
+  private final Map<Key, ByteBufferAllocationStacktraceException> allocated = new HashMap<>();
+  private final ByteBufferAllocator allocator;
+
+  private TrackingByteBufferAllocator(ByteBufferAllocator allocator) {
+    this.allocator = allocator;
+  }
+
+  @Override
+  public ByteBuffer allocate(int size) {
+    ByteBuffer buffer = allocator.allocate(size);
+    allocated.put(new Key(buffer), ByteBufferAllocationStacktraceException.create());
+    return buffer;
+  }
+
+  @Override
+  public void release(ByteBuffer b) throws ReleasingUnallocatedByteBufferException {
+    if (allocated.remove(new Key(b)) == null) {
+      throw new ReleasingUnallocatedByteBufferException();
+    }
+    allocator.release(b);
+    // Clearing the buffer so subsequent access would probably generate errors
+    b.clear();
+  }
+
+  @Override
+  public boolean isDirect() {
+    return allocator.isDirect();
+  }
+
+  @Override
+  public void close() throws LeakedByteBufferException {
+    if (!allocated.isEmpty()) {
+      LeakedByteBufferException ex = new LeakedByteBufferException(
+          allocated.size(), allocated.values().iterator().next());
+      allocated.clear(); // Drop the references to the ByteBuffers, so they can be gc'd
+      throw ex;
+    }
+  }
+}

--- a/parquet-common/src/main/java/org/apache/parquet/util/AutoCloseables.java
+++ b/parquet-common/src/main/java/org/apache/parquet/util/AutoCloseables.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.util;
+
+import org.apache.parquet.ParquetRuntimeException;
+
+/**
+ * Utility class to handle {@link AutoCloseable} objects.
+ */
+public final class AutoCloseables {
+
+  public static class ParquetCloseResourceException extends ParquetRuntimeException {
+
+    private ParquetCloseResourceException(Exception e) {
+      super("Unable to close resource", e);
+    }
+  }
+
+  /**
+   * Invokes the {@link AutoCloseable#close()} method of each specified objects in a way that guarantees that all the
+   * methods will be invoked even if an exception is occurred before.
+   *
+   * @param autoCloseables the objects to be closed
+   * @throws Exception the compound exception built from the exceptions thrown by the close methods
+   */
+  public static void close(Iterable<AutoCloseable> autoCloseables) throws Exception {
+    Exception root = null;
+    for (AutoCloseable autoCloseable : autoCloseables) {
+      try {
+        autoCloseable.close();
+      } catch (Exception e) {
+        if (root == null) {
+          root = e;
+        } else {
+          root.addSuppressed(e);
+        }
+      }
+    }
+    if (root != null) {
+      throw root;
+    }
+  }
+
+  /**
+   * Works similarly to {@link #close(Iterable)} but it wraps the thrown exception (if any) into a
+   * {@link ParquetCloseResourceException}.
+   */
+  public static void uncheckedClose(Iterable<AutoCloseable> autoCloseables) throws ParquetCloseResourceException {
+    try {
+      close(autoCloseables);
+    } catch (Exception e) {
+      throw new ParquetCloseResourceException(e);
+    }
+  }
+
+  private AutoCloseables() {}
+}

--- a/parquet-encoding/src/test/java/org/apache/parquet/bytes/TestCapacityByteArrayOutputStream.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/bytes/TestCapacityByteArrayOutputStream.java
@@ -25,172 +25,194 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class TestCapacityByteArrayOutputStream {
 
+  private TrackingByteBufferAllocator allocator;
+
+  @Before
+  public void initAllocator() {
+    allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator());
+  }
+
+  @After
+  public void closeAllocator() {
+    allocator.close();
+  }
+
   @Test
   public void testWrite() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10);
-    final int expectedSize = 54;
-    for (int i = 0; i < expectedSize; i++) {
-      capacityByteArrayOutputStream.write(i);
-      assertEquals(i + 1, capacityByteArrayOutputStream.size());
+    try (CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10)) {
+      final int expectedSize = 54;
+      for (int i = 0; i < expectedSize; i++) {
+        capacityByteArrayOutputStream.write(i);
+        assertEquals(i + 1, capacityByteArrayOutputStream.size());
+      }
+      validate(capacityByteArrayOutputStream, expectedSize);
     }
-    validate(capacityByteArrayOutputStream, expectedSize);
   }
 
   @Test
   public void testWriteArray() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10);
-    int v = 23;
-    writeArraysOf3(capacityByteArrayOutputStream, v);
-    validate(capacityByteArrayOutputStream, v * 3);
+    try (CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10)) {
+      int v = 23;
+      writeArraysOf3(capacityByteArrayOutputStream, v);
+      validate(capacityByteArrayOutputStream, v * 3);
+    }
   }
 
   @Test
   public void testWriteArrayExpand() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(2);
-    assertEquals(0, capacityByteArrayOutputStream.getCapacity());
+    try (CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(2)) {
+      assertEquals(0, capacityByteArrayOutputStream.getCapacity());
 
-    byte[] toWrite = {(byte) (1), (byte) (2), (byte) (3), (byte) (4)};
-    int toWriteOffset = 0;
-    int writeLength = 2;
-    // write 2 bytes array
-    capacityByteArrayOutputStream.write(toWrite, toWriteOffset, writeLength);
-    toWriteOffset += writeLength;
-    assertEquals(2, capacityByteArrayOutputStream.size());
-    assertEquals(2, capacityByteArrayOutputStream.getCapacity());
+      byte[] toWrite = {(byte) (1), (byte) (2), (byte) (3), (byte) (4)};
+      int toWriteOffset = 0;
+      int writeLength = 2;
+      // write 2 bytes array
+      capacityByteArrayOutputStream.write(toWrite, toWriteOffset, writeLength);
+      toWriteOffset += writeLength;
+      assertEquals(2, capacityByteArrayOutputStream.size());
+      assertEquals(2, capacityByteArrayOutputStream.getCapacity());
 
-    // write 1 byte array, expand capacity to 4
-    writeLength = 1;
-    capacityByteArrayOutputStream.write(toWrite, toWriteOffset, writeLength);
-    toWriteOffset += writeLength;
-    assertEquals(3, capacityByteArrayOutputStream.size());
-    assertEquals(4, capacityByteArrayOutputStream.getCapacity());
+      // write 1 byte array, expand capacity to 4
+      writeLength = 1;
+      capacityByteArrayOutputStream.write(toWrite, toWriteOffset, writeLength);
+      toWriteOffset += writeLength;
+      assertEquals(3, capacityByteArrayOutputStream.size());
+      assertEquals(4, capacityByteArrayOutputStream.getCapacity());
 
-    // write 1 byte array, not expand
-    capacityByteArrayOutputStream.write(toWrite, toWriteOffset, writeLength);
-    assertEquals(4, capacityByteArrayOutputStream.size());
-    assertEquals(4, capacityByteArrayOutputStream.getCapacity());
-    final byte[] byteArray = BytesInput.from(capacityByteArrayOutputStream).toByteArray();
-    assertArrayEquals(toWrite, byteArray);
+      // write 1 byte array, not expand
+      capacityByteArrayOutputStream.write(toWrite, toWriteOffset, writeLength);
+      assertEquals(4, capacityByteArrayOutputStream.size());
+      assertEquals(4, capacityByteArrayOutputStream.getCapacity());
+      final byte[] byteArray =
+          BytesInput.from(capacityByteArrayOutputStream).toByteArray();
+      assertArrayEquals(toWrite, byteArray);
+    }
   }
 
   @Test
   public void testWriteArrayAndInt() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10);
-    for (int i = 0; i < 23; i++) {
-      byte[] toWrite = {(byte) (i * 3), (byte) (i * 3 + 1)};
-      capacityByteArrayOutputStream.write(toWrite);
-      capacityByteArrayOutputStream.write((byte) (i * 3 + 2));
-      assertEquals((i + 1) * 3, capacityByteArrayOutputStream.size());
+    try (CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10)) {
+      for (int i = 0; i < 23; i++) {
+        byte[] toWrite = {(byte) (i * 3), (byte) (i * 3 + 1)};
+        capacityByteArrayOutputStream.write(toWrite);
+        capacityByteArrayOutputStream.write((byte) (i * 3 + 2));
+        assertEquals((i + 1) * 3, capacityByteArrayOutputStream.size());
+      }
+      validate(capacityByteArrayOutputStream, 23 * 3);
     }
-    validate(capacityByteArrayOutputStream, 23 * 3);
   }
 
   protected CapacityByteArrayOutputStream newCapacityBAOS(int initialSize) {
-    return new CapacityByteArrayOutputStream(initialSize, 1000000, new HeapByteBufferAllocator());
+    return new CapacityByteArrayOutputStream(initialSize, 1000000, allocator);
   }
 
   @Test
   public void testReset() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10);
-    for (int i = 0; i < 54; i++) {
-      capacityByteArrayOutputStream.write(i);
-      assertEquals(i + 1, capacityByteArrayOutputStream.size());
-    }
-    capacityByteArrayOutputStream.reset();
-    for (int i = 0; i < 54; i++) {
-      capacityByteArrayOutputStream.write(54 + i);
-      assertEquals(i + 1, capacityByteArrayOutputStream.size());
-    }
-    final byte[] byteArray = BytesInput.from(capacityByteArrayOutputStream).toByteArray();
-    assertEquals(54, byteArray.length);
-    for (int i = 0; i < 54; i++) {
-      assertEquals(i + " in " + Arrays.toString(byteArray), 54 + i, byteArray[i]);
+    try (CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10)) {
+      for (int i = 0; i < 54; i++) {
+        capacityByteArrayOutputStream.write(i);
+        assertEquals(i + 1, capacityByteArrayOutputStream.size());
+      }
+      capacityByteArrayOutputStream.reset();
+      for (int i = 0; i < 54; i++) {
+        capacityByteArrayOutputStream.write(54 + i);
+        assertEquals(i + 1, capacityByteArrayOutputStream.size());
+      }
+      final byte[] byteArray =
+          BytesInput.from(capacityByteArrayOutputStream).toByteArray();
+      assertEquals(54, byteArray.length);
+      for (int i = 0; i < 54; i++) {
+        assertEquals(i + " in " + Arrays.toString(byteArray), 54 + i, byteArray[i]);
+      }
     }
   }
 
   @Test
   public void testWriteArrayBiggerThanSlab() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10);
-    int v = 23;
-    writeArraysOf3(capacityByteArrayOutputStream, v);
-    int n = v * 3;
-    byte[] toWrite = { // bigger than 2 slabs of size of 10
-      (byte) n,
-      (byte) (n + 1),
-      (byte) (n + 2),
-      (byte) (n + 3),
-      (byte) (n + 4),
-      (byte) (n + 5),
-      (byte) (n + 6),
-      (byte) (n + 7),
-      (byte) (n + 8),
-      (byte) (n + 9),
-      (byte) (n + 10),
-      (byte) (n + 11),
-      (byte) (n + 12),
-      (byte) (n + 13),
-      (byte) (n + 14),
-      (byte) (n + 15),
-      (byte) (n + 16),
-      (byte) (n + 17),
-      (byte) (n + 18),
-      (byte) (n + 19),
-      (byte) (n + 20)
-    };
-    capacityByteArrayOutputStream.write(toWrite);
-    n = n + toWrite.length;
-    assertEquals(n, capacityByteArrayOutputStream.size());
-    validate(capacityByteArrayOutputStream, n);
-    capacityByteArrayOutputStream.reset();
-    // check it works after reset too
-    capacityByteArrayOutputStream.write(toWrite);
-    assertEquals(toWrite.length, capacityByteArrayOutputStream.size());
-    byte[] byteArray = BytesInput.from(capacityByteArrayOutputStream).toByteArray();
-    assertEquals(toWrite.length, byteArray.length);
-    for (int i = 0; i < toWrite.length; i++) {
-      assertEquals(toWrite[i], byteArray[i]);
+    try (CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10)) {
+      int v = 23;
+      writeArraysOf3(capacityByteArrayOutputStream, v);
+      int n = v * 3;
+      byte[] toWrite = { // bigger than 2 slabs of size of 10
+        (byte) n,
+        (byte) (n + 1),
+        (byte) (n + 2),
+        (byte) (n + 3),
+        (byte) (n + 4),
+        (byte) (n + 5),
+        (byte) (n + 6),
+        (byte) (n + 7),
+        (byte) (n + 8),
+        (byte) (n + 9),
+        (byte) (n + 10),
+        (byte) (n + 11),
+        (byte) (n + 12),
+        (byte) (n + 13),
+        (byte) (n + 14),
+        (byte) (n + 15),
+        (byte) (n + 16),
+        (byte) (n + 17),
+        (byte) (n + 18),
+        (byte) (n + 19),
+        (byte) (n + 20)
+      };
+      capacityByteArrayOutputStream.write(toWrite);
+      n = n + toWrite.length;
+      assertEquals(n, capacityByteArrayOutputStream.size());
+      validate(capacityByteArrayOutputStream, n);
+      capacityByteArrayOutputStream.reset();
+      // check it works after reset too
+      capacityByteArrayOutputStream.write(toWrite);
+      assertEquals(toWrite.length, capacityByteArrayOutputStream.size());
+      byte[] byteArray = BytesInput.from(capacityByteArrayOutputStream).toByteArray();
+      assertEquals(toWrite.length, byteArray.length);
+      for (int i = 0; i < toWrite.length; i++) {
+        assertEquals(toWrite[i], byteArray[i]);
+      }
     }
   }
 
   @Test
   public void testWriteArrayManySlabs() throws Throwable {
-    CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10);
-    int it = 500;
-    int v = 23;
-    for (int j = 0; j < it; j++) {
-      for (int i = 0; i < v; i++) {
-        byte[] toWrite = {(byte) (i * 3), (byte) (i * 3 + 1), (byte) (i * 3 + 2)};
-        capacityByteArrayOutputStream.write(toWrite);
-        assertEquals((i + 1) * 3 + v * 3 * j, capacityByteArrayOutputStream.size());
+    try (CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10)) {
+      int it = 500;
+      int v = 23;
+      for (int j = 0; j < it; j++) {
+        for (int i = 0; i < v; i++) {
+          byte[] toWrite = {(byte) (i * 3), (byte) (i * 3 + 1), (byte) (i * 3 + 2)};
+          capacityByteArrayOutputStream.write(toWrite);
+          assertEquals((i + 1) * 3 + v * 3 * j, capacityByteArrayOutputStream.size());
+        }
       }
+      byte[] byteArray = BytesInput.from(capacityByteArrayOutputStream).toByteArray();
+      assertEquals(v * 3 * it, byteArray.length);
+      for (int i = 0; i < v * 3 * it; i++) {
+        assertEquals(i % (v * 3), byteArray[i]);
+      }
+      // verifying we have not created 500 * 23 / 10 slabs
+      assertTrue(
+          "slab count: " + capacityByteArrayOutputStream.getSlabCount(),
+          capacityByteArrayOutputStream.getSlabCount() <= 20);
+      capacityByteArrayOutputStream.reset();
+      writeArraysOf3(capacityByteArrayOutputStream, v);
+      validate(capacityByteArrayOutputStream, v * 3);
+      // verifying we use less slabs now
+      assertTrue(
+          "slab count: " + capacityByteArrayOutputStream.getSlabCount(),
+          capacityByteArrayOutputStream.getSlabCount() <= 2);
     }
-    byte[] byteArray = BytesInput.from(capacityByteArrayOutputStream).toByteArray();
-    assertEquals(v * 3 * it, byteArray.length);
-    for (int i = 0; i < v * 3 * it; i++) {
-      assertEquals(i % (v * 3), byteArray[i]);
-    }
-    // verifying we have not created 500 * 23 / 10 slabs
-    assertTrue(
-        "slab count: " + capacityByteArrayOutputStream.getSlabCount(),
-        capacityByteArrayOutputStream.getSlabCount() <= 20);
-    capacityByteArrayOutputStream.reset();
-    writeArraysOf3(capacityByteArrayOutputStream, v);
-    validate(capacityByteArrayOutputStream, v * 3);
-    // verifying we use less slabs now
-    assertTrue(
-        "slab count: " + capacityByteArrayOutputStream.getSlabCount(),
-        capacityByteArrayOutputStream.getSlabCount() <= 2);
   }
 
   @Test
   public void testReplaceByte() throws Throwable {
     // test replace the first value
-    {
-      CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5);
+    try (CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5)) {
       cbaos.write(10);
       assertEquals(0, cbaos.getCurrentIndex());
       cbaos.setByte(0, (byte) 7);
@@ -200,8 +222,7 @@ public class TestCapacityByteArrayOutputStream {
     }
 
     // test replace value in the first slab
-    {
-      CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5);
+    try (CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5)) {
       cbaos.write(10);
       cbaos.write(13);
       cbaos.write(15);
@@ -215,8 +236,7 @@ public class TestCapacityByteArrayOutputStream {
     }
 
     // test replace in *not* the first slab
-    {
-      CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5);
+    try (CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5)) {
 
       // advance part way through the 3rd slab
       for (int i = 0; i < 12; i++) {
@@ -232,8 +252,7 @@ public class TestCapacityByteArrayOutputStream {
     }
 
     // test replace last value of a slab
-    {
-      CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5);
+    try (CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5)) {
 
       // advance part way through the 3rd slab
       for (int i = 0; i < 12; i++) {
@@ -249,8 +268,7 @@ public class TestCapacityByteArrayOutputStream {
     }
 
     // test replace last value
-    {
-      CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5);
+    try (CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5)) {
 
       // advance part way through the 3rd slab
       for (int i = 0; i < 12; i++) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnIndexValidator.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnIndexValidator.java
@@ -616,6 +616,7 @@ public class ColumnIndexValidator {
             pageValidator.finishPage();
           }
         }
+        rowGroup.close();
         rowGroup = reader.readNextRowGroup();
         rowGroupNumber++;
       }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
@@ -198,6 +198,7 @@ class InternalParquetRecordWriter<T> {
       this.nextRowGroupSize = Math.min(parquetFileWriter.getNextRowGroupSize(), rowGroupSizeThreshold);
     }
 
+    columnStore.close();
     columnStore = null;
     pageStore = null;
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.ParquetProperties.WriterVersion;
 import org.apache.parquet.compression.CompressionCodecFactory;
@@ -873,6 +874,17 @@ public class ParquetWriter<T> implements Closeable {
      */
     public SELF withExtraMetaData(Map<String, String> extraMetaData) {
       encodingPropsBuilder.withExtraMetaData(extraMetaData);
+      return self();
+    }
+
+    /**
+     * Sets the ByteBuffer allocator instance to be used for allocating memory for writing.
+     *
+     * @param allocator the allocator instance
+     * @return this builder for method chaining
+     */
+    public SELF withAllocator(ByteBufferAllocator allocator) {
+      encodingPropsBuilder.withAllocator(allocator);
       return self();
     }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -771,6 +771,7 @@ public class ParquetRewriter implements Closeable {
       cStore.endRecord();
     }
 
+    pageReadStore.close();
     cStore.flush();
     cPageStore.flushToFileWriter(writer);
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/recordlevel/PhoneBookWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/recordlevel/PhoneBookWriter.java
@@ -26,6 +26,9 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.bytes.ByteBufferAllocator;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.bytes.TrackingByteBufferAllocator;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroup;
 import org.apache.parquet.filter2.compat.FilterCompat.Filter;
@@ -320,29 +323,33 @@ public class PhoneBookWriter {
     }
   }
 
-  public static ParquetReader<Group> createReader(Path file, Filter filter) throws IOException {
+  public static ParquetReader<Group> createReader(Path file, Filter filter, ByteBufferAllocator allocator)
+      throws IOException {
     Configuration conf = new Configuration();
     GroupWriteSupport.setSchema(schema, conf);
 
     return ParquetReader.builder(new GroupReadSupport(), file)
         .withConf(conf)
         .withFilter(filter)
+        .withAllocator(allocator)
         .build();
   }
 
   public static List<Group> readFile(File f, Filter filter) throws IOException {
-    ParquetReader<Group> reader = createReader(new Path(f.getAbsolutePath()), filter);
+    try (TrackingByteBufferAllocator allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator());
+        ParquetReader<Group> reader = createReader(new Path(f.getAbsolutePath()), filter, allocator)) {
 
-    Group current;
-    List<Group> users = new ArrayList<Group>();
+      Group current;
+      List<Group> users = new ArrayList<Group>();
 
-    current = reader.read();
-    while (current != null) {
-      users.add(current);
       current = reader.read();
-    }
+      while (current != null) {
+        users.add(current);
+        current = reader.read();
+      }
 
-    return users;
+      return users;
+    }
   }
 
   public static List<User> readUsers(ParquetReader.Builder<Group> builder) throws IOException {
@@ -356,18 +363,18 @@ public class PhoneBookWriter {
    */
   public static List<User> readUsers(ParquetReader.Builder<Group> builder, boolean validateRowIndexes)
       throws IOException {
-    ParquetReader<Group> reader = builder.set(GroupWriteSupport.PARQUET_EXAMPLE_SCHEMA, schema.toString())
-        .build();
-
-    List<User> users = new ArrayList<>();
-    for (Group group = reader.read(); group != null; group = reader.read()) {
-      User u = userFromGroup(group);
-      users.add(u);
-      if (validateRowIndexes) {
-        assertEquals("Row index should be equal to User id", u.id, reader.getCurrentRowIndex());
+    try (ParquetReader<Group> reader = builder.set(GroupWriteSupport.PARQUET_EXAMPLE_SCHEMA, schema.toString())
+        .build()) {
+      List<User> users = new ArrayList<>();
+      for (Group group = reader.read(); group != null; group = reader.read()) {
+        User u = userFromGroup(group);
+        users.add(u);
+        if (validateRowIndexes) {
+          assertEquals("Row index should be equal to User id", u.id, reader.getCurrentRowIndex());
+        }
       }
+      return users;
     }
-    return users;
   }
 
   public static void main(String[] args) throws IOException {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [PARQUET-2431](https://issues.apache.org/jira/browse/PARQUET-2431) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-XXX
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
