### PR TITLE
PARQUET-2451: Add BYTE_STREAM_SPLIT support for FIXED_LEN_BYTE_ARRAY, INT32 and INT64

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/Encoding.java
@@ -31,7 +31,10 @@ import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.bitpacking.ByteBitPackingValuesReader;
 import org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesReaderForDouble;
+import org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesReaderForFLBA;
 import org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesReaderForFloat;
+import org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesReaderForInteger;
+import org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesReaderForLong;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
 import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesReader;
 import org.apache.parquet.column.values.deltastrings.DeltaByteArrayReader;
@@ -129,6 +132,12 @@ public enum Encoding {
           return new ByteStreamSplitValuesReaderForFloat();
         case DOUBLE:
           return new ByteStreamSplitValuesReaderForDouble();
+        case INT32:
+          return new ByteStreamSplitValuesReaderForInteger();
+        case INT64:
+          return new ByteStreamSplitValuesReaderForLong();
+        case FIXED_LEN_BYTE_ARRAY:
+          return new ByteStreamSplitValuesReaderForFLBA(descriptor.getTypeLength());
         default:
           throw new ParquetDecodingException("no byte stream split reader for type " + descriptor.getType());
       }

--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -50,6 +50,7 @@ public class ParquetProperties {
   public static final int DEFAULT_DICTIONARY_PAGE_SIZE = DEFAULT_PAGE_SIZE;
   public static final boolean DEFAULT_IS_DICTIONARY_ENABLED = true;
   public static final boolean DEFAULT_IS_BYTE_STREAM_SPLIT_ENABLED = false;
+  public static final boolean DEFAULT_IS_EXTENDED_BYTE_STREAM_SPLIT_ENABLED = false;
   public static final WriterVersion DEFAULT_WRITER_VERSION = WriterVersion.PARQUET_1_0;
   public static final boolean DEFAULT_ESTIMATE_ROW_COUNT_FOR_PAGE_SIZE_CHECK = true;
   public static final int DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK = 100;
@@ -115,6 +116,7 @@ public class ParquetProperties {
   private final int pageRowCountLimit;
   private final boolean pageWriteChecksumEnabled;
   private final boolean enableByteStreamSplit;
+  private final boolean enableExtendedByteStreamSplit;
   private final Map<String, String> extraMetaData;
 
   private ParquetProperties(Builder builder) {
@@ -142,6 +144,7 @@ public class ParquetProperties {
     this.pageRowCountLimit = builder.pageRowCountLimit;
     this.pageWriteChecksumEnabled = builder.pageWriteChecksumEnabled;
     this.enableByteStreamSplit = builder.enableByteStreamSplit;
+    this.enableExtendedByteStreamSplit = builder.enableExtendedByteStreamSplit;
     this.extraMetaData = builder.extraMetaData;
   }
 
@@ -210,6 +213,10 @@ public class ParquetProperties {
 
   public boolean isByteStreamSplitEnabled() {
     return enableByteStreamSplit;
+  }
+
+  public boolean isExtendedByteStreamSplitEnabled() {
+    return enableExtendedByteStreamSplit;
   }
 
   public ByteBufferAllocator getAllocator() {
@@ -350,6 +357,7 @@ public class ParquetProperties {
     private int pageRowCountLimit = DEFAULT_PAGE_ROW_COUNT_LIMIT;
     private boolean pageWriteChecksumEnabled = DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED;
     private boolean enableByteStreamSplit = DEFAULT_IS_BYTE_STREAM_SPLIT_ENABLED;
+    private boolean enableExtendedByteStreamSplit = DEFAULT_IS_EXTENDED_BYTE_STREAM_SPLIT_ENABLED;
     private Map<String, String> extraMetaData = new HashMap<>();
 
     private Builder() {
@@ -382,6 +390,7 @@ public class ParquetProperties {
       this.numBloomFilterCandidates = ColumnProperty.<Integer>builder(toCopy.numBloomFilterCandidates);
       this.maxBloomFilterBytes = toCopy.maxBloomFilterBytes;
       this.enableByteStreamSplit = toCopy.enableByteStreamSplit;
+      this.enableExtendedByteStreamSplit = toCopy.enableExtendedByteStreamSplit;
       this.extraMetaData = toCopy.extraMetaData;
     }
 
@@ -420,8 +429,27 @@ public class ParquetProperties {
       return this;
     }
 
-    public Builder withByteStreamSplitEncoding(boolean enableByteStreamSplit) {
-      this.enableByteStreamSplit = enableByteStreamSplit;
+    /**
+     * Enable or disable BYTE_STREAM_SPLIT encoding for FLOAT and DOUBLE columns.
+     *
+     * @param enable whether BYTE_STREAM_SPLIT encoding should be enabled
+     * @return this builder for method chaining.
+     */
+    public Builder withByteStreamSplitEncoding(boolean enable) {
+      this.enableByteStreamSplit = enable;
+      this.enableExtendedByteStreamSplit &= enable;
+      return this;
+    }
+
+    /**
+     * Enable or disable BYTE_STREAM_SPLIT encoding for FLOAT, DOUBLE, INT32, INT64 and FIXED_LEN_BYTE_ARRAY columns.
+     *
+     * @param enable whether BYTE_STREAM_SPLIT encoding should be enabled
+     * @return this builder for method chaining.
+     */
+    public Builder withExtendedByteStreamSplitEncoding(boolean enable) {
+      this.enableByteStreamSplit |= enable;
+      this.enableExtendedByteStreamSplit = enable;
       return this;
     }
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForDouble.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForDouble.java
@@ -18,20 +18,13 @@
  */
 package org.apache.parquet.column.values.bytestreamsplit;
 
-import org.apache.parquet.bytes.BytesUtils;
-
 public class ByteStreamSplitValuesReaderForDouble extends ByteStreamSplitValuesReader {
-
-  private final byte[] valueByteBuffer;
-
   public ByteStreamSplitValuesReaderForDouble() {
     super(Double.BYTES);
-    valueByteBuffer = new byte[Double.BYTES];
   }
 
   @Override
   public double readDouble() {
-    gatherElementDataFromStreams(valueByteBuffer);
-    return Double.longBitsToDouble(BytesUtils.bytesToLong(valueByteBuffer));
+    return decodedDataBuffer.getDouble(nextElementByteOffset());
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForFLBA.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForFLBA.java
@@ -18,13 +18,16 @@
  */
 package org.apache.parquet.column.values.bytestreamsplit;
 
-public class ByteStreamSplitValuesReaderForFloat extends ByteStreamSplitValuesReader {
-  public ByteStreamSplitValuesReaderForFloat() {
-    super(Float.BYTES);
+import org.apache.parquet.io.api.Binary;
+
+public class ByteStreamSplitValuesReaderForFLBA extends ByteStreamSplitValuesReader {
+  // Trivial, but overriden for clarity
+  public ByteStreamSplitValuesReaderForFLBA(int length) {
+    super(length);
   }
 
   @Override
-  public float readFloat() {
-    return decodedDataBuffer.getFloat(nextElementByteOffset());
+  public Binary readBytes() {
+    return Binary.fromConstantByteBuffer(decodedDataBuffer, nextElementByteOffset(), elementSizeInBytes);
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForInteger.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForInteger.java
@@ -18,13 +18,13 @@
  */
 package org.apache.parquet.column.values.bytestreamsplit;
 
-public class ByteStreamSplitValuesReaderForFloat extends ByteStreamSplitValuesReader {
-  public ByteStreamSplitValuesReaderForFloat() {
-    super(Float.BYTES);
+public class ByteStreamSplitValuesReaderForInteger extends ByteStreamSplitValuesReader {
+  public ByteStreamSplitValuesReaderForInteger() {
+    super(4);
   }
 
   @Override
-  public float readFloat() {
-    return decodedDataBuffer.getFloat(nextElementByteOffset());
+  public int readInteger() {
+    return decodedDataBuffer.getInt(nextElementByteOffset());
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForLong.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderForLong.java
@@ -18,13 +18,13 @@
  */
 package org.apache.parquet.column.values.bytestreamsplit;
 
-public class ByteStreamSplitValuesReaderForFloat extends ByteStreamSplitValuesReader {
-  public ByteStreamSplitValuesReaderForFloat() {
-    super(Float.BYTES);
+public class ByteStreamSplitValuesReaderForLong extends ByteStreamSplitValuesReader {
+  public ByteStreamSplitValuesReaderForLong() {
+    super(8);
   }
 
   @Override
-  public float readFloat() {
-    return decodedDataBuffer.getFloat(nextElementByteOffset());
+  public long readLong() {
+    return decodedDataBuffer.getLong(nextElementByteOffset());
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/factory/DefaultV1ValuesWriterFactory.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/factory/DefaultV1ValuesWriterFactory.java
@@ -77,11 +77,19 @@ public class DefaultV1ValuesWriterFactory implements ValuesWriterFactory {
 
   private ValuesWriter getFixedLenByteArrayValuesWriter(ColumnDescriptor path) {
     // dictionary encoding was not enabled in PARQUET 1.0
-    return new FixedLenByteArrayPlainValuesWriter(
-        path.getTypeLength(),
-        parquetProperties.getInitialSlabSize(),
-        parquetProperties.getPageSizeThreshold(),
-        parquetProperties.getAllocator());
+    if (parquetProperties.isExtendedByteStreamSplitEnabled()) {
+      return new ByteStreamSplitValuesWriter.FixedLenByteArrayByteStreamSplitValuesWriter(
+          path.getTypeLength(),
+          parquetProperties.getInitialSlabSize(),
+          parquetProperties.getPageSizeThreshold(),
+          parquetProperties.getAllocator());
+    } else {
+      return new FixedLenByteArrayPlainValuesWriter(
+          path.getTypeLength(),
+          parquetProperties.getInitialSlabSize(),
+          parquetProperties.getPageSizeThreshold(),
+          parquetProperties.getAllocator());
+    }
   }
 
   private ValuesWriter getBinaryValuesWriter(ColumnDescriptor path) {
@@ -94,19 +102,35 @@ public class DefaultV1ValuesWriterFactory implements ValuesWriterFactory {
   }
 
   private ValuesWriter getInt32ValuesWriter(ColumnDescriptor path) {
-    ValuesWriter fallbackWriter = new PlainValuesWriter(
-        parquetProperties.getInitialSlabSize(),
-        parquetProperties.getPageSizeThreshold(),
-        parquetProperties.getAllocator());
+    final ValuesWriter fallbackWriter;
+    if (parquetProperties.isExtendedByteStreamSplitEnabled()) {
+      fallbackWriter = new ByteStreamSplitValuesWriter.IntegerByteStreamSplitValuesWriter(
+          parquetProperties.getInitialSlabSize(),
+          parquetProperties.getPageSizeThreshold(),
+          parquetProperties.getAllocator());
+    } else {
+      fallbackWriter = new PlainValuesWriter(
+          parquetProperties.getInitialSlabSize(),
+          parquetProperties.getPageSizeThreshold(),
+          parquetProperties.getAllocator());
+    }
     return DefaultValuesWriterFactory.dictWriterWithFallBack(
         path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
   }
 
   private ValuesWriter getInt64ValuesWriter(ColumnDescriptor path) {
-    ValuesWriter fallbackWriter = new PlainValuesWriter(
-        parquetProperties.getInitialSlabSize(),
-        parquetProperties.getPageSizeThreshold(),
-        parquetProperties.getAllocator());
+    final ValuesWriter fallbackWriter;
+    if (parquetProperties.isExtendedByteStreamSplitEnabled()) {
+      fallbackWriter = new ByteStreamSplitValuesWriter.LongByteStreamSplitValuesWriter(
+          parquetProperties.getInitialSlabSize(),
+          parquetProperties.getPageSizeThreshold(),
+          parquetProperties.getAllocator());
+    } else {
+      fallbackWriter = new PlainValuesWriter(
+          parquetProperties.getInitialSlabSize(),
+          parquetProperties.getPageSizeThreshold(),
+          parquetProperties.getAllocator());
+    }
     return DefaultValuesWriterFactory.dictWriterWithFallBack(
         path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
   }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/factory/DefaultV1ValuesWriterFactory.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/factory/DefaultV1ValuesWriterFactory.java
@@ -77,15 +77,15 @@ public class DefaultV1ValuesWriterFactory implements ValuesWriterFactory {
 
   private ValuesWriter getFixedLenByteArrayValuesWriter(ColumnDescriptor path) {
     // dictionary encoding was not enabled in PARQUET 1.0
-    if (parquetProperties.isExtendedByteStreamSplitEnabled()) {
+    if (parquetProperties.isByteStreamSplitEnabled(path)) {
       return new ByteStreamSplitValuesWriter.FixedLenByteArrayByteStreamSplitValuesWriter(
-          path.getTypeLength(),
+          path.getPrimitiveType().getTypeLength(),
           parquetProperties.getInitialSlabSize(),
           parquetProperties.getPageSizeThreshold(),
           parquetProperties.getAllocator());
     } else {
       return new FixedLenByteArrayPlainValuesWriter(
-          path.getTypeLength(),
+          path.getPrimitiveType().getTypeLength(),
           parquetProperties.getInitialSlabSize(),
           parquetProperties.getPageSizeThreshold(),
           parquetProperties.getAllocator());
@@ -103,7 +103,7 @@ public class DefaultV1ValuesWriterFactory implements ValuesWriterFactory {
 
   private ValuesWriter getInt32ValuesWriter(ColumnDescriptor path) {
     final ValuesWriter fallbackWriter;
-    if (parquetProperties.isExtendedByteStreamSplitEnabled()) {
+    if (parquetProperties.isByteStreamSplitEnabled(path)) {
       fallbackWriter = new ByteStreamSplitValuesWriter.IntegerByteStreamSplitValuesWriter(
           parquetProperties.getInitialSlabSize(),
           parquetProperties.getPageSizeThreshold(),
@@ -120,7 +120,7 @@ public class DefaultV1ValuesWriterFactory implements ValuesWriterFactory {
 
   private ValuesWriter getInt64ValuesWriter(ColumnDescriptor path) {
     final ValuesWriter fallbackWriter;
-    if (parquetProperties.isExtendedByteStreamSplitEnabled()) {
+    if (parquetProperties.isByteStreamSplitEnabled(path)) {
       fallbackWriter = new ByteStreamSplitValuesWriter.LongByteStreamSplitValuesWriter(
           parquetProperties.getInitialSlabSize(),
           parquetProperties.getPageSizeThreshold(),
@@ -147,7 +147,7 @@ public class DefaultV1ValuesWriterFactory implements ValuesWriterFactory {
 
   private ValuesWriter getDoubleValuesWriter(ColumnDescriptor path) {
     final ValuesWriter fallbackWriter;
-    if (this.parquetProperties.isByteStreamSplitEnabled()) {
+    if (this.parquetProperties.isByteStreamSplitEnabled(path)) {
       fallbackWriter = new ByteStreamSplitValuesWriter.DoubleByteStreamSplitValuesWriter(
           parquetProperties.getInitialSlabSize(),
           parquetProperties.getPageSizeThreshold(),
@@ -164,7 +164,7 @@ public class DefaultV1ValuesWriterFactory implements ValuesWriterFactory {
 
   private ValuesWriter getFloatValuesWriter(ColumnDescriptor path) {
     final ValuesWriter fallbackWriter;
-    if (this.parquetProperties.isByteStreamSplitEnabled()) {
+    if (this.parquetProperties.isByteStreamSplitEnabled(path)) {
       fallbackWriter = new ByteStreamSplitValuesWriter.FloatByteStreamSplitValuesWriter(
           parquetProperties.getInitialSlabSize(),
           parquetProperties.getPageSizeThreshold(),

--- a/parquet-column/src/main/java/org/apache/parquet/example/data/simple/SimpleGroup.java
+++ b/parquet-column/src/main/java/org/apache/parquet/example/data/simple/SimpleGroup.java
@@ -60,7 +60,7 @@ public class SimpleGroup extends Group {
             builder.append('\n');
             ((SimpleGroup) value).appendToString(builder, indent + "  ");
           } else {
-            builder.append(": ").append(value.toString()).append('\n');
+            builder.append(": ").append(value).append('\n');
           }
         }
       }
@@ -79,6 +79,32 @@ public class SimpleGroup extends Group {
     SimpleGroup g = new SimpleGroup(schema.getType(fieldIndex).asGroupType());
     add(fieldIndex, g);
     return g;
+  }
+
+  public Object getObject(String field, int index) {
+    return getObject(getType().getFieldIndex(field), index);
+  }
+
+  public Object getObject(int fieldIndex, int index) {
+    Object wrapped = getValue(fieldIndex, index);
+    // Unwrap to Java standard object, if possible
+    if (wrapped instanceof BooleanValue) {
+      return ((BooleanValue) wrapped).getBoolean();
+    } else if (wrapped instanceof IntegerValue) {
+      return ((IntegerValue) wrapped).getInteger();
+    } else if (wrapped instanceof LongValue) {
+      return ((LongValue) wrapped).getLong();
+    } else if (wrapped instanceof Int96Value) {
+      return ((Int96Value) wrapped).getInt96();
+    } else if (wrapped instanceof FloatValue) {
+      return ((FloatValue) wrapped).getFloat();
+    } else if (wrapped instanceof DoubleValue) {
+      return ((DoubleValue) wrapped).getDouble();
+    } else if (wrapped instanceof BinaryValue) {
+      return ((BinaryValue) wrapped).getBinary();
+    } else {
+      return wrapped;
+    }
   }
 
   @Override

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesEndToEndTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesEndToEndTest.java
@@ -24,6 +24,7 @@ import java.util.Random;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
+import org.apache.parquet.io.api.Binary;
 import org.junit.Test;
 
 public class ByteStreamSplitValuesEndToEndTest {
@@ -73,11 +74,7 @@ public class ByteStreamSplitValuesEndToEndTest {
     // Generate random data.
     Random rand = new Random(18990);
     final int numElements = 1024;
-    double[] values = new double[numElements];
-    for (int i = 0; i < numElements; ++i) {
-      double f = rand.nextDouble() * 16384.0;
-      values[i] = f;
-    }
+    double[] values = rand.doubles(numElements).toArray();
 
     // Encode data.
     ByteStreamSplitValuesWriter.DoubleByteStreamSplitValuesWriter writer =
@@ -98,6 +95,115 @@ public class ByteStreamSplitValuesEndToEndTest {
     for (double expectedValue : values) {
       double newValue = reader.readDouble();
       assertEquals(expectedValue, newValue, 0.0);
+    }
+
+    writer.reset();
+    writer.close();
+  }
+
+  @Test
+  public void testIntegerPipeline() throws Exception {
+    // Generate random data.
+    Random rand = new Random(18990);
+    final int numElements = 1024;
+    int[] values = rand.ints(numElements).toArray();
+
+    // Encode data.
+    ByteStreamSplitValuesWriter.IntegerByteStreamSplitValuesWriter writer =
+        new ByteStreamSplitValuesWriter.IntegerByteStreamSplitValuesWriter(
+            numElements * 4, numElements * 4, new DirectByteBufferAllocator());
+    for (int v : values) {
+      writer.writeInteger(v);
+    }
+
+    assertEquals(numElements * 4, writer.getBufferedSize());
+    BytesInput input = writer.getBytes();
+    assertEquals(numElements * 4, input.size());
+
+    ByteStreamSplitValuesReaderForInteger reader = new ByteStreamSplitValuesReaderForInteger();
+    reader.initFromPage(numElements, ByteBufferInputStream.wrap(input.toByteBuffer()));
+
+    for (int expectedValue : values) {
+      int newValue = reader.readInteger();
+      assertEquals(expectedValue, newValue);
+    }
+
+    writer.reset();
+    writer.close();
+  }
+
+  @Test
+  public void testLongPipeline() throws Exception {
+    // Generate random data.
+    Random rand = new Random(18990);
+    final int numElements = 1024;
+    long[] values = rand.longs(numElements).toArray();
+
+    // Encode data.
+    ByteStreamSplitValuesWriter.LongByteStreamSplitValuesWriter writer =
+        new ByteStreamSplitValuesWriter.LongByteStreamSplitValuesWriter(
+            numElements * 8, numElements * 8, new DirectByteBufferAllocator());
+    for (long v : values) {
+      writer.writeLong(v);
+    }
+
+    assertEquals(numElements * 8, writer.getBufferedSize());
+    BytesInput input = writer.getBytes();
+    assertEquals(numElements * 8, input.size());
+
+    ByteStreamSplitValuesReaderForLong reader = new ByteStreamSplitValuesReaderForLong();
+    reader.initFromPage(numElements, ByteBufferInputStream.wrap(input.toByteBuffer()));
+
+    for (long expectedValue : values) {
+      long newValue = reader.readLong();
+      assertEquals(expectedValue, newValue);
+    }
+
+    writer.reset();
+    writer.close();
+  }
+
+  @Test
+  public void testFixedLenByteArrayPipeline() throws Exception {
+    // Generate random data.
+    Random rand = new Random(18990);
+    final int numElements = 1024;
+    final int typeLength = 3;
+    byte[][] values = new byte[numElements][];
+    for (int i = 0; i < numElements; ++i) {
+      values[i] = new byte[typeLength];
+      rand.nextBytes(values[i]);
+    }
+
+    // Encode data.
+    ByteStreamSplitValuesWriter.FixedLenByteArrayByteStreamSplitValuesWriter writer =
+        new ByteStreamSplitValuesWriter.FixedLenByteArrayByteStreamSplitValuesWriter(
+            typeLength,
+            numElements * typeLength,
+            numElements * typeLength,
+            new DirectByteBufferAllocator());
+    for (byte[] v : values) {
+      writer.writeBytes(Binary.fromConstantByteArray(v));
+    }
+
+    assertEquals(numElements * typeLength, writer.getBufferedSize());
+    BytesInput input = writer.getBytes();
+    assertEquals(numElements * typeLength, input.size());
+
+    ByteStreamSplitValuesReaderForFLBA reader = new ByteStreamSplitValuesReaderForFLBA(typeLength);
+    reader.initFromPage(numElements, ByteBufferInputStream.wrap(input.toByteBuffer()));
+
+    Binary previousExpected = null, previousActual = null;
+    for (byte[] expectedValue : values) {
+      Binary expected = Binary.fromConstantByteArray(expectedValue);
+      Binary actual = reader.readBytes();
+      assertEquals(expected, actual);
+      if (previousExpected != null) {
+        // The latest readBytes() call shouldn't have clobbered the result of the previous call.
+        assertEquals(previousExpected, previousActual);
+      }
+      previousExpected = expected;
+      previousActual = actual;
     }
 
     writer.reset();

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactoryTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactoryTest.java
@@ -87,13 +87,21 @@ public class DefaultValuesWriterFactoryTest {
 
   @Test
   public void testFixedLenByteArray_WithByteStreamSplit() {
+    // No dictionary encoding for FLBA in Parquet 1.0
     doTestValueWriter(
         PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
         WriterVersion.PARQUET_1_0,
         true,
         false,
         true,
-        ByteStreamSplitValuesWriter.FixedLenByteArrayByteStreamSplitValuesWriter.class);
+        ByteStreamSplitValuesWriter.class);
+    doTestValueWriter(
+        PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+        WriterVersion.PARQUET_1_0,
+        true,
+        true,
+        false,
+        FixedLenByteArrayPlainValuesWriter.class);
   }
 
   @Test
@@ -110,38 +118,14 @@ public class DefaultValuesWriterFactoryTest {
 
   @Test
   public void testFixedLenByteArray_V2_WithByteStreamSplit() {
-    // DELTA_BYTE_ARRAY still selected by default
-    doTestValueWriter(
-        PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
-        WriterVersion.PARQUET_2_0,
-        true,
-        false,
-        true,
-        DictionaryValuesWriter.class,
-        ByteStreamSplitValuesWriter.class);
+    testExtendedByteStreamSplit(
+        PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, WriterVersion.PARQUET_2_0, DeltaByteArrayWriter.class);
   }
 
+  @Test
   public void testFixedLenByteArray_V2_WithByteStreamSplit_NoDict() {
-    doTestValueWriter(
-        PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
-        WriterVersion.PARQUET_2_0,
-        false,
-        false,
-        true,
-        DeltaByteArrayWriter.class);
-    LogicalTypeAnnotation[] logicalTypes = {
-      LogicalTypeAnnotation.float16Type(), LogicalTypeAnnotation.decimalType(4, 18)
-    };
-    for (LogicalTypeAnnotation logicalType : logicalTypes) {
-      ColumnDescriptor path = createColumnDescriptor(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, logicalType);
-      doTestValueWriter(
-          path,
-          WriterVersion.PARQUET_2_0,
-          false,
-          false,
-          true,
-          ByteStreamSplitValuesWriter.FixedLenByteArrayByteStreamSplitValuesWriter.class);
-    }
+    testExtendedByteStreamSplit_NoDict(
+        PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, WriterVersion.PARQUET_2_0, DeltaByteArrayWriter.class);
   }
 
   @Test
@@ -211,25 +195,12 @@ public class DefaultValuesWriterFactoryTest {
 
   @Test
   public void testInt32_ByteStreamSplit() {
-    doTestValueWriter(
-        PrimitiveTypeName.INT32,
-        WriterVersion.PARQUET_1_0,
-        true,
-        false,
-        true,
-        PlainIntegerDictionaryValuesWriter.class,
-        ByteStreamSplitValuesWriter.IntegerByteStreamSplitValuesWriter.class);
+    testExtendedByteStreamSplit(PrimitiveTypeName.INT32, WriterVersion.PARQUET_1_0, PlainValuesWriter.class);
   }
 
   @Test
   public void testInt32_ByteStreamSplit_NoDict() {
-    doTestValueWriter(
-        PrimitiveTypeName.INT32,
-        WriterVersion.PARQUET_1_0,
-        false,
-        false,
-        true,
-        ByteStreamSplitValuesWriter.IntegerByteStreamSplitValuesWriter.class);
+    testExtendedByteStreamSplit_NoDict(PrimitiveTypeName.INT32, WriterVersion.PARQUET_1_0, PlainValuesWriter.class);
   }
 
   @Test
@@ -255,26 +226,14 @@ public class DefaultValuesWriterFactoryTest {
         DeltaBinaryPackingValuesWriter.class);
   }
 
+  @Test
   public void testInt32_V2_ByteStreamSplit() {
-    doTestValueWriter(
-        PrimitiveTypeName.INT32,
-        WriterVersion.PARQUET_2_0,
-        true,
-        false,
-        true,
-        PlainIntegerDictionaryValuesWriter.class,
-        ByteStreamSplitValuesWriter.IntegerByteStreamSplitValuesWriter.class);
+    testExtendedByteStreamSplit(INT32, WriterVersion.PARQUET_2_0, DeltaBinaryPackingValuesWriter.class);
   }
 
   @Test
   public void testInt32_V2_ByteStreamSplit_NoDict() {
-    doTestValueWriter(
-        PrimitiveTypeName.INT32,
-        WriterVersion.PARQUET_2_0,
-        false,
-        false,
-        true,
-        ByteStreamSplitValuesWriter.IntegerByteStreamSplitValuesWriter.class);
+    testExtendedByteStreamSplit_NoDict(INT32, WriterVersion.PARQUET_2_0, DeltaBinaryPackingValuesWriter.class);
   }
 
   @Test
@@ -297,25 +256,12 @@ public class DefaultValuesWriterFactoryTest {
 
   @Test
   public void testInt64_ByteStreamSplit() {
-    doTestValueWriter(
-        PrimitiveTypeName.INT64,
-        WriterVersion.PARQUET_1_0,
-        true,
-        false,
-        true,
-        PlainLongDictionaryValuesWriter.class,
-        ByteStreamSplitValuesWriter.LongByteStreamSplitValuesWriter.class);
+    testExtendedByteStreamSplit(PrimitiveTypeName.INT64, WriterVersion.PARQUET_1_0, PlainValuesWriter.class);
   }
 
   @Test
   public void testInt64_ByteStreamSplit_NoDict() {
-    doTestValueWriter(
-        PrimitiveTypeName.INT64,
-        WriterVersion.PARQUET_1_0,
-        false,
-        false,
-        true,
-        ByteStreamSplitValuesWriter.LongByteStreamSplitValuesWriter.class);
+    testExtendedByteStreamSplit_NoDict(PrimitiveTypeName.INT64, WriterVersion.PARQUET_1_0, PlainValuesWriter.class);
   }
 
   @Test
@@ -343,25 +289,14 @@ public class DefaultValuesWriterFactoryTest {
 
   @Test
   public void testInt64_V2_ByteStreamSplit() {
-    doTestValueWriter(
-        PrimitiveTypeName.INT64,
-        WriterVersion.PARQUET_2_0,
-        true,
-        false,
-        true,
-        PlainLongDictionaryValuesWriter.class,
-        ByteStreamSplitValuesWriter.LongByteStreamSplitValuesWriter.class);
+    testExtendedByteStreamSplit(
+        PrimitiveTypeName.INT64, WriterVersion.PARQUET_2_0, DeltaBinaryPackingValuesWriter.class);
   }
 
   @Test
   public void testInt64_V2_ByteStreamSplit_NoDict() {
-    doTestValueWriter(
-        PrimitiveTypeName.INT64,
-        WriterVersion.PARQUET_1_0,
-        false,
-        false,
-        true,
-        ByteStreamSplitValuesWriter.LongByteStreamSplitValuesWriter.class);
+    testExtendedByteStreamSplit_NoDict(
+        PrimitiveTypeName.INT64, WriterVersion.PARQUET_2_0, DeltaBinaryPackingValuesWriter.class);
   }
 
   @Test
@@ -482,6 +417,153 @@ public class DefaultValuesWriterFactoryTest {
         PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_2_0, false, false, false, PlainValuesWriter.class);
   }
 
+  @Test
+  public void testFloat_V1_WithByteStreamSplit() {
+    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_1_0);
+  }
+
+  @Test
+  public void testDouble_V1_WithByteStreamSplit() {
+    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.DOUBLE, WriterVersion.PARQUET_1_0);
+  }
+
+  @Test
+  public void testFloat_V2_WithByteStreamSplit() {
+    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_2_0);
+  }
+
+  @Test
+  public void testDouble_V2_WithByteStreamSplit() {
+    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.DOUBLE, WriterVersion.PARQUET_2_0);
+  }
+
+  @Test
+  public void testFloat_V1_WithByteStreamSplitAndDictionary() {
+    testFloatingPoint_WithByteStreamSplitAndDictionary(PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_1_0);
+  }
+
+  @Test
+  public void testDouble_V1_WithByteStreamSplitAndDictionary() {
+    testFloatingPoint_WithByteStreamSplitAndDictionary(PrimitiveTypeName.DOUBLE, WriterVersion.PARQUET_1_0);
+  }
+
+  @Test
+  public void testFloat_V2_WithByteStreamSplitAndDictionary() {
+    testFloatingPoint_WithByteStreamSplitAndDictionary(PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_2_0);
+  }
+
+  @Test
+  public void testDouble_V2_WithByteStreamSplitAndDictionary() {
+    testFloatingPoint_WithByteStreamSplitAndDictionary(PrimitiveTypeName.DOUBLE, WriterVersion.PARQUET_2_0);
+  }
+
+  @Test
+  public void testColumnWiseDictionaryWithFalseDefault() {
+    ValuesWriterFactory factory = getDefaultFactory(
+        WriterVersion.PARQUET_2_0, false, "binary_dict", "boolean_dict", "float_dict", "int32_dict");
+    validateFactory(
+        factory, BINARY, "binary_dict", PlainBinaryDictionaryValuesWriter.class, DeltaByteArrayWriter.class);
+    validateFactory(factory, BINARY, "binary_no_dict", DeltaByteArrayWriter.class);
+    validateFactory(factory, BOOLEAN, "boolean_dict", RunLengthBitPackingHybridValuesWriter.class);
+    validateFactory(factory, BOOLEAN, "boolean_no_dict", RunLengthBitPackingHybridValuesWriter.class);
+    validateFactory(factory, FLOAT, "float_dict", PlainFloatDictionaryValuesWriter.class, PlainValuesWriter.class);
+    validateFactory(factory, FLOAT, "float_no_dict", PlainValuesWriter.class);
+    validateFactory(
+        factory,
+        INT32,
+        "int32_dict",
+        PlainIntegerDictionaryValuesWriter.class,
+        DeltaBinaryPackingValuesWriter.class);
+    validateFactory(factory, INT32, "int32_no_dict", DeltaBinaryPackingValuesWriter.class);
+  }
+
+  @Test
+  public void testColumnWiseDictionaryWithTrueDefault() {
+    ValuesWriterFactory factory = getDefaultFactory(
+        WriterVersion.PARQUET_2_0, true, "binary_no_dict", "boolean_no_dict", "float_no_dict", "int32_no_dict");
+    validateFactory(
+        factory, BINARY, "binary_dict", PlainBinaryDictionaryValuesWriter.class, DeltaByteArrayWriter.class);
+    validateFactory(factory, BINARY, "binary_no_dict", DeltaByteArrayWriter.class);
+    validateFactory(factory, BOOLEAN, "boolean_dict", RunLengthBitPackingHybridValuesWriter.class);
+    validateFactory(factory, BOOLEAN, "boolean_no_dict", RunLengthBitPackingHybridValuesWriter.class);
+    validateFactory(factory, FLOAT, "float_dict", PlainFloatDictionaryValuesWriter.class, PlainValuesWriter.class);
+    validateFactory(factory, FLOAT, "float_no_dict", PlainValuesWriter.class);
+    validateFactory(
+        factory,
+        INT32,
+        "int32_dict",
+        PlainIntegerDictionaryValuesWriter.class,
+        DeltaBinaryPackingValuesWriter.class);
+    validateFactory(factory, INT32, "int32_no_dict", DeltaBinaryPackingValuesWriter.class);
+  }
+
+  private void testExtendedByteStreamSplit(
+      PrimitiveTypeName typeName,
+      WriterVersion writerVersion,
+      Class<? extends ValuesWriter> defaultFallbackWriterClass) {
+    // cross-column settings
+    doTestValueWriter(
+        createColumnDescriptor(typeName),
+        ParquetProperties.builder()
+            .withWriterVersion(writerVersion)
+            .withExtendedByteStreamSplitEncoding(true)
+            .build(),
+        DictionaryValuesWriter.class,
+        ByteStreamSplitValuesWriter.class);
+    doTestValueWriter(
+        createColumnDescriptor(typeName),
+        ParquetProperties.builder()
+            .withWriterVersion(writerVersion)
+            .withByteStreamSplitEncoding(true)
+            .build(),
+        DictionaryValuesWriter.class,
+        defaultFallbackWriterClass);
+    // per-column settings
+    ParquetProperties properties = ParquetProperties.builder()
+        .withWriterVersion(writerVersion)
+        .withByteStreamSplitEncoding("colA", true)
+        .build();
+    doTestValueWriter(
+        createColumnDescriptor(typeName, "colA"),
+        properties,
+        DictionaryValuesWriter.class,
+        ByteStreamSplitValuesWriter.class);
+    doTestValueWriter(
+        createColumnDescriptor(typeName, "colB"),
+        properties,
+        DictionaryValuesWriter.class,
+        defaultFallbackWriterClass);
+  }
+
+  private void testExtendedByteStreamSplit_NoDict(
+      PrimitiveTypeName typeName, WriterVersion writerVersion, Class<? extends ValuesWriter> defaultWriterClass) {
+    // cross-column settings
+    doTestValueWriter(
+        createColumnDescriptor(typeName),
+        ParquetProperties.builder()
+            .withWriterVersion(writerVersion)
+            .withDictionaryEncoding(false)
+            .withExtendedByteStreamSplitEncoding(true)
+            .build(),
+        ByteStreamSplitValuesWriter.class);
+    doTestValueWriter(
+        createColumnDescriptor(typeName),
+        ParquetProperties.builder()
+            .withWriterVersion(writerVersion)
+            .withDictionaryEncoding(false)
+            .withByteStreamSplitEncoding(true)
+            .build(),
+        defaultWriterClass);
+    // per-column settings
+    ParquetProperties properties = ParquetProperties.builder()
+        .withWriterVersion(writerVersion)
+        .withDictionaryEncoding(false)
+        .withByteStreamSplitEncoding("colA", true)
+        .build();
+    doTestValueWriter(createColumnDescriptor(typeName, "colA"), properties, ByteStreamSplitValuesWriter.class);
+    doTestValueWriter(createColumnDescriptor(typeName, "colB"), properties, defaultWriterClass);
+  }
+
   private void testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName typeName, WriterVersion writerVersion) {
     // With cross-column settings
     doTestValueWriter(
@@ -544,86 +626,6 @@ public class DefaultValuesWriterFactoryTest {
         properties,
         DictionaryValuesWriter.class,
         PlainValuesWriter.class);
-  }
-
-  @Test
-  public void testFloat_V1_WithByteStreamSplit() {
-    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_1_0);
-  }
-
-  @Test
-  public void testDouble_V1_WithByteStreamSplit() {
-    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.DOUBLE, WriterVersion.PARQUET_1_0);
-  }
-
-  @Test
-  public void testFloat_V2_WithByteStreamSplit() {
-    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_2_0);
-  }
-
-  @Test
-  public void testDouble_V2_WithByteStreamSplit() {
-    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.DOUBLE, WriterVersion.PARQUET_2_0);
-  }
-
-  @Test
-  public void testFloat_V1_WithByteStreamSplitAndDictionary() {
-    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_1_0);
-  }
-
-  @Test
-  public void testDouble_V1_WithByteStreamSplitAndDictionary() {
-    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.DOUBLE, WriterVersion.PARQUET_1_0);
-  }
-
-  @Test
-  public void testFloat_V2_WithByteStreamSplitAndDictionary() {
-    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_2_0);
-  }
-
-  @Test
-  public void testDouble_V2_WithByteStreamSplitAndDictionary() {
-    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.DOUBLE, WriterVersion.PARQUET_2_0);
-  }
-
-  @Test
-  public void testColumnWiseDictionaryWithFalseDefault() {
-    ValuesWriterFactory factory = getDefaultFactory(
-        WriterVersion.PARQUET_2_0, false, "binary_dict", "boolean_dict", "float_dict", "int32_dict");
-    validateFactory(
-        factory, BINARY, "binary_dict", PlainBinaryDictionaryValuesWriter.class, DeltaByteArrayWriter.class);
-    validateFactory(factory, BINARY, "binary_no_dict", DeltaByteArrayWriter.class);
-    validateFactory(factory, BOOLEAN, "boolean_dict", RunLengthBitPackingHybridValuesWriter.class);
-    validateFactory(factory, BOOLEAN, "boolean_no_dict", RunLengthBitPackingHybridValuesWriter.class);
-    validateFactory(factory, FLOAT, "float_dict", PlainFloatDictionaryValuesWriter.class, PlainValuesWriter.class);
-    validateFactory(factory, FLOAT, "float_no_dict", PlainValuesWriter.class);
-    validateFactory(
-        factory,
-        INT32,
-        "int32_dict",
-        PlainIntegerDictionaryValuesWriter.class,
-        DeltaBinaryPackingValuesWriter.class);
-    validateFactory(factory, INT32, "int32_no_dict", DeltaBinaryPackingValuesWriter.class);
-  }
-
-  @Test
-  public void testColumnWiseDictionaryWithTrueDefault() {
-    ValuesWriterFactory factory = getDefaultFactory(
-        WriterVersion.PARQUET_2_0, true, "binary_no_dict", "boolean_no_dict", "float_no_dict", "int32_no_dict");
-    validateFactory(
-        factory, BINARY, "binary_dict", PlainBinaryDictionaryValuesWriter.class, DeltaByteArrayWriter.class);
-    validateFactory(factory, BINARY, "binary_no_dict", DeltaByteArrayWriter.class);
-    validateFactory(factory, BOOLEAN, "boolean_dict", RunLengthBitPackingHybridValuesWriter.class);
-    validateFactory(factory, BOOLEAN, "boolean_no_dict", RunLengthBitPackingHybridValuesWriter.class);
-    validateFactory(factory, FLOAT, "float_dict", PlainFloatDictionaryValuesWriter.class, PlainValuesWriter.class);
-    validateFactory(factory, FLOAT, "float_no_dict", PlainValuesWriter.class);
-    validateFactory(
-        factory,
-        INT32,
-        "int32_dict",
-        PlainIntegerDictionaryValuesWriter.class,
-        DeltaBinaryPackingValuesWriter.class);
-    validateFactory(factory, INT32, "int32_no_dict", DeltaBinaryPackingValuesWriter.class);
   }
 
   private void validateFactory(
@@ -789,7 +791,10 @@ public class DefaultValuesWriterFactoryTest {
   }
 
   private void validateWriterType(ValuesWriter writer, Class<? extends ValuesWriter> valuesWriterClass) {
-    assertTrue("Not instance of: " + valuesWriterClass.getName(), valuesWriterClass.isInstance(writer));
+    assertTrue(
+        "Not instance of " + valuesWriterClass.getName() + ": actual class is "
+            + writer.getClass().getName(),
+        valuesWriterClass.isInstance(writer));
   }
 
   private void validateFallbackWriter(

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactoryTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactoryTest.java
@@ -118,22 +118,7 @@ public class DefaultValuesWriterFactoryTest {
         false,
         true,
         DictionaryValuesWriter.class,
-        DeltaByteArrayWriter.class);
-    // Some logical types select BYTE_STREAM_SPLIT as a heuristic
-    LogicalTypeAnnotation[] logicalTypes = {
-      LogicalTypeAnnotation.float16Type(), LogicalTypeAnnotation.decimalType(4, 18)
-    };
-    for (LogicalTypeAnnotation logicalType : logicalTypes) {
-      ColumnDescriptor path = createColumnDescriptor(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, logicalType);
-      doTestValueWriter(
-          path,
-          WriterVersion.PARQUET_2_0,
-          true,
-          false,
-          true,
-          DictionaryValuesWriter.class,
-          ByteStreamSplitValuesWriter.FixedLenByteArrayByteStreamSplitValuesWriter.class);
-    }
+        ByteStreamSplitValuesWriter.class);
   }
 
   public void testFixedLenByteArray_V2_WithByteStreamSplit_NoDict() {
@@ -497,96 +482,108 @@ public class DefaultValuesWriterFactoryTest {
         PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_2_0, false, false, false, PlainValuesWriter.class);
   }
 
+  private void testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName typeName, WriterVersion writerVersion) {
+    // With cross-column settings
+    doTestValueWriter(
+        createColumnDescriptor(typeName),
+        ParquetProperties.builder()
+            .withWriterVersion(writerVersion)
+            .withDictionaryEncoding(false)
+            .withByteStreamSplitEncoding(true)
+            .build(),
+        ByteStreamSplitValuesWriter.class);
+    doTestValueWriter(
+        createColumnDescriptor(typeName),
+        ParquetProperties.builder()
+            .withWriterVersion(writerVersion)
+            .withDictionaryEncoding(false)
+            .withExtendedByteStreamSplitEncoding(true)
+            .build(),
+        ByteStreamSplitValuesWriter.class);
+    // With per-column settings
+    ParquetProperties properties = ParquetProperties.builder()
+        .withWriterVersion(writerVersion)
+        .withDictionaryEncoding(false)
+        .withByteStreamSplitEncoding("colA", true)
+        .build();
+    doTestValueWriter(createColumnDescriptor(typeName, "colA"), properties, ByteStreamSplitValuesWriter.class);
+    doTestValueWriter(createColumnDescriptor(typeName, "colB"), properties, PlainValuesWriter.class);
+  }
+
+  private void testFloatingPoint_WithByteStreamSplitAndDictionary(
+      PrimitiveTypeName typeName, WriterVersion writerVersion) {
+    // With cross-column settings
+    doTestValueWriter(
+        createColumnDescriptor(typeName),
+        ParquetProperties.builder()
+            .withWriterVersion(writerVersion)
+            .withByteStreamSplitEncoding(true)
+            .build(),
+        DictionaryValuesWriter.class,
+        ByteStreamSplitValuesWriter.class);
+    doTestValueWriter(
+        createColumnDescriptor(typeName),
+        ParquetProperties.builder()
+            .withWriterVersion(writerVersion)
+            .withExtendedByteStreamSplitEncoding(true)
+            .build(),
+        DictionaryValuesWriter.class,
+        ByteStreamSplitValuesWriter.class);
+    // With per-column settings
+    ParquetProperties properties = ParquetProperties.builder()
+        .withWriterVersion(writerVersion)
+        .withByteStreamSplitEncoding("colA", true)
+        .build();
+    doTestValueWriter(
+        createColumnDescriptor(typeName, "colA"),
+        properties,
+        DictionaryValuesWriter.class,
+        ByteStreamSplitValuesWriter.class);
+    doTestValueWriter(
+        createColumnDescriptor(typeName, "colB"),
+        properties,
+        DictionaryValuesWriter.class,
+        PlainValuesWriter.class);
+  }
+
   @Test
   public void testFloat_V1_WithByteStreamSplit() {
-    doTestValueWriter(
-        PrimitiveTypeName.FLOAT,
-        WriterVersion.PARQUET_1_0,
-        false,
-        true,
-        false,
-        ByteStreamSplitValuesWriter.class);
+    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_1_0);
   }
 
   @Test
   public void testDouble_V1_WithByteStreamSplit() {
-    doTestValueWriter(
-        PrimitiveTypeName.DOUBLE,
-        WriterVersion.PARQUET_1_0,
-        false,
-        true,
-        false,
-        ByteStreamSplitValuesWriter.class);
+    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.DOUBLE, WriterVersion.PARQUET_1_0);
   }
 
   @Test
   public void testFloat_V2_WithByteStreamSplit() {
-    doTestValueWriter(
-        PrimitiveTypeName.FLOAT,
-        WriterVersion.PARQUET_2_0,
-        false,
-        true,
-        false,
-        ByteStreamSplitValuesWriter.class);
+    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_2_0);
   }
 
   @Test
   public void testDouble_V2_WithByteStreamSplit() {
-    doTestValueWriter(
-        PrimitiveTypeName.DOUBLE,
-        WriterVersion.PARQUET_2_0,
-        false,
-        true,
-        false,
-        ByteStreamSplitValuesWriter.class);
+    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.DOUBLE, WriterVersion.PARQUET_2_0);
   }
 
   @Test
   public void testFloat_V1_WithByteStreamSplitAndDictionary() {
-    doTestValueWriter(
-        PrimitiveTypeName.FLOAT,
-        WriterVersion.PARQUET_1_0,
-        true,
-        true,
-        false,
-        PlainFloatDictionaryValuesWriter.class,
-        ByteStreamSplitValuesWriter.class);
+    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_1_0);
   }
 
   @Test
   public void testDouble_V1_WithByteStreamSplitAndDictionary() {
-    doTestValueWriter(
-        PrimitiveTypeName.DOUBLE,
-        WriterVersion.PARQUET_1_0,
-        true,
-        true,
-        false,
-        PlainDoubleDictionaryValuesWriter.class,
-        ByteStreamSplitValuesWriter.class);
+    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.DOUBLE, WriterVersion.PARQUET_1_0);
   }
 
   @Test
   public void testFloat_V2_WithByteStreamSplitAndDictionary() {
-    doTestValueWriter(
-        PrimitiveTypeName.FLOAT,
-        WriterVersion.PARQUET_2_0,
-        true,
-        true,
-        false,
-        PlainFloatDictionaryValuesWriter.class,
-        ByteStreamSplitValuesWriter.class);
+    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.FLOAT, WriterVersion.PARQUET_2_0);
   }
 
   @Test
   public void testDouble_V2_WithByteStreamSplitAndDictionary() {
-    doTestValueWriter(
-        PrimitiveTypeName.DOUBLE,
-        WriterVersion.PARQUET_2_0,
-        true,
-        true,
-        false,
-        PlainDoubleDictionaryValuesWriter.class,
-        ByteStreamSplitValuesWriter.class);
+    testFloatingPoint_WithByteStreamSplit(PrimitiveTypeName.DOUBLE, WriterVersion.PARQUET_2_0);
   }
 
   @Test
@@ -715,6 +712,25 @@ public class DefaultValuesWriterFactoryTest {
     validateFallbackWriter(writer, initialValueWriterClass, fallbackValueWriterClass);
   }
 
+  private void doTestValueWriter(
+      ColumnDescriptor path,
+      ParquetProperties properties,
+      Class<? extends ValuesWriter> initialValueWriterClass,
+      Class<? extends ValuesWriter> fallbackValueWriterClass) {
+    ValuesWriterFactory factory = getDefaultFactory(properties);
+    ValuesWriter writer = factory.newValuesWriter(path);
+    validateFallbackWriter(writer, initialValueWriterClass, fallbackValueWriterClass);
+  }
+
+  private void doTestValueWriter(
+      ColumnDescriptor path,
+      ParquetProperties properties,
+      Class<? extends ValuesWriter> expectedValueWriterClass) {
+    ValuesWriterFactory factory = getDefaultFactory(properties);
+    ValuesWriter writer = factory.newValuesWriter(path);
+    validateWriterType(writer, expectedValueWriterClass);
+  }
+
   private ColumnDescriptor createColumnDescriptor(PrimitiveTypeName typeName) {
     return createColumnDescriptor(typeName, (LogicalTypeAnnotation) null);
   }
@@ -739,6 +755,7 @@ public class DefaultValuesWriterFactoryTest {
       boolean enableByteStreamSplit,
       boolean enableExtendedByteStreamSplit) {
     ValuesWriterFactory factory = new DefaultValuesWriterFactory();
+    // Initialize factory with the given properties
     ParquetProperties.builder()
         .withDictionaryEncoding(enableDictionary)
         .withByteStreamSplitEncoding(enableByteStreamSplit)
@@ -747,6 +764,12 @@ public class DefaultValuesWriterFactoryTest {
         .withValuesWriterFactory(factory)
         .build();
 
+    return factory;
+  }
+
+  private ValuesWriterFactory getDefaultFactory(ParquetProperties properties) {
+    ValuesWriterFactory factory = new DefaultValuesWriterFactory();
+    factory.initialize(properties);
     return factory;
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInterOpReadByteStreamSplit.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInterOpReadByteStreamSplit.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 public class TestInterOpReadByteStreamSplit {
   private static final String FLOATS_FILE = "byte_stream_split.zstd.parquet";
   private static final String EXTENDED_FILE = "byte_stream_split_extended.gzip.parquet";
-  // FIXME after https://github.com/apache/parquet-testing/pull/46 is merged
   private static final String CHANGESET = "74278bc";
   private final InterOpTester interop = new InterOpTester();
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInterOpReadByteStreamSplit.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInterOpReadByteStreamSplit.java
@@ -20,18 +20,23 @@
 package org.apache.parquet.hadoop;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroup;
 import org.apache.parquet.hadoop.example.GroupReadSupport;
 import org.junit.Test;
 
 public class TestInterOpReadByteStreamSplit {
-  private InterOpTester interop = new InterOpTester();
   private static final String FLOATS_FILE = "byte_stream_split.zstd.parquet";
-  private static final String CHANGESET = "4cb3cff";
+  private static final String EXTENDED_FILE = "byte_stream_split_extended.gzip.parquet";
+  // FIXME after https://github.com/apache/parquet-testing/pull/46 is merged
+  private static final String CHANGESET = "74278bc";
+  private final InterOpTester interop = new InterOpTester();
 
   @Test
   public void testReadFloats() throws IOException {
@@ -42,7 +47,7 @@ public class TestInterOpReadByteStreamSplit {
         ParquetReader.builder(new GroupReadSupport(), floatsFile).build()) {
       for (int i = 0; i < expectRows; ++i) {
         Group group = reader.read();
-        assertTrue(group != null);
+        assertNotNull(group);
         float fval = group.getFloat("f32", 0);
         double dval = group.getDouble("f64", 0);
         // Values are from the normal distribution
@@ -67,7 +72,34 @@ public class TestInterOpReadByteStreamSplit {
             break;
         }
       }
-      assertTrue(reader.read() == null);
+      assertNull(reader.read());
     }
+  }
+
+  private void compareColumnValues(Path path, int expectRows, String leftCol, String rightCol) throws IOException {
+    try (ParquetReader<Group> reader =
+        ParquetReader.builder(new GroupReadSupport(), path).build()) {
+      for (int i = 0; i < expectRows; ++i) {
+        SimpleGroup group = (SimpleGroup) reader.read();
+        assertNotNull(group);
+        Object left = group.getObject(leftCol, 0);
+        Object right = group.getObject(rightCol, 0);
+        assertEquals(left, right);
+      }
+      assertNull(reader.read());
+    }
+  }
+
+  @Test
+  public void testReadAllSupportedTypes() throws IOException {
+    Path extendedFile = interop.GetInterOpFile(EXTENDED_FILE, CHANGESET);
+    final int expectRows = 200;
+    compareColumnValues(extendedFile, expectRows, "float_plain", "float_byte_stream_split");
+    compareColumnValues(extendedFile, expectRows, "double_plain", "double_byte_stream_split");
+    compareColumnValues(extendedFile, expectRows, "int32_plain", "int32_byte_stream_split");
+    compareColumnValues(extendedFile, expectRows, "int64_plain", "int64_byte_stream_split");
+    compareColumnValues(extendedFile, expectRows, "float16_plain", "float16_byte_stream_split");
+    compareColumnValues(extendedFile, expectRows, "flba5_plain", "flba5_byte_stream_split");
+    compareColumnValues(extendedFile, expectRows, "decimal_plain", "decimal_byte_stream_split");
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -595,6 +595,8 @@
               <exclude>org.apache.parquet.hadoop.thrift.TBaseWriteSupport#setThriftClass(org.apache.parquet.conf.ParquetConfiguration,java.lang.Class)</exclude>
               <exclude>org.apache.parquet.proto.ProtoParquetReader#builder(org.apache.hadoop.fs.Path,boolean)</exclude>
               <exclude>org.apache.parquet.proto.ProtoParquetReader#builder(org.apache.parquet.io.InputFile,boolean)</exclude>
+              <!-- removal of a protected method in a class that's not supposed to be subclassed by third-party code -->
+              <exclude>org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesReader#gatherElementDataFromStreams(byte[])</exclude>
 
               <!-- Due to the removal of deprecated methods -->
               <exclude>org.apache.parquet.arrow.schema.SchemaMapping</exclude>


### PR DESCRIPTION
Implement the format additions described in PARQUET-2414.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET-2451) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-2451
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
