### PR TITLE
PARQUET-2465: Fall back to HadoopConfig (#1339)

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -495,7 +495,9 @@ public class ParquetWriter<T> implements Closeable {
     /**
      * @param conf a configuration
      * @return an appropriate WriteSupport for the object model.
+     * @deprecated Use {@link #getWriteSupport(ParquetConfiguration)} instead
      */
+    @Deprecated
     protected abstract WriteSupport<T> getWriteSupport(Configuration conf);
 
     /**
@@ -503,8 +505,7 @@ public class ParquetWriter<T> implements Closeable {
      * @return an appropriate WriteSupport for the object model.
      */
     protected WriteSupport<T> getWriteSupport(ParquetConfiguration conf) {
-      throw new UnsupportedOperationException(
-          "Override ParquetWriter$Builder#getWriteSupport(ParquetConfiguration)");
+      return getWriteSupport(ConfigurationUtil.createHadoopConfiguration(conf));
     }
 
     /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/InitContext.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/InitContext.java
@@ -79,7 +79,9 @@ public class InitContext {
 
   /**
    * @return the configuration for this job
+   * @deprecated Use {@link #getParquetConfiguration()} instead
    */
+  @Deprecated
   public Configuration getConfiguration() {
     return ConfigurationUtil.createHadoopConfiguration(configuration);
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/ReadSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/ReadSupport.java
@@ -21,6 +21,7 @@ package org.apache.parquet.hadoop.api;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.conf.ParquetConfiguration;
+import org.apache.parquet.hadoop.util.ConfigurationUtil;
 import org.apache.parquet.io.api.RecordMaterializer;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
@@ -76,12 +77,12 @@ public abstract class ReadSupport<T> {
    * @param keyValueMetaData the app specific metadata from the file
    * @param fileSchema       the schema of the file
    * @return the readContext that defines how to read the file
-   * @deprecated override {@link ReadSupport#init(InitContext)} instead
+   * @deprecated override {@link #init(InitContext)} instead
    */
   @Deprecated
   public ReadContext init(
       ParquetConfiguration configuration, Map<String, String> keyValueMetaData, MessageType fileSchema) {
-    throw new UnsupportedOperationException("Override ReadSupport.init(InitContext)");
+    return init(ConfigurationUtil.createHadoopConfiguration(configuration), keyValueMetaData, fileSchema);
   }
 
   /**
@@ -103,7 +104,9 @@ public abstract class ReadSupport<T> {
    * @param fileSchema       the schema of the file
    * @param readContext      returned by the init method
    * @return the recordMaterializer that will materialize the records
+   * @deprecated override {@link #prepareForRead(ParquetConfiguration,Map,MessageType,ReadContext)} instead
    */
+  @Deprecated
   public abstract RecordMaterializer<T> prepareForRead(
       Configuration configuration,
       Map<String, String> keyValueMetaData,
@@ -125,8 +128,8 @@ public abstract class ReadSupport<T> {
       Map<String, String> keyValueMetaData,
       MessageType fileSchema,
       ReadContext readContext) {
-    throw new UnsupportedOperationException(
-        "Override ReadSupport.prepareForRead(ParquetConfiguration, Map<String, String>, MessageType, ReadContext)");
+    return prepareForRead(
+        ConfigurationUtil.createHadoopConfiguration(configuration), keyValueMetaData, fileSchema, readContext);
   }
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/WriteSupport.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/api/WriteSupport.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.conf.ParquetConfiguration;
+import org.apache.parquet.hadoop.util.ConfigurationUtil;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.MessageType;
 
@@ -99,7 +100,9 @@ public abstract class WriteSupport<T> {
    *
    * @param configuration the job's configuration
    * @return the information needed to write the file
+   * @deprecated override {@link #init(ParquetConfiguration)} instead
    */
+  @Deprecated
   public abstract WriteContext init(Configuration configuration);
 
   /**
@@ -109,7 +112,7 @@ public abstract class WriteSupport<T> {
    * @return the information needed to write the file
    */
   public WriteContext init(ParquetConfiguration configuration) {
-    throw new UnsupportedOperationException("Override WriteSupport#init(ParquetConfiguration)");
+    return init(ConfigurationUtil.createHadoopConfiguration(configuration));
   }
 
   /**


### PR DESCRIPTION
Backporting the fallback logic

We see that this causes the 1.14 to be incompatible with the previous releases. The config will be created and right after that the `getWriteSupport(conf)` is called.

But since this method is freshly introduced:

```java
    protected WriteSupport<T> getWriteSupport(ParquetConfiguration conf) {
      throw new UnsupportedOperationException(
          "Override ParquetWriter$Builder#getWriteSupport(ParquetConfiguration)");
    }
```

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-XXX
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [ ] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
