### PR TITLE
PARQUET-2449: Limit local buffer to be similar to Hadoop writing

### DIFF
--- a/parquet-common/src/main/java/org/apache/parquet/io/LocalOutputFile.java
+++ b/parquet-common/src/main/java/org/apache/parquet/io/LocalOutputFile.java
@@ -30,6 +30,8 @@ import java.nio.file.StandardOpenOption;
  */
 public class LocalOutputFile implements OutputFile {
 
+  private static final int BUFFER_SIZE_DEFAULT = 4096;
+
   private class LocalPositionOutputStream extends PositionOutputStream {
 
     private final BufferedOutputStream stream;
@@ -80,24 +82,24 @@ public class LocalOutputFile implements OutputFile {
   }
 
   @Override
-  public PositionOutputStream create(long buffer) throws IOException {
-    return new LocalPositionOutputStream((int) buffer, StandardOpenOption.CREATE_NEW);
+  public PositionOutputStream create(long blockSize) throws IOException {
+    return new LocalPositionOutputStream(BUFFER_SIZE_DEFAULT, StandardOpenOption.CREATE_NEW);
   }
 
   @Override
-  public PositionOutputStream createOrOverwrite(long buffer) throws IOException {
+  public PositionOutputStream createOrOverwrite(long blockSize) throws IOException {
     return new LocalPositionOutputStream(
-        (int) buffer, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        BUFFER_SIZE_DEFAULT, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
   }
 
   @Override
   public boolean supportsBlockSize() {
-    return true;
+    return false;
   }
 
   @Override
   public long defaultBlockSize() {
-    return 512;
+    return -1;
   }
 
   @Override


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-XXX
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [ ] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does

---

The implementation mixed up block and buffer sizes
