### PR TITLE
PARQUET-2438: Fixes minMaxSize for BinaryColumnIndexBuilder

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/BinaryColumnIndexBuilder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/BinaryColumnIndexBuilder.java
@@ -136,4 +136,11 @@ class BinaryColumnIndexBuilder extends ColumnIndexBuilder {
   int sizeOf(Object value) {
     return ((Binary) value).length();
   }
+
+  @Override
+  public long getMinMaxSize() {
+    long minSizesSum = minValues.stream().mapToLong(Binary::length).sum();
+    long maxSizesSum = maxValues.stream().mapToLong(Binary::length).sum();
+    return minSizesSum + maxSizesSum;
+  }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/BooleanColumnIndexBuilder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/BooleanColumnIndexBuilder.java
@@ -129,4 +129,9 @@ class BooleanColumnIndexBuilder extends ColumnIndexBuilder {
   int sizeOf(Object value) {
     return 1;
   }
+
+  @Override
+  public long getMinMaxSize() {
+    return minValues.size() + maxValues.size();
+  }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/ColumnIndexBuilder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/ColumnIndexBuilder.java
@@ -451,7 +451,6 @@ public abstract class ColumnIndexBuilder {
   private PrimitiveType type;
   private final BooleanList nullPages = new BooleanArrayList();
   private final LongList nullCounts = new LongArrayList();
-  private long minMaxSize;
   private final IntList pageIndexes = new IntArrayList();
   private int nextPageIndex;
 
@@ -537,8 +536,6 @@ public abstract class ColumnIndexBuilder {
       Object max = stats.genericGetMax();
       addMinMax(min, max);
       pageIndexes.add(nextPageIndex);
-      minMaxSize += sizeOf(min);
-      minMaxSize += sizeOf(max);
     } else {
       nullPages.add(true);
     }
@@ -576,8 +573,6 @@ public abstract class ColumnIndexBuilder {
         ByteBuffer max = maxValues.get(i);
         addMinMaxFromBytes(min, max);
         pageIndexes.add(i);
-        minMaxSize += min.remaining();
-        minMaxSize += max.remaining();
       }
     }
   }
@@ -651,7 +646,6 @@ public abstract class ColumnIndexBuilder {
     nullPages.clear();
     nullCounts.clear();
     clearMinMax();
-    minMaxSize = 0;
     nextPageIndex = 0;
     pageIndexes.clear();
   }
@@ -673,6 +667,6 @@ public abstract class ColumnIndexBuilder {
    * @return the sum of size in bytes of the min/max values added so far to this builder
    */
   public long getMinMaxSize() {
-    return minMaxSize;
+    return 0;
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/ColumnIndexBuilder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/ColumnIndexBuilder.java
@@ -446,6 +446,11 @@ public abstract class ColumnIndexBuilder {
     int sizeOf(Object value) {
       return 0;
     }
+
+    @Override
+    public long getMinMaxSize() {
+      return 0;
+    }
   };
 
   private PrimitiveType type;
@@ -667,6 +672,6 @@ public abstract class ColumnIndexBuilder {
    * @return the sum of size in bytes of the min/max values added so far to this builder
    */
   public long getMinMaxSize() {
-    return 0;
+    throw new UnsupportedOperationException("Not implemented");
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/DoubleColumnIndexBuilder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/DoubleColumnIndexBuilder.java
@@ -150,4 +150,9 @@ class DoubleColumnIndexBuilder extends ColumnIndexBuilder {
   int sizeOf(Object value) {
     return Double.BYTES;
   }
+
+  @Override
+  public long getMinMaxSize() {
+    return (long) minValues.size() * Double.BYTES + (long) maxValues.size() * Double.BYTES;
+  }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/FloatColumnIndexBuilder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/FloatColumnIndexBuilder.java
@@ -150,4 +150,9 @@ class FloatColumnIndexBuilder extends ColumnIndexBuilder {
   int sizeOf(Object value) {
     return Float.BYTES;
   }
+
+  @Override
+  public long getMinMaxSize() {
+    return (long) minValues.size() * Float.BYTES + (long) maxValues.size() * Float.BYTES;
+  }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/IntColumnIndexBuilder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/IntColumnIndexBuilder.java
@@ -131,4 +131,9 @@ class IntColumnIndexBuilder extends ColumnIndexBuilder {
   int sizeOf(Object value) {
     return Integer.BYTES;
   }
+
+  @Override
+  public long getMinMaxSize() {
+    return (long) minValues.size() * Integer.BYTES + (long) maxValues.size() * Integer.BYTES;
+  }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/LongColumnIndexBuilder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/LongColumnIndexBuilder.java
@@ -131,4 +131,9 @@ class LongColumnIndexBuilder extends ColumnIndexBuilder {
   int sizeOf(Object value) {
     return Long.BYTES;
   }
+
+  @Override
+  public long getMinMaxSize() {
+    return (long) minValues.size() * Long.BYTES + (long) maxValues.size() * Long.BYTES;
+  }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -524,6 +524,7 @@ public class ParquetFileWriter implements AutoCloseable {
    * @param file            the file to write to
    * @param rowAndBlockSize the row group size
    * @param maxPaddingSize  the maximum padding
+   * @param columnIndexTruncateLength  the length which the min/max values in column indexes tried to be truncated to
    * @param allocator       allocator to potentially allocate {@link java.nio.ByteBuffer} objects
    * @throws IOException if the file can not be created
    */
@@ -533,6 +534,7 @@ public class ParquetFileWriter implements AutoCloseable {
       Path file,
       long rowAndBlockSize,
       int maxPaddingSize,
+      int columnIndexTruncateLength,
       ByteBufferAllocator allocator)
       throws IOException {
     FileSystem fs = file.getFileSystem(configuration);
@@ -540,8 +542,7 @@ public class ParquetFileWriter implements AutoCloseable {
     this.alignment = PaddingAlignment.get(rowAndBlockSize, rowAndBlockSize, maxPaddingSize);
     this.out = HadoopStreams.wrap(fs.create(file, true, 8192, fs.getDefaultReplication(file), rowAndBlockSize));
     this.encodingStatsBuilder = new EncodingStats.Builder();
-    // no truncation is needed for testing
-    this.columnIndexTruncateLength = Integer.MAX_VALUE;
+    this.columnIndexTruncateLength = columnIndexTruncateLength;
     this.pageWriteChecksumEnabled = ParquetOutputFormat.getPageWriteChecksumEnabled(configuration);
     this.crc = pageWriteChecksumEnabled ? new CRC32() : null;
     this.crcAllocator = pageWriteChecksumEnabled

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDataPageChecksums.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDataPageChecksums.java
@@ -136,6 +136,7 @@ public class TestDataPageChecksums {
         path,
         ParquetWriter.DEFAULT_BLOCK_SIZE,
         ParquetWriter.MAX_PADDING_SIZE_DEFAULT,
+        Integer.MAX_VALUE,
         allocator);
 
     writer.start();


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-2438

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does

This fixes the `minMaxSize` calculation for BinaryColumnIndexBuilder since the min/max value can be truncated.