### PR TITLE
PARQUET-2432: Use ByteBufferAllocator over hardcoded heap allocation

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/ColumnWriteStore.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ColumnWriteStore.java
@@ -22,7 +22,7 @@ package org.apache.parquet.column;
  * Container which can construct writers for multiple columns to be stored
  * together.
  */
-public interface ColumnWriteStore {
+public interface ColumnWriteStore extends AutoCloseable {
   /**
    * @param path the column for which to create a writer
    * @return the column writer for the given column
@@ -63,6 +63,7 @@ public interface ColumnWriteStore {
   /**
    * Close the related output stream and release any resources
    */
+  @Override
   public abstract void close();
 
   /**

--- a/parquet-column/src/main/java/org/apache/parquet/column/ColumnWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ColumnWriter.java
@@ -23,7 +23,7 @@ import org.apache.parquet.io.api.Binary;
 /**
  * writer for (repetition level, definition level, values) triplets
  */
-public interface ColumnWriter {
+public interface ColumnWriter extends AutoCloseable {
 
   /**
    * writes the current value
@@ -91,6 +91,7 @@ public interface ColumnWriter {
    * Close the underlying store. This should be called when there are no
    * more data to be written.
    */
+  @Override
   void close();
 
   /**

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/DictionaryPageReadStore.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/DictionaryPageReadStore.java
@@ -23,7 +23,7 @@ import org.apache.parquet.column.ColumnDescriptor;
 /**
  * Interface to read dictionary pages for all the columns of a row group
  */
-public interface DictionaryPageReadStore {
+public interface DictionaryPageReadStore extends AutoCloseable {
 
   /**
    * Returns a {@link DictionaryPage} for the given column descriptor.
@@ -33,4 +33,9 @@ public interface DictionaryPageReadStore {
    * @return the DictionaryPage for that column, or null if there isn't one
    */
   DictionaryPage readDictionaryPage(ColumnDescriptor descriptor);
+
+  @Override
+  default void close() {
+    // No-op default implementation for compatibility
+  }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/PageWriteStore.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/PageWriteStore.java
@@ -23,11 +23,16 @@ import org.apache.parquet.column.ColumnDescriptor;
 /**
  * contains all the writers for the columns in the corresponding row group
  */
-public interface PageWriteStore {
+public interface PageWriteStore extends AutoCloseable {
 
   /**
    * @param path the descriptor for the column
    * @return the corresponding page writer
    */
   PageWriter getPageWriter(ColumnDescriptor path);
+
+  @Override
+  default void close() {
+    // No-op default implementation for compatibility
+  }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/PageWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/PageWriter.java
@@ -26,7 +26,7 @@ import org.apache.parquet.column.statistics.Statistics;
 /**
  * a writer for all the pages of a given column chunk
  */
-public interface PageWriter {
+public interface PageWriter extends AutoCloseable {
 
   /**
    * writes a single page
@@ -120,4 +120,9 @@ public interface PageWriter {
    * @return a string presenting a summary of how memory is used
    */
   String memUsageString(String prefix);
+
+  @Override
+  default void close() {
+    // No-op default implementation for compatibility
+  }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilterWriteStore.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilterWriteStore.java
@@ -24,7 +24,7 @@ import org.apache.parquet.column.ColumnDescriptor;
 /**
  * Contains all writers for all columns of a row group
  */
-public interface BloomFilterWriteStore {
+public interface BloomFilterWriteStore extends AutoCloseable {
   /**
    * Get bloom filter writer of a column
    *
@@ -32,4 +32,9 @@ public interface BloomFilterWriteStore {
    * @return the corresponding Bloom filter writer
    */
   BloomFilterWriter getBloomFilterWriter(ColumnDescriptor path);
+
+  @Override
+  default void close() {
+    // No-op default implementation for compatibility
+  }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilterWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bloomfilter/BloomFilterWriter.java
@@ -19,11 +19,16 @@
 
 package org.apache.parquet.column.values.bloomfilter;
 
-public interface BloomFilterWriter {
+public interface BloomFilterWriter extends AutoCloseable {
   /**
    * Write a Bloom filter
    *
    * @param bloomFilter the Bloom filter to write
    */
   void writeBloomFilter(BloomFilter bloomFilter);
+
+  @Override
+  default void close() {
+    // No-op default implementation for compatibility
+  }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/page/mem/MemPageStore.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/page/mem/MemPageStore.java
@@ -70,6 +70,11 @@ public class MemPageStore implements PageReadStore, PageWriteStore {
     return rowCount;
   }
 
+  @Override
+  public void close() {
+    // no-op
+  }
+
   public void addRowCount(long count) {
     rowCount += count;
   }

--- a/parquet-common/pom.xml
+++ b/parquet-common/pom.xml
@@ -61,6 +61,13 @@
       <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/ByteBufferReleaser.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/ByteBufferReleaser.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.bytes;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Convenient class for releasing {@link java.nio.ByteBuffer} objects with the corresponding allocator;
+ */
+public class ByteBufferReleaser implements AutoCloseable {
+
+  final ByteBufferAllocator allocator;
+  private final List<ByteBuffer> toRelease = new ArrayList<>();
+
+  /**
+   * Constructs a new {@link ByteBufferReleaser} instance with the specified {@link ByteBufferAllocator} to be used for
+   * releasing the buffers in {@link #close()}.
+   *
+   * @param allocator the allocator to be used for releasing the buffers
+   * @see #releaseLater(ByteBuffer)
+   * @see #close()
+   */
+  public ByteBufferReleaser(ByteBufferAllocator allocator) {
+    this.allocator = allocator;
+  }
+
+  /**
+   * Adds a {@link ByteBuffer} object to the list of buffers to be released at {@link #close()}. The specified buffer
+   * shall be one that was allocated by the {@link ByteBufferAllocator} of this object.
+   *
+   * @param buffer the buffer to be released
+   */
+  public void releaseLater(ByteBuffer buffer) {
+    toRelease.add(buffer);
+  }
+
+  @Override
+  public void close() {
+    for (ByteBuffer buf : toRelease) {
+      allocator.release(buf);
+    }
+    toRelease.clear();
+  }
+}

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
@@ -250,8 +250,12 @@ public abstract class BytesInput {
 
   /**
    * Copies the content of this {@link BytesInput} object to a newly created {@link ByteBuffer} and returns it wrapped
-   * in a {@link BytesInput} object. <strong>The data content shall be able to be fit in a {@link ByteBuffer}
-   * object!</strong>
+   * in a {@link BytesInput} object.
+   *
+   * <strong>The data content shall be able to be fit in a {@link ByteBuffer} object!</strong> (In case of the size of
+   * this {@link BytesInput} object cannot fit in an {@code int}, an {@link ArithmeticException} will be thrown. The
+   * {@code allocator} might throw an {@link OutOfMemoryError} if it is unable to allocate the required
+   * {@link ByteBuffer}.)
    *
    * @param allocator the allocator to be used for creating the new {@link ByteBuffer} object
    * @param callback  the callback called with the newly created {@link ByteBuffer} object; to be used for make it
@@ -279,7 +283,11 @@ public abstract class BytesInput {
    * {@link ByteBuffer} object if this {@link BytesInput} is not backed by a single {@link ByteBuffer}. In the latter
    * case the specified {@link ByteBufferAllocator} object will be used. In case of allocation the specified callback
    * will be invoked so the release of the newly allocated {@link ByteBuffer} object can be released at a proper time.
-   * <strong>The data content shall be able to be fit in a {@link ByteBuffer} object!</strong>
+   *
+   * <strong>The data content shall be able to be fit in a {@link ByteBuffer} object!</strong> (In case of the size of
+   * this {@link BytesInput} object cannot fit in an {@code int}, an {@link ArithmeticException} will be thrown. The
+   * {@code allocator} might throw an {@link OutOfMemoryError} if it is unable to allocate the required
+   * {@link ByteBuffer}.)
    *
    * @param allocator the {@link ByteBufferAllocator} to be used for potentially allocating a new {@link ByteBuffer}
    *                  object

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/BytesUtils.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/BytesUtils.java
@@ -233,10 +233,10 @@ public class BytesUtils {
 
   public static void writeUnsignedVarInt(int value, ByteBuffer dest) throws IOException {
     while ((value & 0xFFFFFF80) != 0L) {
-      dest.putInt((value & 0x7F) | 0x80);
+      dest.put((byte) ((value & 0x7F) | 0x80));
       value >>>= 7;
     }
-    dest.putInt(value & 0x7F);
+    dest.put((byte) (value & 0x7F));
   }
 
   public static void writeZigZagVarInt(int intValue, OutputStream out) throws IOException {
@@ -274,6 +274,14 @@ public class BytesUtils {
       value >>>= 7;
     }
     out.write((int) (value & 0x7F));
+  }
+
+  public static void writeUnsignedVarLong(long value, ByteBuffer out) {
+    while ((value & 0xFFFFFFFFFFFFFF80L) != 0L) {
+      out.put((byte) ((value & 0x7F) | 0x80));
+      value >>>= 7;
+    }
+    out.put((byte) (value & 0x7F));
   }
 
   public static void writeZigZagVarLong(long longValue, OutputStream out) throws IOException {

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
@@ -252,6 +252,16 @@ public class CapacityByteArrayOutputStream extends OutputStream {
   }
 
   /**
+   * It is expected that the buffer is large enough to fit the content of this.
+   */
+  void writeInto(ByteBuffer buffer) {
+    for (ByteBuffer slab : slabs) {
+      slab.flip();
+      buffer.put(slab);
+    }
+  }
+
+  /**
    * @return The total size in bytes of data written to this stream.
    */
   public long size() {
@@ -327,6 +337,15 @@ public class CapacityByteArrayOutputStream extends OutputStream {
    */
   int getSlabCount() {
     return slabs.size();
+  }
+
+  ByteBuffer getInternalByteBuffer() {
+    if (slabs.size() == 1) {
+      ByteBuffer buf = slabs.get(0).duplicate();
+      buf.flip();
+      return buf.slice();
+    }
+    return null;
   }
 
   @Override

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/ConcatenatingByteArrayCollector.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/ConcatenatingByteArrayCollector.java
@@ -22,10 +22,18 @@ import static java.lang.String.format;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Used for collecting the content of {@link BytesInput} objects.
+ *
+ * @deprecated Use {@link ConcatenatingByteBufferCollector} instead.
+ */
+@Deprecated
 public class ConcatenatingByteArrayCollector extends BytesInput {
+
   private final List<byte[]> slabs = new ArrayList<byte[]>();
   private long size = 0;
 
@@ -44,6 +52,13 @@ public class ConcatenatingByteArrayCollector extends BytesInput {
   public void writeAllTo(OutputStream out) throws IOException {
     for (byte[] slab : slabs) {
       out.write(slab);
+    }
+  }
+
+  @Override
+  public void writeInto(ByteBuffer buffer) {
+    for (byte[] slab : slabs) {
+      buffer.put(slab);
     }
   }
 

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/ConcatenatingByteBufferCollector.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/ConcatenatingByteBufferCollector.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.bytes;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Alternative to {@link ConcatenatingByteArrayCollector} but using {@link java.nio.ByteBuffer}s allocated by its
+ * {@link ByteBufferAllocator}.
+ */
+public class ConcatenatingByteBufferCollector extends BytesInput implements AutoCloseable {
+
+  private final ByteBufferAllocator allocator;
+  private final List<ByteBuffer> slabs = new ArrayList<>();
+  private long size = 0;
+
+  /**
+   * Constructs a new {@link ConcatenatingByteBufferCollector} instance with the specified allocator.
+   *
+   * @param allocator to be used for allocating the required {@link ByteBuffer} instances
+   */
+  public ConcatenatingByteBufferCollector(ByteBufferAllocator allocator) {
+    this.allocator = allocator;
+  }
+
+  /**
+   * Collects the content of the specified input. It allocates a new {@link ByteBuffer} instance that can contain all
+   * the content.
+   *
+   * @param bytesInput the input which content is to be collected
+   */
+  public void collect(BytesInput bytesInput) {
+    int inputSize = Math.toIntExact(bytesInput.size());
+    ByteBuffer slab = allocator.allocate(inputSize);
+    bytesInput.writeInto(slab);
+    slab.flip();
+    slabs.add(slab);
+    size += inputSize;
+  }
+
+  @Override
+  public void close() {
+    for (ByteBuffer slab : slabs) {
+      allocator.release(slab);
+    }
+    slabs.clear();
+  }
+
+  @Override
+  public void writeAllTo(OutputStream out) throws IOException {
+    WritableByteChannel channel = Channels.newChannel(out);
+    for (ByteBuffer buffer : slabs) {
+      channel.write(buffer.duplicate());
+    }
+  }
+
+  @Override
+  public void writeInto(ByteBuffer buffer) {
+    for (ByteBuffer slab : slabs) {
+      buffer.put(slab.duplicate());
+    }
+  }
+
+  @Override
+  ByteBuffer getInternalByteBuffer() {
+    return slabs.size() == 1 ? slabs.get(0).duplicate() : null;
+  }
+
+  @Override
+  public long size() {
+    return size;
+  }
+
+  /**
+   * @param prefix a prefix to be used for every new line in the string
+   * @return a text representation of the memory usage of this structure
+   */
+  public String memUsageString(String prefix) {
+    return format("%s %s %d slabs, %,d bytes", prefix, getClass().getSimpleName(), slabs.size(), size);
+  }
+}

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/ReusingByteBufferAllocator.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/ReusingByteBufferAllocator.java
@@ -1,0 +1,107 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.parquet.bytes;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A special {@link ByteBufferAllocator} implementation that keeps one {@link ByteBuffer} object and reuse it at the
+ * next {@link #allocate(int)} call. The {@link #close()} shall be called when this allocator is not needed anymore to
+ * really release the one buffer.
+ */
+public class ReusingByteBufferAllocator implements ByteBufferAllocator, AutoCloseable {
+
+  private final ByteBufferAllocator allocator;
+  private final ByteBufferReleaser releaser = new ByteBufferReleaser(this);
+  private ByteBuffer buffer;
+  private ByteBuffer bufferOut;
+
+  /**
+   * Constructs a new {@link ReusingByteBufferAllocator} object with the specified "parent" allocator to be used for
+   * allocating/releasing the one buffer.
+   *
+   * @param allocator the allocator to be used for allocating/releasing the one buffer
+   */
+  public ReusingByteBufferAllocator(ByteBufferAllocator allocator) {
+    this.allocator = allocator;
+  }
+
+  /**
+   * A convenience method to get a {@link ByteBufferReleaser} instance already created for this allocator.
+   *
+   * @return a releaser for this allocator
+   */
+  public ByteBufferReleaser getReleaser() {
+    return releaser;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalStateException if the one buffer was not released yet
+   */
+  @Override
+  public ByteBuffer allocate(int size) {
+    if (bufferOut != null) {
+      throw new IllegalStateException("The single buffer is not yet released");
+    }
+    if (buffer == null) {
+      bufferOut = buffer = allocator.allocate(size);
+    } else if (buffer.capacity() < size) {
+      allocator.release(buffer);
+      bufferOut = buffer = allocator.allocate(size);
+    } else {
+      buffer.clear();
+      buffer.limit(size);
+      bufferOut = buffer.slice();
+    }
+    return bufferOut;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalStateException    if the one has already been released or never allocated
+   * @throws IllegalArgumentException if the specified buffer is not the one allocated by this allocator
+   */
+  @Override
+  public void release(ByteBuffer b) {
+    if (bufferOut == null) {
+      throw new IllegalStateException("The single buffer has already been released or never allocated");
+    }
+    if (b != bufferOut) {
+      throw new IllegalArgumentException("The buffer to be released is not the one allocated by this allocator");
+    }
+    bufferOut = null;
+  }
+
+  @Override
+  public boolean isDirect() {
+    return allocator.isDirect();
+  }
+
+  @Override
+  public void close() {
+    if (buffer != null) {
+      allocator.release(buffer);
+      buffer = null;
+      bufferOut = null;
+    }
+  }
+}

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/ReusingByteBufferAllocator.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/ReusingByteBufferAllocator.java
@@ -21,7 +21,7 @@ package org.apache.parquet.bytes;
 import java.nio.ByteBuffer;
 
 /**
- * A special {@link ByteBufferAllocator} implementation that keeps one {@link ByteBuffer} object and reuse it at the
+ * A special {@link ByteBufferAllocator} implementation that keeps one {@link ByteBuffer} object and reuses it at the
  * next {@link #allocate(int)} call. The {@link #close()} shall be called when this allocator is not needed anymore to
  * really release the one buffer.
  */

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/TrackingByteBufferAllocator.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/TrackingByteBufferAllocator.java
@@ -21,6 +21,7 @@ package org.apache.parquet.bytes;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A wrapper {@link ByteBufferAllocator} implementation that tracks whether all allocated buffers are released. It
@@ -138,6 +139,7 @@ public final class TrackingByteBufferAllocator implements ByteBufferAllocator, A
 
   @Override
   public void release(ByteBuffer b) throws ReleasingUnallocatedByteBufferException {
+    Objects.requireNonNull(b);
     if (allocated.remove(new Key(b)) == null) {
       throw new ReleasingUnallocatedByteBufferException();
     }

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestBytesInput.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestBytesInput.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.bytes;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.apache.parquet.util.AutoCloseables;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for the {@link BytesInput} class and its descendants.
+ */
+@RunWith(Parameterized.class)
+public class TestBytesInput {
+
+  private static final Random RANDOM = new Random(2024_02_20_16_28L);
+  private TrackingByteBufferAllocator allocator;
+  private final ByteBufferAllocator innerAllocator;
+
+  @Parameters(name = "{0}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        new HeapByteBufferAllocator() {
+          @Override
+          public String toString() {
+            return "heap-allocator";
+          }
+        }
+      },
+      {
+        new DirectByteBufferAllocator() {
+          @Override
+          public String toString() {
+            return "direct-allocator";
+          }
+        }
+      }
+    };
+  }
+
+  public TestBytesInput(ByteBufferAllocator innerAllocator) {
+    this.innerAllocator = innerAllocator;
+  }
+
+  @Before
+  public void initAllocator() {
+    allocator = TrackingByteBufferAllocator.wrap(innerAllocator);
+  }
+
+  @After
+  public void closeAllocator() {
+    allocator.close();
+  }
+
+  @Test
+  public void testFromSingleByteBuffer() throws IOException {
+    byte[] data = new byte[1000];
+    RANDOM.nextBytes(data);
+    Supplier<BytesInput> factory = () -> BytesInput.from(toByteBuffer(data));
+
+    validate(data, factory);
+
+    validateToByteBufferIsInternal(factory);
+  }
+
+  @Test
+  public void testFromMultipleByteBuffers() throws IOException {
+    byte[] data = new byte[1000];
+    RANDOM.nextBytes(data);
+    Supplier<BytesInput> factory = () -> BytesInput.from(
+        toByteBuffer(data, 0, 250),
+        toByteBuffer(data, 250, 250),
+        toByteBuffer(data, 500, 250),
+        toByteBuffer(data, 750, 250));
+
+    validate(data, factory);
+  }
+
+  @Test
+  public void testFromByteArray() throws IOException {
+    byte[] data = new byte[1000];
+    RANDOM.nextBytes(data);
+    byte[] input = new byte[data.length + 20];
+    RANDOM.nextBytes(input);
+    System.arraycopy(data, 0, input, 10, data.length);
+    Supplier<BytesInput> factory = () -> BytesInput.from(input, 10, data.length);
+
+    validate(data, factory);
+  }
+
+  @Test
+  public void testFromInputStream() throws IOException {
+    byte[] data = new byte[1000];
+    RANDOM.nextBytes(data);
+    byte[] input = new byte[data.length + 10];
+    RANDOM.nextBytes(input);
+    System.arraycopy(data, 0, input, 0, data.length);
+    Supplier<BytesInput> factory = () -> BytesInput.from(new ByteArrayInputStream(input), 1000);
+
+    validate(data, factory);
+  }
+
+  @Test
+  public void testFromByteArrayOutputStream() throws IOException {
+    byte[] data = new byte[1000];
+    RANDOM.nextBytes(data);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    baos.write(data);
+    Supplier<BytesInput> factory = () -> BytesInput.from(baos);
+
+    validate(data, factory);
+  }
+
+  @Test
+  public void testFromCapacityByteArrayOutputStreamOneSlab() throws IOException {
+    byte[] data = new byte[1000];
+    RANDOM.nextBytes(data);
+    List<CapacityByteArrayOutputStream> toClose = new ArrayList<>();
+    Supplier<BytesInput> factory = () -> {
+      CapacityByteArrayOutputStream cbaos = new CapacityByteArrayOutputStream(10, 1000, allocator);
+      toClose.add(cbaos);
+      try {
+        cbaos.write(data);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      return BytesInput.from(cbaos);
+    };
+
+    try {
+      validate(data, factory);
+
+      validateToByteBufferIsInternal(factory);
+    } finally {
+      AutoCloseables.uncheckedClose(toClose);
+    }
+  }
+
+  @Test
+  public void testFromCapacityByteArrayOutputStreamMultipleSlabs() throws IOException {
+    byte[] data = new byte[1000];
+    RANDOM.nextBytes(data);
+    List<CapacityByteArrayOutputStream> toClose = new ArrayList<>();
+    Supplier<BytesInput> factory = () -> {
+      CapacityByteArrayOutputStream cbaos = new CapacityByteArrayOutputStream(10, 1000, allocator);
+      toClose.add(cbaos);
+      for (byte b : data) {
+        cbaos.write(b);
+      }
+      return BytesInput.from(cbaos);
+    };
+
+    try {
+      validate(data, factory);
+    } finally {
+      AutoCloseables.uncheckedClose(toClose);
+    }
+  }
+
+  @Test
+  public void testFromInt() throws IOException {
+    int value = RANDOM.nextInt();
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(4);
+    BytesUtils.writeIntLittleEndian(baos, value);
+    byte[] data = baos.toByteArray();
+    Supplier<BytesInput> factory = () -> BytesInput.fromInt(value);
+
+    validate(data, factory);
+  }
+
+  @Test
+  public void testFromUnsignedVarInt() throws IOException {
+    int value = RANDOM.nextInt(Short.MAX_VALUE);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(2);
+    BytesUtils.writeUnsignedVarInt(value, baos);
+    byte[] data = baos.toByteArray();
+    Supplier<BytesInput> factory = () -> BytesInput.fromUnsignedVarInt(value);
+
+    validate(data, factory);
+  }
+
+  @Test
+  public void testFromUnsignedVarLong() throws IOException {
+    long value = RANDOM.nextInt(Integer.MAX_VALUE);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(4);
+    BytesUtils.writeUnsignedVarLong(value, baos);
+    byte[] data = baos.toByteArray();
+    Supplier<BytesInput> factory = () -> BytesInput.fromUnsignedVarLong(value);
+
+    validate(data, factory);
+  }
+
+  @Test
+  public void testFromZigZagVarInt() throws IOException {
+    int value = RANDOM.nextInt() % Short.MAX_VALUE;
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    BytesUtils.writeZigZagVarInt(value, baos);
+    byte[] data = baos.toByteArray();
+    Supplier<BytesInput> factory = () -> BytesInput.fromZigZagVarInt(value);
+
+    validate(data, factory);
+  }
+
+  @Test
+  public void testFromZigZagVarLong() throws IOException {
+    long value = RANDOM.nextInt();
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    BytesUtils.writeZigZagVarLong(value, baos);
+    byte[] data = baos.toByteArray();
+    Supplier<BytesInput> factory = () -> BytesInput.fromZigZagVarLong(value);
+
+    validate(data, factory);
+  }
+
+  @Test
+  public void testEmpty() throws IOException {
+    byte[] data = new byte[0];
+    Supplier<BytesInput> factory = () -> BytesInput.empty();
+
+    validate(data, factory);
+  }
+
+  @Test
+  public void testConcatenatingByteBufferCollectorOneSlab() throws IOException {
+    byte[] data = new byte[1000];
+    RANDOM.nextBytes(data);
+    List<ConcatenatingByteBufferCollector> toClose = new ArrayList<>();
+
+    Supplier<BytesInput> factory = () -> {
+      ConcatenatingByteBufferCollector collector = new ConcatenatingByteBufferCollector(allocator);
+      toClose.add(collector);
+      collector.collect(BytesInput.from(toByteBuffer(data)));
+      return collector;
+    };
+
+    try {
+      validate(data, factory);
+
+      validateToByteBufferIsInternal(factory);
+    } finally {
+      AutoCloseables.uncheckedClose(toClose);
+    }
+  }
+
+  @Test
+  public void testConcatenatingByteBufferCollectorMultipleSlabs() throws IOException {
+    byte[] data = new byte[1000];
+    RANDOM.nextBytes(data);
+    List<ConcatenatingByteBufferCollector> toClose = new ArrayList<>();
+
+    Supplier<BytesInput> factory = () -> {
+      ConcatenatingByteBufferCollector collector = new ConcatenatingByteBufferCollector(allocator);
+      toClose.add(collector);
+      collector.collect(BytesInput.from(toByteBuffer(data, 0, 250)));
+      collector.collect(BytesInput.from(toByteBuffer(data, 250, 250)));
+      collector.collect(BytesInput.from(toByteBuffer(data, 500, 250)));
+      collector.collect(BytesInput.from(toByteBuffer(data, 750, 250)));
+      return collector;
+    };
+
+    try {
+      validate(data, factory);
+    } finally {
+      AutoCloseables.uncheckedClose(toClose);
+    }
+  }
+
+  @Test
+  public void testConcat() throws IOException {
+    byte[] data = new byte[1000];
+    RANDOM.nextBytes(data);
+
+    Supplier<BytesInput> factory = () -> BytesInput.concat(
+        BytesInput.from(toByteBuffer(data, 0, 250)),
+        BytesInput.empty(),
+        BytesInput.from(toByteBuffer(data, 250, 250)),
+        BytesInput.from(data, 500, 250),
+        BytesInput.from(new ByteArrayInputStream(data, 750, 250), 250));
+
+    validate(data, factory);
+  }
+
+  private ByteBuffer toByteBuffer(byte[] data) {
+    return toByteBuffer(data, 0, data.length);
+  }
+
+  private ByteBuffer toByteBuffer(byte[] data, int offset, int length) {
+    ByteBuffer buf = innerAllocator.allocate(length);
+    buf.put(data, offset, length);
+    buf.flip();
+    return buf;
+  }
+
+  private void validate(byte[] data, Supplier<BytesInput> factory) throws IOException {
+    assertEquals(data.length, factory.get().size());
+    validateToByteBuffer(data, factory);
+    validateCopy(data, factory);
+    validateToInputStream(data, factory);
+    validateWriteAllTo(data, factory);
+  }
+
+  private void validateToByteBuffer(byte[] data, Supplier<BytesInput> factory) {
+    BytesInput bi = factory.get();
+    try (ByteBufferReleaser releaser = new ByteBufferReleaser(allocator)) {
+      ByteBuffer buf = bi.toByteBuffer(releaser);
+      int index = 0;
+      while (buf.hasRemaining()) {
+        if (buf.get() != data[index++]) {
+          fail("Data mismatch at position " + index);
+        }
+      }
+    }
+  }
+
+  private void validateCopy(byte[] data, Supplier<BytesInput> factory) throws IOException {
+    BytesInput bi = factory.get();
+    try (ByteBufferReleaser releaser = new ByteBufferReleaser(allocator);
+        InputStream is = bi.copy(releaser).toInputStream()) {
+      assertContentEquals(data, is);
+    }
+  }
+
+  private void validateToInputStream(byte[] data, Supplier<BytesInput> factory) throws IOException {
+    BytesInput bi = factory.get();
+    try (InputStream is = bi.toInputStream()) {
+      assertContentEquals(data, is);
+    }
+  }
+
+  private void assertContentEquals(byte[] expected, InputStream is) throws IOException {
+    byte[] actual = new byte[expected.length];
+    is.read(actual);
+    assertArrayEquals(expected, actual);
+  }
+
+  private void validateWriteAllTo(byte[] data, Supplier<BytesInput> factory) throws IOException {
+    BytesInput bi = factory.get();
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      bi.writeAllTo(baos);
+      assertArrayEquals(data, baos.toByteArray());
+    }
+  }
+
+  private void validateToByteBufferIsInternal(Supplier<BytesInput> factory) {
+    ByteBufferAllocator allocatorMock = Mockito.mock(ByteBufferAllocator.class);
+    when(allocatorMock.isDirect()).thenReturn(innerAllocator.isDirect());
+    Consumer<ByteBuffer> callbackMock = Mockito.mock(Consumer.class);
+    factory.get().toByteBuffer(allocatorMock, callbackMock);
+    verify(allocatorMock, never()).allocate(anyInt());
+    verify(callbackMock, never()).accept(anyObject());
+  }
+}

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestConcatenatingByteBufferCollector.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestConcatenatingByteBufferCollector.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.bytes;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test class of {@link ConcatenatingByteBufferCollector}.
+ */
+public class TestConcatenatingByteBufferCollector {
+
+  private TrackingByteBufferAllocator allocator;
+
+  @Before
+  public void initAllocator() {
+    allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator());
+  }
+
+  @After
+  public void closeAllocator() {
+    allocator.close();
+  }
+
+  @Test
+  public void test() throws IOException {
+    byte[] result;
+    try (ConcatenatingByteBufferCollector outer = new ConcatenatingByteBufferCollector(allocator);
+        ConcatenatingByteBufferCollector inner = new ConcatenatingByteBufferCollector(allocator)) {
+      outer.collect(BytesInput.concat(
+          BytesInput.from(byteBuffer("This"), byteBuffer(" "), byteBuffer("is")),
+          BytesInput.from(Arrays.asList(byteBuffer(" a"), byteBuffer(" "), byteBuffer("test"))),
+          BytesInput.from(inputStream(" text to blabla"), 8),
+          BytesInput.from(bytes(" ")),
+          BytesInput.from(bytes("blabla validate blabla"), 7, 9),
+          BytesInput.from(byteArrayOutputStream("the class ")),
+          BytesInput.from(capacityByteArrayOutputStream("ConcatenatingByteBufferCollector"))));
+      inner.collect(BytesInput.fromInt(12345));
+      inner.collect(BytesInput.fromUnsignedVarInt(67891));
+      inner.collect(BytesInput.fromUnsignedVarLong(2345678901L));
+      inner.collect(BytesInput.fromZigZagVarInt(-234567));
+      inner.collect(BytesInput.fromZigZagVarLong(-890123456789L));
+      outer.collect(inner);
+
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      outer.writeAllTo(baos);
+      result = baos.toByteArray();
+    }
+
+    Assert.assertEquals(
+        "This is a test text to validate the class ConcatenatingByteBufferCollector",
+        new String(result, 0, 74));
+    InputStream in = new ByteArrayInputStream(result, 74, result.length - 74);
+    Assert.assertEquals(12345, BytesUtils.readIntLittleEndian(in));
+    Assert.assertEquals(67891, BytesUtils.readUnsignedVarInt(in));
+    Assert.assertEquals(2345678901L, BytesUtils.readUnsignedVarLong(in));
+    Assert.assertEquals(-234567, BytesUtils.readZigZagVarInt(in));
+    Assert.assertEquals(-890123456789L, BytesUtils.readZigZagVarLong(in));
+  }
+
+  private static byte[] bytes(String str) {
+    return str.getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static ByteBuffer byteBuffer(String str) {
+    return ByteBuffer.wrap(bytes(str));
+  }
+
+  private static InputStream inputStream(String str) {
+    return new ByteArrayInputStream(bytes(str));
+  }
+
+  private static ByteArrayOutputStream byteArrayOutputStream(String str) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    baos.write(bytes(str));
+    return baos;
+  }
+
+  private static CapacityByteArrayOutputStream capacityByteArrayOutputStream(String str) {
+    CapacityByteArrayOutputStream cbaos =
+        new CapacityByteArrayOutputStream(2, Integer.MAX_VALUE, new HeapByteBufferAllocator());
+    for (byte b : bytes(str)) {
+      cbaos.write(b);
+    }
+    return cbaos;
+  }
+}

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestReusingByteBufferAllocator.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestReusingByteBufferAllocator.java
@@ -1,0 +1,124 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.parquet.bytes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.nio.ByteBuffer;
+import java.nio.InvalidMarkException;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TestReusingByteBufferAllocator {
+
+  private static final Random RANDOM = new Random(2024_02_22_09_51L);
+
+  private TrackingByteBufferAllocator allocator;
+
+  @Parameter
+  public ByteBufferAllocator innerAllocator;
+
+  @Parameters(name = "{0}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {
+        new HeapByteBufferAllocator() {
+          @Override
+          public String toString() {
+            return "HEAP";
+          }
+        }
+      },
+      {
+        new DirectByteBufferAllocator() {
+          @Override
+          public String toString() {
+            return "DIRECT";
+          }
+        }
+      }
+    };
+  }
+
+  @Before
+  public void initAllocator() {
+    allocator = TrackingByteBufferAllocator.wrap(innerAllocator);
+  }
+
+  @After
+  public void closeAllocator() {
+    allocator.close();
+  }
+
+  @Test
+  public void normalUseCase() {
+    try (ReusingByteBufferAllocator reusingAllocator = new ReusingByteBufferAllocator(allocator)) {
+      assertEquals(innerAllocator.isDirect(), reusingAllocator.isDirect());
+      for (int i = 0; i < 10; ++i) {
+        try (ByteBufferReleaser releaser = reusingAllocator.getReleaser()) {
+          int size = RANDOM.nextInt(1024);
+          ByteBuffer buf = reusingAllocator.allocate(size);
+          releaser.releaseLater(buf);
+
+          assertEquals(0, buf.position());
+          assertEquals(size, buf.capacity());
+          assertEquals(size, buf.remaining());
+          assertEquals(allocator.isDirect(), buf.isDirect());
+          assertThrows(InvalidMarkException.class, buf::reset);
+
+          // Let's see if the next allocate would clear the buffer
+          buf.position(buf.capacity() / 2);
+          buf.mark();
+          buf.position(buf.limit());
+        }
+      }
+
+      // Check if actually releasing the buffer is independent of the release call in the reusing allocator
+      reusingAllocator.allocate(1025);
+    }
+  }
+
+  @Test
+  public void validateExceptions() {
+    try (ByteBufferReleaser releaser = new ByteBufferReleaser(allocator);
+        ReusingByteBufferAllocator reusingAllocator = new ReusingByteBufferAllocator(allocator)) {
+      ByteBuffer fromOther = allocator.allocate(10);
+      releaser.releaseLater(fromOther);
+
+      assertThrows(IllegalStateException.class, () -> reusingAllocator.release(fromOther));
+
+      ByteBuffer fromReusing = reusingAllocator.allocate(10);
+
+      assertThrows(IllegalArgumentException.class, () -> reusingAllocator.release(fromOther));
+      assertThrows(IllegalStateException.class, () -> reusingAllocator.allocate(10));
+
+      reusingAllocator.release(fromReusing);
+      assertThrows(IllegalStateException.class, () -> reusingAllocator.release(fromOther));
+      assertThrows(IllegalStateException.class, () -> reusingAllocator.release(fromReusing));
+    }
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/compat/RowGroupFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/compat/RowGroupFilter.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import org.apache.parquet.column.page.DictionaryPageReadStore;
 import org.apache.parquet.filter2.bloomfilterlevel.BloomFilterImpl;
 import org.apache.parquet.filter2.compat.FilterCompat.Filter;
 import org.apache.parquet.filter2.compat.FilterCompat.NoOpFilter;
@@ -102,7 +103,9 @@ public class RowGroupFilter implements Visitor<List<BlockMetaData>> {
       }
 
       if (!drop && levels.contains(FilterLevel.DICTIONARY)) {
-        drop = DictionaryFilter.canDrop(filterPredicate, block.getColumns(), reader.getDictionaryReader(block));
+        try (DictionaryPageReadStore dictionaryPageReadStore = reader.getDictionaryReader(block)) {
+          drop = DictionaryFilter.canDrop(filterPredicate, block.getColumns(), dictionaryPageReadStore);
+        }
       }
 
       if (!drop && levels.contains(FilterLevel.BLOOMFILTER)) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -1515,7 +1515,7 @@ public class ParquetMetadataConverter {
 
     // Mark the beginning of the footer for verifyFooterIntegrity
     final InputStream from;
-    if (fileDecryptor.checkFooterIntegrity()) {
+    if (fileDecryptor != null && fileDecryptor.checkFooterIntegrity()) {
       // fromInputStream should already support marking but let's be on the safe side
       if (!fromInputStream.markSupported()) {
         from = new BufferedInputStream(fromInputStream, combinedFooterLength);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
@@ -37,6 +37,7 @@ import org.apache.parquet.io.ColumnIOFactory;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.util.AutoCloseables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -197,10 +198,10 @@ class InternalParquetRecordWriter<T> {
       parquetFileWriter.endBlock();
       this.nextRowGroupSize = Math.min(parquetFileWriter.getNextRowGroupSize(), rowGroupSizeThreshold);
     }
-
-    columnStore.close();
+    AutoCloseables.uncheckedClose(columnStore, pageStore, bloomFilterWriteStore);
     columnStore = null;
     pageStore = null;
+    bloomFilterWriteStore = null;
   }
 
   long getRowGroupSizeThreshold() {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -359,6 +359,7 @@ public class ParquetFileWriter implements AutoCloseable {
         statisticsTruncateLength,
         pageWriteChecksumEnabled,
         null,
+        null,
         null);
   }
 
@@ -383,6 +384,7 @@ public class ParquetFileWriter implements AutoCloseable {
         statisticsTruncateLength,
         pageWriteChecksumEnabled,
         encryptionProperties,
+        null,
         null);
   }
 
@@ -392,11 +394,8 @@ public class ParquetFileWriter implements AutoCloseable {
       Mode mode,
       long rowGroupSize,
       int maxPaddingSize,
-      int columnIndexTruncateLength,
-      int statisticsTruncateLength,
-      boolean pageWriteChecksumEnabled,
       FileEncryptionProperties encryptionProperties,
-      ByteBufferAllocator allocator)
+      ParquetProperties props)
       throws IOException {
     this(
         file,
@@ -404,12 +403,12 @@ public class ParquetFileWriter implements AutoCloseable {
         mode,
         rowGroupSize,
         maxPaddingSize,
-        columnIndexTruncateLength,
-        statisticsTruncateLength,
-        pageWriteChecksumEnabled,
+        props.getColumnIndexTruncateLength(),
+        props.getStatisticsTruncateLength(),
+        props.getPageWriteChecksumEnabled(),
         encryptionProperties,
         null,
-        allocator);
+        props.getAllocator());
   }
 
   @Deprecated

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -505,11 +505,8 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
         mode,
         blockSize,
         maxPaddingSize,
-        props.getColumnIndexTruncateLength(),
-        props.getStatisticsTruncateLength(),
-        props.getPageWriteChecksumEnabled(),
         encryptionProperties,
-        props.getAllocator());
+        props);
     w.start();
 
     float maxLoad = conf.getFloat(ParquetOutputFormat.MEMORY_POOL_RATIO, MemoryManager.DEFAULT_MEMORY_POOL_RATIO);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -508,7 +508,8 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
         props.getColumnIndexTruncateLength(),
         props.getStatisticsTruncateLength(),
         props.getPageWriteChecksumEnabled(),
-        encryptionProperties);
+        encryptionProperties,
+        props.getAllocator());
     w.start();
 
     float maxLoad = conf.getFloat(ParquetOutputFormat.MEMORY_POOL_RATIO, MemoryManager.DEFAULT_MEMORY_POOL_RATIO);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -393,13 +393,7 @@ public class ParquetWriter<T> implements Closeable {
     }
 
     ParquetFileWriter fileWriter = new ParquetFileWriter(
-        file,
-        schema,
-        mode,
-        rowGroupSize,
-        maxPaddingSize,
-        encryptionProperties,
-        encodingProps);
+        file, schema, mode, rowGroupSize, maxPaddingSize, encryptionProperties, encodingProps);
     fileWriter.start();
 
     this.codecFactory = codecFactory;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -398,11 +398,8 @@ public class ParquetWriter<T> implements Closeable {
         mode,
         rowGroupSize,
         maxPaddingSize,
-        encodingProps.getColumnIndexTruncateLength(),
-        encodingProps.getStatisticsTruncateLength(),
-        encodingProps.getPageWriteChecksumEnabled(),
         encryptionProperties,
-        encodingProps.getAllocator());
+        encodingProps);
     fileWriter.start();
 
     this.codecFactory = codecFactory;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -401,7 +401,8 @@ public class ParquetWriter<T> implements Closeable {
         encodingProps.getColumnIndexTruncateLength(),
         encodingProps.getStatisticsTruncateLength(),
         encodingProps.getPageWriteChecksumEnabled(),
-        encryptionProperties);
+        encryptionProperties,
+        encodingProps.getAllocator());
     fileWriter.start();
 
     this.codecFactory = codecFactory;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
@@ -189,11 +189,8 @@ public class TestColumnChunkPageWriteStore {
           Mode.CREATE,
           ParquetWriter.DEFAULT_BLOCK_SIZE,
           ParquetWriter.MAX_PADDING_SIZE_DEFAULT,
-          ParquetProperties.DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH,
-          ParquetProperties.DEFAULT_STATISTICS_TRUNCATE_LENGTH,
-          ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED,
           null,
-          allocator);
+          ParquetProperties.builder().withAllocator(allocator).build());
       writer.start();
       writer.startBlock(rowCount);
       pageOffset = outputFile.out().getPos();

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDataPageChecksums.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDataPageChecksums.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.bytes.TrackingByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.ParquetProperties;
@@ -67,6 +68,8 @@ import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
 import org.apache.parquet.schema.Types;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -78,6 +81,18 @@ import org.junit.rules.TemporaryFolder;
 public class TestDataPageChecksums {
   @Rule
   public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private TrackingByteBufferAllocator allocator;
+
+  @Before
+  public void initAllocator() {
+    allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator());
+  }
+
+  @After
+  public void closeAllocator() {
+    allocator.close();
+  }
 
   private static final Statistics<?> EMPTY_STATS_INT32 =
       Statistics.getBuilderForReading(Types.required(INT32).named("a")).build();
@@ -116,7 +131,12 @@ public class TestDataPageChecksums {
     }
 
     ParquetFileWriter writer = new ParquetFileWriter(
-        conf, schemaSimple, path, ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.MAX_PADDING_SIZE_DEFAULT);
+        conf,
+        schemaSimple,
+        path,
+        ParquetWriter.DEFAULT_BLOCK_SIZE,
+        ParquetWriter.MAX_PADDING_SIZE_DEFAULT,
+        allocator);
 
     writer.start();
     writer.startBlock(numRecordsLargeFile);
@@ -251,6 +271,7 @@ public class TestDataPageChecksums {
 
     try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(path)
         .withConf(conf)
+        .withAllocator(allocator)
         .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
         .withCompressionCodec(compression)
         .withDictionaryEncoding(dictionaryEncoding)

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -23,8 +23,11 @@ import static org.apache.parquet.column.Encoding.BIT_PACKED;
 import static org.apache.parquet.column.Encoding.PLAIN;
 import static org.apache.parquet.column.Encoding.RLE_DICTIONARY;
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.MAX_STATS_SIZE;
+import static org.apache.parquet.hadoop.ParquetFileWriter.Mode.CREATE;
 import static org.apache.parquet.hadoop.ParquetFileWriter.Mode.OVERWRITE;
 import static org.apache.parquet.hadoop.ParquetInputFormat.READ_SUPPORT_CLASS;
+import static org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE;
+import static org.apache.parquet.hadoop.ParquetWriter.MAX_PADDING_SIZE_DEFAULT;
 import static org.apache.parquet.hadoop.TestUtils.enforceEmptyDir;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
@@ -61,8 +64,11 @@ import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.Version;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.bytes.TrackingByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.page.DataPage;
 import org.apache.parquet.column.page.DataPageV1;
 import org.apache.parquet.column.page.DataPageV2;
@@ -89,6 +95,7 @@ import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.metadata.StrictKeyValueMetadataMergeStrategy;
 import org.apache.parquet.hadoop.util.ContextUtil;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.apache.parquet.hadoop.util.HadoopOutputFile;
 import org.apache.parquet.hadoop.util.HiddenFileFilter;
 import org.apache.parquet.internal.column.columnindex.BoundaryOrder;
 import org.apache.parquet.internal.column.columnindex.ColumnIndex;
@@ -100,7 +107,9 @@ import org.apache.parquet.schema.MessageTypeParser;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
+import org.junit.After;
 import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -141,6 +150,42 @@ public class TestParquetFileWriter {
   @Rule
   public final TemporaryFolder temp = new TemporaryFolder();
 
+  private TrackingByteBufferAllocator allocator;
+
+  @Before
+  public void initAllocator() {
+    allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator());
+  }
+
+  @After
+  public void closeAllocator() {
+    allocator.close();
+  }
+
+  private ParquetFileWriter createWriter(Configuration conf, MessageType schema, Path path) throws IOException {
+    return createWriter(conf, schema, path, CREATE);
+  }
+
+  private ParquetFileWriter createWriter(
+      Configuration conf, MessageType schema, Path path, ParquetFileWriter.Mode mode) throws IOException {
+    return new ParquetFileWriter(
+        HadoopOutputFile.fromPath(path, conf),
+        schema,
+        mode,
+        DEFAULT_BLOCK_SIZE,
+        MAX_PADDING_SIZE_DEFAULT,
+        ParquetProperties.DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH,
+        ParquetProperties.DEFAULT_STATISTICS_TRUNCATE_LENGTH,
+        ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED,
+        null,
+        allocator);
+  }
+
+  private ParquetFileWriter createWriter(
+      Configuration conf, MessageType schema, Path path, long blockSize, int maxPaddingSize) throws IOException {
+    return new ParquetFileWriter(conf, schema, path, blockSize, maxPaddingSize, allocator);
+  }
+
   @Test
   public void testWriteMode() throws Exception {
     File testFile = temp.newFile();
@@ -152,14 +197,14 @@ public class TestParquetFileWriter {
     boolean exceptionThrown = false;
     Path path = new Path(testFile.toURI());
     try {
-      writer = new ParquetFileWriter(conf, schema, path, ParquetFileWriter.Mode.CREATE);
+      writer = createWriter(conf, schema, path);
     } catch (IOException ioe1) {
       exceptionThrown = true;
     }
     assertTrue(exceptionThrown);
     exceptionThrown = false;
     try {
-      writer = new ParquetFileWriter(conf, schema, path, OVERWRITE);
+      writer = createWriter(conf, schema, path, OVERWRITE);
     } catch (IOException ioe2) {
       exceptionThrown = true;
     }
@@ -175,7 +220,7 @@ public class TestParquetFileWriter {
     Path path = new Path(testFile.toURI());
     Configuration configuration = new Configuration();
 
-    ParquetFileWriter w = new ParquetFileWriter(configuration, SCHEMA, path);
+    ParquetFileWriter w = createWriter(configuration, SCHEMA, path);
     w.start();
     w.startBlock(3);
     w.startColumn(C1, 5, CODEC);
@@ -275,7 +320,7 @@ public class TestParquetFileWriter {
     Path path = new Path(testFile.toURI());
     Configuration configuration = new Configuration();
 
-    ParquetFileWriter w = new ParquetFileWriter(configuration, SCHEMA, path);
+    ParquetFileWriter w = createWriter(configuration, SCHEMA, path);
     w.start();
     w.startBlock(3);
     w.startColumn(C1, 5, CODEC);
@@ -355,7 +400,7 @@ public class TestParquetFileWriter {
     Path path = new Path(testFile.toURI());
     Configuration configuration = new Configuration();
 
-    ParquetFileWriter w = new ParquetFileWriter(configuration, SCHEMA, path);
+    ParquetFileWriter w = createWriter(configuration, SCHEMA, path);
     w.start();
     w.startBlock(0);
 
@@ -376,7 +421,7 @@ public class TestParquetFileWriter {
     String[] colPath = {"foo"};
     ColumnDescriptor col = schema.getColumnDescription(colPath);
     BinaryStatistics stats1 = new BinaryStatistics();
-    ParquetFileWriter w = new ParquetFileWriter(configuration, schema, path);
+    ParquetFileWriter w = createWriter(configuration, schema, path);
     w.start();
     w.startBlock(3);
     w.startColumn(col, 5, CODEC);
@@ -414,7 +459,7 @@ public class TestParquetFileWriter {
     Path path = new Path(testFile.toURI());
     Configuration configuration = new Configuration();
 
-    ParquetFileWriter w = new ParquetFileWriter(configuration, SCHEMA, path);
+    ParquetFileWriter w = createWriter(configuration, SCHEMA, path);
     w.start();
     w.startBlock(14);
 
@@ -530,7 +575,7 @@ public class TestParquetFileWriter {
     conf.setBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED, false);
 
     // uses the test constructor
-    ParquetFileWriter w = new ParquetFileWriter(conf, SCHEMA, path, 120, 60);
+    ParquetFileWriter w = createWriter(conf, SCHEMA, path, 120, 60);
 
     w.start();
     w.startBlock(3);
@@ -654,7 +699,7 @@ public class TestParquetFileWriter {
     conf.setBoolean(ParquetOutputFormat.PAGE_WRITE_CHECKSUM_ENABLED, false);
 
     // uses the test constructor
-    ParquetFileWriter w = new ParquetFileWriter(conf, SCHEMA, path, 100, 50);
+    ParquetFileWriter w = createWriter(conf, SCHEMA, path, 100, 50);
 
     w.start();
     w.startBlock(3);
@@ -827,7 +872,7 @@ public class TestParquetFileWriter {
     statsB2C1P1.setMinMax(Binary.fromString("d"), Binary.fromString("e"));
     statsB2C2P1.setMinMax(11l, 122l);
 
-    ParquetFileWriter w = new ParquetFileWriter(configuration, schema, path);
+    ParquetFileWriter w = createWriter(configuration, schema, path);
     w.start();
     w.startBlock(3);
     w.startColumn(c1, 5, codec);
@@ -999,7 +1044,7 @@ public class TestParquetFileWriter {
     BinaryStatistics stats1 = new BinaryStatistics();
     BinaryStatistics stats2 = new BinaryStatistics();
 
-    ParquetFileWriter w = new ParquetFileWriter(configuration, schema, path);
+    ParquetFileWriter w = createWriter(configuration, schema, path);
     w.start();
     w.startBlock(3);
     w.startColumn(c1, 5, codec);
@@ -1170,7 +1215,7 @@ public class TestParquetFileWriter {
     Path path = new Path(testFile.toURI());
     Configuration configuration = new Configuration();
 
-    ParquetFileWriter w = new ParquetFileWriter(configuration, SCHEMA, path);
+    ParquetFileWriter w = createWriter(configuration, SCHEMA, path);
     w.start();
     w.startBlock(4);
     w.startColumn(C1, 7, CODEC);

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -174,11 +174,8 @@ public class TestParquetFileWriter {
         mode,
         DEFAULT_BLOCK_SIZE,
         MAX_PADDING_SIZE_DEFAULT,
-        ParquetProperties.DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH,
-        ParquetProperties.DEFAULT_STATISTICS_TRUNCATE_LENGTH,
-        ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED,
         null,
-        allocator);
+        ParquetProperties.builder().withAllocator(allocator).build());
   }
 
   private ParquetFileWriter createWriter(


### PR DESCRIPTION
* Updated BytesInput implementations to rely on a ByteBufferAllocator instance for allocating/releasing ByteBuffer objects.
* Extend the usage of a ByteBufferAllocator instead of the hardcoded usage of heap (e.g. byte[], ByteBuffer.allocate etc.)
* parquet-cli related code parts including ParquetRewriter and tests are not changed in this effort

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [PARQUET-2432](https://issues.apache.org/jira/browse/PARQUET-2432) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-XXX
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
