### PR TITLE
PARQUET-2446:  ProtoParquetWriter support dynamic message

### DIFF
--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoParquetWriter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.proto;
 
+import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
 import java.io.IOException;
@@ -115,8 +116,14 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
     return new ProtoWriteSupport<>(protoMessage);
   }
 
+  private static <T extends MessageOrBuilder> WriteSupport<T> writeSupport(Descriptors.Descriptor descriptor) {
+    return new ProtoWriteSupport<>(descriptor);
+  }
+
   public static class Builder<T> extends ParquetWriter.Builder<T, Builder<T>> {
     Class<? extends Message> protoMessage = null;
+
+    private Descriptors.Descriptor descriptor = null;
 
     private Builder(Path file) {
       super(file);
@@ -135,6 +142,11 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
       return this;
     }
 
+    public Builder<T> withDescriptor(Descriptors.Descriptor descriptor) {
+      this.descriptor = descriptor;
+      return this;
+    }
+
     @Override
     protected WriteSupport<T> getWriteSupport(Configuration conf) {
       return getWriteSupport((ParquetConfiguration) null);
@@ -143,6 +155,9 @@ public class ProtoParquetWriter<T extends MessageOrBuilder> extends ParquetWrite
     @Override
     @SuppressWarnings("unchecked")
     protected WriteSupport<T> getWriteSupport(ParquetConfiguration conf) {
+      if (this.descriptor != null) {
+        return (WriteSupport<T>) ProtoParquetWriter.writeSupport(descriptor);
+      }
       return (WriteSupport<T>) ProtoParquetWriter.writeSupport(protoMessage);
     }
   }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoParquetWriterTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoParquetWriterTest.java
@@ -1,0 +1,43 @@
+package org.apache.parquet.proto;
+
+import static org.apache.parquet.proto.TestUtils.readMessages;
+import static org.apache.parquet.proto.TestUtils.someTemporaryFilePath;
+import static org.junit.Assert.assertEquals;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.ParquetFileWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.proto.test.TestProto3;
+import org.junit.Test;
+
+public class ProtoParquetWriterTest {
+  @Test
+  public void testProtoParquetWriterWithDynamicMessage() throws Exception {
+    Path file = someTemporaryFilePath();
+    Descriptors.Descriptor descriptor = TestProto3.InnerMessage.getDescriptor();
+    TestProto3.InnerMessage.Builder msg = TestProto3.InnerMessage.newBuilder();
+    msg.setOne("oneValue");
+    DynamicMessage dynamicMessage = DynamicMessage.newBuilder(msg.build()).build();
+
+    Configuration conf = new Configuration();
+    ParquetWriter<DynamicMessage> writer = ProtoParquetWriter.<DynamicMessage>builder(file)
+        .withDescriptor(descriptor)
+        .withConf(conf)
+        .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
+        .build();
+    writer.write(dynamicMessage);
+    writer.close();
+
+    readMessages(file, TestProto3.InnerMessage.class);
+    List<TestProto3.InnerMessage> gotBack = TestUtils.readMessages(file, TestProto3.InnerMessage.class);
+
+    TestProto3.InnerMessage getFirst = gotBack.get(0);
+    assertEquals(getFirst.getOne(), "oneValue");
+    assertEquals(getFirst.getTwo(), "");
+    assertEquals(getFirst.getThree(), "");
+  }
+}

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoParquetWriterTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoParquetWriterTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.parquet.proto;
 
 import static org.apache.parquet.proto.TestUtils.readMessages;


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET-2446) issues and references them in the PR title. For example, "ProtoParquetWriter doesn't Support DynamicMessage"

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:this change is simple and only affects the ProtoParquetWriter Builder function


### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does

