### PR TITLE
PARQUET-2458: Use --release 8 with java compiler

### DIFF
--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -78,6 +78,12 @@
       <artifactId>hadoop-annotations</artifactId>
       <version>${hadoop.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>

--- a/parquet-plugins/parquet-encoding-vector/pom.xml
+++ b/parquet-plugins/parquet-encoding-vector/pom.xml
@@ -35,6 +35,7 @@
   <url>https://parquet.apache.org</url>
 
   <properties>
+    <maven.compiler.release>17</maven.compiler.release>
     <extraJavaVectorArgs>
       --add-modules=jdk.incubator.vector
     </extraJavaVectorArgs>
@@ -73,7 +74,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <release>17</release>
           <compilerArgs combine.children="append">
             <compilerArg>${extraJavaVectorArgs}</compilerArg>
           </compilerArgs>

--- a/parquet-plugins/parquet-encoding-vector/pom.xml
+++ b/parquet-plugins/parquet-encoding-vector/pom.xml
@@ -35,10 +35,9 @@
   <url>https://parquet.apache.org</url>
 
   <properties>
-    <maven.compiler.release>17</maven.compiler.release>
-    <extraJavaVectorArgs>
-      --add-modules=jdk.incubator.vector
-    </extraJavaVectorArgs>
+    <!-- Those properties prevent java 8 to try and compile this code -->
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -124,4 +123,19 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>jdk9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <!-- release takes precedence over source/target if java version is 9 or higher -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <extraJavaVectorArgs>
+          --add-modules=jdk.incubator.vector
+        </extraJavaVectorArgs>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/parquet-plugins/parquet-encoding-vector/pom.xml
+++ b/parquet-plugins/parquet-encoding-vector/pom.xml
@@ -97,6 +97,14 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <additionalJOption>${extraJavaVectorArgs}</additionalJOption>>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.5.2</version>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,6 @@
   </repositories>
 
   <properties>
-    <!-- release takes precedence over source/target if java version is 9 or higher -->
-    <maven.compiler.release>8</maven.compiler.release>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <github.global.server>github</github.global.server>
@@ -649,6 +647,17 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>jdk9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <!-- release takes precedence over source/target if java version is 9 or higher -->
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
+    </profile>
+
     <profile>
       <id>hadoop2</id>
       <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,7 @@
   </repositories>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
     <github.global.server>github</github.global.server>
     <jackson.groupId>com.fasterxml.jackson.core</jackson.groupId>
     <jackson.datatype.groupId>com.fasterxml.jackson.datatype</jackson.datatype.groupId>
@@ -97,6 +96,8 @@
     <powermock.version>2.0.9</powermock.version>
     <net.openhft.version>0.16</net.openhft.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+    <!-- override org.apache:apache version -->
+    <version.maven-compiler-plugin>3.13.0</version.maven-compiler-plugin>
 
     <!-- parquet-cli dependencies -->
     <opencsv.version>2.3</opencsv.version>
@@ -412,11 +413,6 @@
         <!-- Override source and target from the ASF parent -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <argLine>-XX:MaxPermSize=256m</argLine>
-          <source>${maven.compiler.source}</source>
-          <target>${maven.compiler.target}</target>
-        </configuration>
       </plugin>
 
       <plugin>
@@ -664,21 +660,6 @@
         <surefire.logLevel>INFO</surefire.logLevel>
         <surefire.argLine>-XX:MaxJavaStackTraceDepth=1024</surefire.argLine>
       </properties>
-    </profile>
-
-    <profile>
-      <id>jdk9+</id>
-      <activation>
-        <jdk>[1.9,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
 
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,10 @@
   </repositories>
 
   <properties>
+    <!-- release takes precedence over source/target if java version is 9 or higher -->
     <maven.compiler.release>8</maven.compiler.release>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <github.global.server>github</github.global.server>
     <jackson.groupId>com.fasterxml.jackson.core</jackson.groupId>
     <jackson.datatype.groupId>com.fasterxml.jackson.datatype</jackson.datatype.groupId>


### PR DESCRIPTION
Update maven-compiler-plugin to 3.13.0 version and use `maven.compiler.release` property instead of
`maven.compiler.{source|target}` to set which Java version to target.

Also remove argLine configuration entry from the plugin
- argLine is not a valid option (it's compilerArgs)
- XX:MaxPermSize has been ignored since java 8

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET-2458) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-XXX
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: no new test needed (no bugfix/new features ; change covered by existing tests)

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
