### PR TITLE
PARQUET-2440: Avoid getting Hadoop codec for internal compressor/decompressor

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CodecPool;
 import org.apache.hadoop.io.compress.CompressionCodec;
@@ -32,6 +33,7 @@ import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
 import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.parquet.Preconditions;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.compression.CompressionCodecFactory;
@@ -51,6 +53,40 @@ public class CodecFactory implements CompressionCodecFactory {
 
   protected final ParquetConfiguration configuration;
   protected final int pageSize;
+
+  static final BytesDecompressor NO_OP_DECOMPRESSOR = new BytesDecompressor() {
+    @Override
+    public void decompress(ByteBuffer input, int compressedSize, ByteBuffer output, int uncompressedSize) {
+      Preconditions.checkArgument(
+          compressedSize == uncompressedSize,
+          "Non-compressed data did not have matching compressed and uncompressed sizes.");
+      output.clear();
+      output.put((ByteBuffer) input.duplicate().position(0).limit(compressedSize));
+    }
+
+    @Override
+    public BytesInput decompress(BytesInput bytes, int uncompressedSize) {
+      return bytes;
+    }
+
+    @Override
+    public void release() {}
+  };
+
+  static final BytesCompressor NO_OP_COMPRESSOR = new BytesCompressor() {
+    @Override
+    public BytesInput compress(BytesInput bytes) {
+      return bytes;
+    }
+
+    @Override
+    public CompressionCodecName getCodecName() {
+      return CompressionCodecName.UNCOMPRESSED;
+    }
+
+    @Override
+    public void release() {}
+  };
 
   /**
    * Create a new codec factory.
@@ -108,37 +144,28 @@ public class CodecFactory implements CompressionCodecFactory {
     private final CompressionCodec codec;
     private final Decompressor decompressor;
 
-    HeapBytesDecompressor(CompressionCodecName codecName) {
-      this.codec = getCodec(codecName);
-      if (codec != null) {
-        decompressor = CodecPool.getDecompressor(codec);
-      } else {
-        decompressor = null;
-      }
+    HeapBytesDecompressor(CompressionCodec codec) {
+      this.codec = Objects.requireNonNull(codec);
+      decompressor = CodecPool.getDecompressor(codec);
     }
 
     @Override
     public BytesInput decompress(BytesInput bytes, int uncompressedSize) throws IOException {
       final BytesInput decompressed;
-      if (codec != null) {
-        if (decompressor != null) {
-          decompressor.reset();
-        }
-        InputStream is = codec.createInputStream(bytes.toInputStream(), decompressor);
+      if (decompressor != null) {
+        decompressor.reset();
+      }
+      InputStream is = codec.createInputStream(bytes.toInputStream(), decompressor);
 
-        // We need to explicitly close the ZstdDecompressorStream here to release the resources it holds to
-        // avoid
-        // off-heap memory fragmentation issue, see https://issues.apache.org/jira/browse/PARQUET-2160.
-        // This change will load the decompressor stream into heap a little earlier, since the problem it solves
-        // only happens in the ZSTD codec, so this modification is only made for ZSTD streams.
-        if (codec instanceof ZstandardCodec) {
-          decompressed = BytesInput.copy(BytesInput.from(is, uncompressedSize));
-          is.close();
-        } else {
-          decompressed = BytesInput.from(is, uncompressedSize);
-        }
+      // We need to explicitly close the ZstdDecompressorStream here to release the resources it holds to
+      // avoid off-heap memory fragmentation issue, see https://issues.apache.org/jira/browse/PARQUET-2160.
+      // This change will load the decompressor stream into heap a little earlier, since the problem it solves
+      // only happens in the ZSTD codec, so this modification is only made for ZSTD streams.
+      if (codec instanceof ZstandardCodec) {
+        decompressed = BytesInput.copy(BytesInput.from(is, uncompressedSize));
+        is.close();
       } else {
-        decompressed = bytes;
+        decompressed = BytesInput.from(is, uncompressedSize);
       }
       return decompressed;
     }
@@ -168,36 +195,25 @@ public class CodecFactory implements CompressionCodecFactory {
     private final ByteArrayOutputStream compressedOutBuffer;
     private final CompressionCodecName codecName;
 
-    HeapBytesCompressor(CompressionCodecName codecName) {
+    HeapBytesCompressor(CompressionCodecName codecName, CompressionCodec codec) {
       this.codecName = codecName;
-      this.codec = getCodec(codecName);
-      if (codec != null) {
-        this.compressor = CodecPool.getCompressor(codec);
-        this.compressedOutBuffer = new ByteArrayOutputStream(pageSize);
-      } else {
-        this.compressor = null;
-        this.compressedOutBuffer = null;
-      }
+      this.codec = Objects.requireNonNull(codec);
+      this.compressor = CodecPool.getCompressor(codec);
+      this.compressedOutBuffer = new ByteArrayOutputStream(pageSize);
     }
 
     @Override
     public BytesInput compress(BytesInput bytes) throws IOException {
-      final BytesInput compressedBytes;
-      if (codec == null) {
-        compressedBytes = bytes;
-      } else {
-        compressedOutBuffer.reset();
-        if (compressor != null) {
-          // null compressor for non-native gzip
-          compressor.reset();
-        }
-        try (CompressionOutputStream cos = codec.createOutputStream(compressedOutBuffer, compressor)) {
-          bytes.writeAllTo(cos);
-          cos.finish();
-        }
-        compressedBytes = BytesInput.from(compressedOutBuffer);
+      compressedOutBuffer.reset();
+      if (compressor != null) {
+        // null compressor for non-native gzip
+        compressor.reset();
       }
-      return compressedBytes;
+      try (CompressionOutputStream cos = codec.createOutputStream(compressedOutBuffer, compressor)) {
+        bytes.writeAllTo(cos);
+        cos.finish();
+      }
+      return BytesInput.from(compressedOutBuffer);
     }
 
     @Override
@@ -233,11 +249,13 @@ public class CodecFactory implements CompressionCodecFactory {
   }
 
   protected BytesCompressor createCompressor(CompressionCodecName codecName) {
-    return new HeapBytesCompressor(codecName);
+    CompressionCodec codec = getCodec(codecName);
+    return codec == null ? NO_OP_COMPRESSOR : new HeapBytesCompressor(codecName, codec);
   }
 
   protected BytesDecompressor createDecompressor(CompressionCodecName codecName) {
-    return new HeapBytesDecompressor(codecName);
+    CompressionCodec codec = getCodec(codecName);
+    return codec == null ? NO_OP_DECOMPRESSOR : new HeapBytesDecompressor(codec);
   }
 
   /**


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [PARQUET-2440](https://issues.apache.org/jira/browse/PARQUET-2440) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-XXX
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
