### PR TITLE
PARQUET-2439: Upgrade ZSTD-JNI to 1.5.5-11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <opencsv.version>2.3</opencsv.version>
     <jcommander.version>1.82</jcommander.version>
     <tukaani.version>1.9</tukaani.version>
-    <zstd-jni.version>1.5.0-1</zstd-jni.version>
+    <zstd-jni.version>1.5.5-11</zstd-jni.version>
     <commons-text.version>1.11.0</commons-text.version>
     <jsr305.version>3.0.2</jsr305.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>


### PR DESCRIPTION
The current version of zstd-jni used by parquet is [1.5.0-1](https://github.com/luben/zstd-jni/releases/tag/v1.5.0-1), which was released on Jun 6, 2021. 

The current version of zstd-jni is [1.5.5-11](https://github.com/luben/zstd-jni/releases/tag/v1.5.5-11), which was released on Dec 1, 2023.

### Jira

- [x] https://issues.apache.org/jira/browse/PARQUET-2439
### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [ ] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
