### PR TITLE
PARQUET-2459: parquet-hadoop tests to work with hadoop 3.4.0

### DIFF
--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -67,6 +67,28 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-reload4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Removes all log dependencies from hadoop-common, so test runs
do not get confused.

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-2459
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: it's dependency tuning to fix test runs with -Dhadoop.version=3.4.0

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [X] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
