### PR TITLE
PARQUET-2442: Remove old parquet-mr site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -657,68 +657,6 @@
       </properties>
     </profile>
 
-    <profile>
-      <id>update-github-site</id>
-      <reporting>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-project-info-reports-plugin</artifactId>
-            <reportSets>
-              <reportSet>
-                <reports>
-                  <report>index</report>
-                  <report>mailing-list</report>
-                  <report>dependency-info</report>
-                  <report>project-team</report>
-                  <report>dependencies</report>
-                  <report>license</report>
-                  <report>scm</report>
-                </reports>
-              </reportSet>
-            </reportSets>
-          </plugin>
-        </plugins>
-      </reporting>
-      <distributionManagement>
-        <site>
-          <id>github-pages-site</id>
-          <name>Deployment through GitHub's site deployment plugin</name>
-          <url>site/${project.version}</url>
-        </site>
-      </distributionManagement>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-site-plugin</artifactId>
-            <configuration>
-              <skipDeploy>true</skipDeploy>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>com.github.github</groupId>
-            <artifactId>site-maven-plugin</artifactId>
-            <version>0.12</version>
-            <configuration>
-              <message>Creating site for ${project.version}</message>
-              <path>${project.distributionManagement.site.url}</path>
-              <merge>true</merge>
-            </configuration>
-            <executions>
-              <execution>
-                <id>github-site</id>
-                <goals>
-                  <goal>site</goal>
-                </goals>
-                <phase>site-deploy</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <!-- Profile for tests to have more output -->
     <profile>
       <id>verbose-test</id>


### PR DESCRIPTION
Email received identifying vulnerabilities including in parquet-mr. Given that we have a new parquet site: https://github.com/apache/parquet-site, we can remove the old site that has issues.  

```
Dear Apache, I have identified several vulnerabilities of varying types in your numerous repositories. (Some of these may have already been reported; Maybe even by me, but I thought I'd compile a list)
 
https://apache.github.io/parquet-mr/site/1.0.0/apidocs/?//evil.com
```
 
 

### Jira

- [X] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-2442

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: Removing website, no code additions

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [X] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
