### PR TITLE
PARQUET-2437: Avoid flushing at Parquet writes after an exception

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriteStoreBase.java
@@ -25,7 +25,6 @@ import static java.util.Collections.unmodifiableMap;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import org.apache.parquet.column.ColumnDescriptor;
@@ -134,7 +133,10 @@ abstract class ColumnWriteStoreBase implements ColumnWriteStore {
   }
 
   private ColumnWriterBase createColumnWriterBase(
-      ColumnDescriptor path, PageWriter pageWriter, BloomFilterWriter bloomFilterWriter, ParquetProperties props) {
+      ColumnDescriptor path,
+      PageWriter pageWriter,
+      BloomFilterWriter bloomFilterWriter,
+      ParquetProperties props) {
     ColumnWriterBase columnWriterBase = createColumnWriter(path, pageWriter, bloomFilterWriter, props);
     columnWriterBase.initStatusManager(statusManager);
     return columnWriterBase;

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnWriterBase.java
@@ -373,8 +373,7 @@ abstract class ColumnWriterBase implements ColumnWriter {
     }
     try {
       this.rowsWrittenSoFar += pageRowCount;
-      if (DEBUG)
-        LOG.debug("write page");
+      if (DEBUG) LOG.debug("write page");
       try {
         writePage(
             pageRowCount,
@@ -393,7 +392,7 @@ abstract class ColumnWriterBase implements ColumnWriter {
       valueCount = 0;
       collector.resetPageStatistics();
       pageRowCount = 0;
-    } catch(Throwable t) {
+    } catch (Throwable t) {
       statusManager.abort();
       throw t;
     }

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/StatusManager.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/StatusManager.java
@@ -1,0 +1,42 @@
+package org.apache.parquet.column.impl;
+
+/**
+ * Interface to manage the current error status. It is used to share the status of all the different (column, page,
+ * etc.) writer/reader instances.
+ */
+interface StatusManager {
+
+  /**
+   * Creates an instance of the default {@link StatusManager} implementation.
+   *
+   * @return the newly created {@link StatusManager} instance
+   */
+  static StatusManager create() {
+    return new StatusManager() {
+      private boolean aborted;
+
+      @Override
+      public void abort() {
+        aborted = true;
+      }
+
+      @Override
+      public boolean isAborted() {
+        return aborted;
+      }
+    };
+  }
+
+  /**
+   * To be invoked if the current process is to be aborted. For example in case of an exception is occurred during
+   * writing a page.
+   */
+  void abort();
+
+  /**
+   * Returns whether the current process is aborted.
+   *
+   * @return {@code true} if the current process is aborted, {@code false} otherwise
+   */
+  boolean isAborted();
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/StatusManager.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/StatusManager.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.parquet.column.impl;
 
 /**

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/recordlevel/PhoneBookWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/recordlevel/PhoneBookWriter.java
@@ -56,7 +56,11 @@ public class PhoneBookWriter {
       + "  }\n"
       + "}\n";
 
-  private static final MessageType schema = MessageTypeParser.parseMessageType(schemaString);
+  private static final MessageType schema = getSchema();
+
+  public static MessageType getSchema() {
+    return MessageTypeParser.parseMessageType(schemaString);
+  }
 
   public static class Location {
     private final Double lon;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterError.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterError.java
@@ -157,6 +157,7 @@ public class TestParquetWriterError {
     }
 
     public static void main(String[] args) throws Throwable {
+      // Codecs supported by the direct codec factory by default (without specific hadoop native libs)
       CompressionCodecName[] codecs = {
         CompressionCodecName.UNCOMPRESSED,
         CompressionCodecName.GZIP,
@@ -173,6 +174,7 @@ public class TestParquetWriterError {
                 .withAllocator(allocator)
                 .withCodecFactory(CodecFactory.createDirectCodecFactory(
                     new Configuration(), allocator, ParquetProperties.DEFAULT_PAGE_SIZE))
+                // Also validating the different direct codecs which might also have issues if an OOM happens
                 .withCompressionCodec(codecs[RANDOM.nextInt(codecs.length)])
                 .build()) {
           for (int i = 0; i < 100_000; ++i) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterError.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterError.java
@@ -1,0 +1,170 @@
+package org.apache.parquet.hadoop;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.bytes.DirectByteBufferAllocator;
+import org.apache.parquet.bytes.TrackingByteBufferAllocator;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.filter2.recordlevel.PhoneBookWriter;
+import org.apache.parquet.hadoop.codec.CleanUtil;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.LocalOutputFile;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Unit test to check how Parquet writing behaves in case of an error happens during the writes. We use an OOM because
+ * that is the most tricky to handle. In this case we shall avoid flushing since it may cause writing to already
+ * released memory spaces.
+ * <p>
+ * To catch the potential issue of writing into released ByteBuffer objects, direct memory allocation is used and at the
+ * release() call we actually release the related direct memory and zero the address inside the ByteBuffer object. As a
+ * result, a subsequent read/write call on the related ByteBuffer object will crash the whole jvm. (Unfortunately, there
+ * is no better way to test this.) To avoid crashing the test executor jvm, the code of this test is executed in a
+ * separate process.
+ */
+public class TestParquetWriterError {
+
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Test
+  public void testInSeparateProcess() throws IOException, InterruptedException {
+    String outputFile = tmpFolder.newFile("out.parquet").toString();
+
+    String classpath = System.getProperty("java.class.path");
+    String javaPath = Paths.get(System.getProperty("java.home"), "bin", "java").toAbsolutePath().toString();
+    Process process = new ProcessBuilder()
+        .command(
+            javaPath,
+            "-cp",
+            classpath,
+            Main.class.getName(),
+            outputFile)
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        .start();
+    Assert.assertEquals("Test process exited with a non-zero return code. See previous logs for details.", 0,
+        process.waitFor());
+  }
+
+  /**
+   * The class to be used to execute this test in a separate thread.
+   */
+  public static class Main {
+
+    private static final Random RANDOM = new Random(2024_02_27_14_20L);
+
+    // See the release() implementation in createAllocator()
+    private static final Field BUFFER_ADDRESS;
+
+    static {
+      try {
+        Class<?> bufferClass = Class.forName("java.nio.Buffer");
+        BUFFER_ADDRESS = bufferClass.getDeclaredField("address");
+        BUFFER_ADDRESS.setAccessible(true);
+      } catch (ClassNotFoundException | NoSuchFieldException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    private static Group generateNext() {
+      PhoneBookWriter.Location location;
+      double chance = RANDOM.nextDouble();
+      if (chance < .45) {
+        location = new PhoneBookWriter.Location(RANDOM.nextDouble(), RANDOM.nextDouble());
+      } else if (chance < .9) {
+        location = new PhoneBookWriter.Location(RANDOM.nextDouble(), null);
+      } else {
+        location = null;
+      }
+      List<PhoneBookWriter.PhoneNumber> phoneNumbers;
+      if (RANDOM.nextDouble() < .1) {
+        phoneNumbers = null;
+      } else {
+        int n = RANDOM.nextInt(4);
+        phoneNumbers = new ArrayList<>(n);
+        for (int i = 0; i < n; ++i) {
+          String kind = RANDOM.nextDouble() < .1 ? null : "kind" + RANDOM.nextInt(5);
+          phoneNumbers.add(new PhoneBookWriter.PhoneNumber(RANDOM.nextInt(), kind));
+        }
+      }
+      String name = RANDOM.nextDouble() < .1 ? null : "name" + RANDOM.nextLong();
+      PhoneBookWriter.User user = new PhoneBookWriter.User(RANDOM.nextLong(), name, phoneNumbers, location);
+      return PhoneBookWriter.groupFromUser(user);
+    }
+
+    private static TrackingByteBufferAllocator createAllocator(final int oomAt) {
+      return TrackingByteBufferAllocator.wrap(new DirectByteBufferAllocator() {
+        private int counter = 0;
+
+        @Override
+        public ByteBuffer allocate(int size) {
+          if (++counter >= oomAt) {
+            Assert.assertEquals("There should not be any additional allocations after an OOM", oomAt, counter);
+            throw new OutOfMemoryError("Artificial OOM to fail write");
+          }
+          return super.allocate(size);
+        }
+
+        @Override
+        public void release(ByteBuffer b) {
+          CleanUtil.cleanDirectBuffer(b);
+
+          // It seems, if the size of the buffers are small, the related memory space is not given back to the OS, so
+          // writing to them after release does not cause any identifiable issue. Therefore, we explicitly zero the
+          // address, so the jvm crashes for a subsequent access.
+          try {
+            BUFFER_ADDRESS.setLong(b, 0L);
+          } catch (IllegalAccessException e) {
+            throw new RuntimeException("Unable to zero direct ByteBuffer address", e);
+          }
+        }
+      });
+    }
+
+    public static void main(String[] args) throws Throwable {
+      CompressionCodecName[] codecs = {
+          CompressionCodecName.UNCOMPRESSED,
+          CompressionCodecName.GZIP,
+          CompressionCodecName.SNAPPY,
+          CompressionCodecName.ZSTD,
+          CompressionCodecName.LZ4_RAW};
+      for (int cycle = 0; cycle < 50; ++cycle) {
+        try (TrackingByteBufferAllocator allocator = createAllocator(RANDOM.nextInt(100) + 1);
+            ParquetWriter<Group> writer = ExampleParquetWriter.builder(new LocalOutputFile(Paths.get(args[0])))
+                .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
+                .withType(PhoneBookWriter.getSchema())
+                .withAllocator(allocator)
+                .withCodecFactory(CodecFactory.createDirectCodecFactory(
+                    new Configuration(),
+                    allocator,
+                    ParquetProperties.DEFAULT_PAGE_SIZE))
+                .withCompressionCodec(codecs[RANDOM.nextInt(codecs.length)])
+                .build()) {
+          for (int i = 0; i < 100_000; ++i) {
+            writer.write(generateNext());
+          }
+          Assert.fail("An OOM should have been thrown");
+        } catch (OutOfMemoryError oom) {
+          Throwable[] suppressed = oom.getSuppressed();
+          // No exception should be suppressed after the expected OOM:
+          // It would mean that a close() call fails with an exception
+          if (suppressed != null && suppressed.length > 0) {
+            throw suppressed[0];
+          }
+        }
+      }
+    }
+  }
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterError.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterError.java
@@ -174,7 +174,8 @@ public class TestParquetWriterError {
                 .withAllocator(allocator)
                 .withCodecFactory(CodecFactory.createDirectCodecFactory(
                     new Configuration(), allocator, ParquetProperties.DEFAULT_PAGE_SIZE))
-                // Also validating the different direct codecs which might also have issues if an OOM happens
+                // Also validating the different direct codecs which might also have issues if an OOM
+                // happens
                 .withCompressionCodec(codecs[RANDOM.nextInt(codecs.length)])
                 .build()) {
           for (int i = 0; i < 100_000; ++i) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [PARQUET-2437](https://issues.apache.org/jira/browse/PARQUET-2437) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-XXX
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
